### PR TITLE
Create RNA-seq readme file.

### DIFF
--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -5,8 +5,8 @@ It is designed to be taught in approximately 3.5 hours.
 It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
 It covers quality control steps, gene expression abundance estimation, and certain downstream analyses.
 The notebooks that comprise this module are:
-* [quality control, trim, and quantification with salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
-* [gene-level summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
-* [exploratory analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
-* differential expression analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
-* [additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)
+* [Quality control, trim, and quantification with salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
+* [Gene-level summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
+* [Exploratory analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
+* Differential expression analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
+* [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)

--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -8,5 +8,5 @@ The notebooks that comprise this module are:
 * [Quality control, trim, and quantification with salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
 * [Gene-level summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
 * [Exploratory analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
-* Differential expression analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
+* Differential expression analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [differential expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
 * [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)

--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -5,8 +5,8 @@ It is designed to be taught in approximately 3.5 hours.
 It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
 It covers quality control steps, gene expression abundance estimation, and certain downstream analyses.
 The notebooks that comprise this module are:
-* [Quality Control, Trim, and Quantification with Salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
-* [Gene-Level Summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
-* [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
-* Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
-* [Additional Exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)
+* [quality control, trim, and quantification with salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
+* [gene-level summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
+* [exploratory analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
+* differential expression analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
+* [additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)

--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -1,0 +1,12 @@
+# RNA-Seq Training Module
+
+This CCDL-designed module covers the analysis of RNA-seq data using Alevin.
+It is designed to be taught in approximately 3.5 hours.
+It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
+It covers QC steps, gene expression abundance estimation, and certain downstream analyses.
+The notebooks that comprise this module are:
+* [QC, trim, and quantification with Salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
+* [Gene-Level Summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
+* [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
+* Differential Expression Analysis Steps: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
+* [Additional Exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)

--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -3,10 +3,10 @@
 This CCDL-designed module covers the analysis of RNA-seq data using Salmon.
 It is designed to be taught in approximately 3.5 hours.
 It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
-It covers QC steps, gene expression abundance estimation, and certain downstream analyses.
+It covers quality control steps, gene expression abundance estimation, and certain downstream analyses.
 The notebooks that comprise this module are:
-* [QC, trim, and quantification with Salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
+* [Quality Control, Trim, and Quantification with Salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
 * [Gene-Level Summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
 * [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
-* Differential Expression Analysis Steps: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
+* Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
 * [Additional Exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)

--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -1,6 +1,6 @@
 # RNA-Seq Training Module
 
-This CCDL-designed module covers the analysis of RNA-seq data using Alevin.
+This CCDL-designed module covers the analysis of RNA-seq data using Salmon.
 It is designed to be taught in approximately 3.5 hours.
 It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
 It covers QC steps, gene expression abundance estimation, and certain downstream analyses.


### PR DESCRIPTION
To address https://github.com/AlexsLemonade/training-admin/issues/56 we need to provide useful links to the training materials. @dvenprasad and I discussed, and it seems most feasible to link from the CCDL website to the folder in training-modules. Then each folder in training-modules would provide links to the materials covered during that module. These links are to the items that comprise the modules on the schedule. This is my attempt to put together a first one for our RNA-seq exercises. Once we like it, we can use it as a template for the others.