### PR TITLE
Addition of `README.md` to machine-learning training module

### DIFF
--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -3,7 +3,7 @@
 This CCDL-designed module involves the analysis of primary medulloblastoma sample gene expression data from [Northcott, et al. _Nature._ 2012](https://www.ncbi.nlm.nih.gov/pubmed/22832581) using some machine learning methods.        
 It is designed to be taught in approximately 1.5 hours.          
 It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).      
-It covers conversion between different gene identifiers, hierarchical clustering, consensus clustering, and obtaining correlated patterns of expression in data or latent variables (LVs) through the implemenation of PLIER (Pathway-Level Information Extractor).      
+It covers conversion between different gene identifiers, hierarchical clustering, consensus clustering, and obtaining correlated patterns of expression in data or latent variables (LVs) through the implementation of PLIER (Pathway-Level Information Extractor).      
 The notebooks that comprise this module are:
 
 * [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html)

--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -1,0 +1,13 @@
+# Machine Learning Training Module 
+
+This CCDL-designed module involves the analysis of primary medulloblastoma sample gene expression data from [Northcott, et al. _Nature._ 2012](https://www.ncbi.nlm.nih.gov/pubmed/22832581) using some machine learning methods.        
+It is designed to be taught in approximately 1.5 hours.          
+It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).      
+It covers conversion between different gene identifiers, hierarchical clustering, consensus clustering, and obtaining correlated patterns of expression in data or latent variables (LVs) through the implemenation of PLIER (Pathway-Level Information Extractor).      
+The notebooks that comprise this module are:
+
+* [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html)
+* [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html)
+* [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html)
+* [Group differences in latent variable (LV) expression](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)
+* [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)


### PR DESCRIPTION
This PR addresses [issue #76](https://github.com/AlexsLemonade/training-admin/issues/76) filed in the training-admin repository. 

This adds a `README.md` file to the `machine-learning` training module to foreshadow the contents of the module. 