### PR TITLE
Stub in virtual-setup

### DIFF
--- a/virtual-setup/README.md
+++ b/virtual-setup/README.md
@@ -1,4 +1,4 @@
-## Set up for virtual workshops
+## Setup for virtual workshops
 
 The `virtual-setup` module houses instructions specifically for CCDL virtual training workshops.
 

--- a/virtual-setup/README.md
+++ b/virtual-setup/README.md
@@ -3,3 +3,11 @@
 The `virtual-setup` module houses instructions specifically for CCDL virtual training workshops.
 
 #### Table of Contents
+
+* [RStudio Login](./rstudio-login.md)
+* [Slack Procedures](./slack-procedures.md)
+* [Zoom Procedures](./zoom-procedures.md)
+* Set Up Instructions for Slack and Zoom
+  * [Linux](./linux-instructions.md)
+  * [Mac](./mac-instructions.md)
+  * [Windows](./windows-instructions.md) 

--- a/virtual-setup/README.md
+++ b/virtual-setup/README.md
@@ -1,0 +1,5 @@
+## Set up for virtual workshops
+
+The `virtual-setup` module houses instructions specifically for CCDL virtual training workshops.
+
+#### Table of Contents

--- a/virtual-setup/linux-instructions.md
+++ b/virtual-setup/linux-instructions.md
@@ -1,0 +1,7 @@
+## Linux set up instructions for virtual workshops
+
+TOC
+
+### Zoom
+
+### Slack

--- a/virtual-setup/mac-instructions.md
+++ b/virtual-setup/mac-instructions.md
@@ -1,0 +1,7 @@
+## Mac set up instructions for virtual workshops
+
+TOC
+
+### Zoom
+
+### Slack

--- a/virtual-setup/rstudio-login.md
+++ b/virtual-setup/rstudio-login.md
@@ -1,0 +1,1 @@
+## RStudio Server instructions

--- a/virtual-setup/slack-procedures.md
+++ b/virtual-setup/slack-procedures.md
@@ -1,0 +1,1 @@
+## Using Slack for CCDL virtual workshops

--- a/virtual-setup/windows-instructions.md
+++ b/virtual-setup/windows-instructions.md
@@ -1,0 +1,7 @@
+## Windows set up instructions for virtual workshops
+
+TOC
+
+### Zoom
+
+### Slack

--- a/virtual-setup/zoom-procedures.md
+++ b/virtual-setup/zoom-procedures.md
@@ -1,0 +1,1 @@
+## Zoom procedures for CCDL virtual workshops


### PR DESCRIPTION
Here I've put together a series of (mostly blank!) markdown documents so folks can get an idea of the structure I'm envisioning for the `virtual-setup` module. We'd then link to these markdown documents from the specific training's wiki. A downside of this approach is that we won't have everything "all in one place," but a big advantage is that it will be considerably easier to maintain. For things like the Slack and Zoom procedures, I think we should plan to spend some time during the first day of instruction covering these documents.