### PR TITLE
More context added to step 6 to advise against maximum RAM usage #118

### DIFF
--- a/docker-install/README.md
+++ b/docker-install/README.md
@@ -25,7 +25,7 @@ When you are finished, return to the schedule for your workshop for the link to 
 ![Mac Docker Log In](screenshots/mac-03-dockerlogin.png)
 5. Click the whale icon in the taskbar and go to Preferences.
 ![Mac preferences](screenshots/mac-preferences.png)
-6. Increase the resources available to Docker. For reference, we've found that 2 CPUs and 6 GB of RAM on a quad-core with 8 GB of RAM total works for the workshop offerings. If you are able to provide more resources, do so.  
+6. Increase the resources available to Docker. For reference, we've found that 2 CPUs and 6 GB of RAM on a quad-core with 8 GB of RAM total works for the workshop offerings. If you are able to provide more than 8GB of RAM, do so. However, be careful not to allot your computer's maximum RAM capacity. 
 ![Mac advanced](screenshots/mac-advanced-settings.png)
 7. Click the whale icon in the taskbar. Click the Kitematic menu entry.  
 ![Mac Kitematic Round 1](screenshots/mac-04-kitematic.png)

--- a/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd
+++ b/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd
@@ -118,7 +118,7 @@ Let's rename them to something more manageable like `sample_id`, `age`, and
 
 To do this, tidyverse has a function `dplyr::rename`. 
 Use the help window to understand how you can use this function. 
-Store the renamed metadata back into the variable `metadata_clean`. 
+Store the renamed metadata from the previous step back into the variable `metadata_clean`. Hint: `metadata_clean` should be placed before your first pipe operator.
 (Feel free to google for solutions as well!)
 
 ```{r}


### PR DESCRIPTION
Added more context to Step 6 in the Docker Install instructions to encourage increasing resources but also to advise against using the maximum resources. 
"If you are able to provide more than 8GB of RAM, do so. However, be careful not to allot your computer's maximum RAM capacity."