### PR TITLE
Update ggtheme wording in accordance with exercise notebook PR

### DIFF
--- a/intro-to-R-tidyverse/04a-intro_to_R_exercise.Rmd
+++ b/intro-to-R-tidyverse/04a-intro_to_R_exercise.Rmd
@@ -153,9 +153,9 @@ Use the `+` to add on a layer called `geom_density()`
 ggplot(<DATA_FRAME>, aes(x = <VARIABLE_NAME>)) 
 ```
 
-Use the plot you started above and add a `ggtheme` layer to play with its aesthetics (e.g. `theme_classic()`)
-See the [ggthemes vignette](https://mran.microsoft.com/snapshot/2017-02-04/web/packages/ggthemes/vignettes/ggthemes.html) 
-to see a list of ggtheme options. 
+Use the plot you started above and add a `ggplot2::theme` layer to play with its aesthetics (e.g. `theme_classic()`)
+See the [ggplot2 themes vignette](https://ggplot2.tidyverse.org/reference/ggtheme.html)
+to see a list of theme options.
 
 ```{r}
 

--- a/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd
+++ b/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd
@@ -151,7 +151,7 @@ the plot completely to something else!
 # Ideas to get your juices flowing: 
 # - Add a jitter layer over the boxplot
 # - Play with the color of the points!
-# - Use ggplot2::theme to play with the aesthetics
+# - Use ggplot2::ggthemes (e.g. theme_classic()) to play with the aesthetics
 # - facet_wrap() by another variable
 ```
 

--- a/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd
+++ b/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd
@@ -151,7 +151,7 @@ the plot completely to something else!
 # Ideas to get your juices flowing: 
 # - Add a jitter layer over the boxplot
 # - Play with the color of the points!
-# - Use ggthemes to play with the aesthetics
+# - Use ggplot2::theme to play with the aesthetics
 # - facet_wrap() by another variable
 ```
 


### PR DESCRIPTION
### Background: 
The original instructions surrounding ggthemes, was a little too open ended and lead participants to think they needed to install the ggthemes package which often lead them on a rabbit hole that was not intended. 

With it's [companion PR on `exercise-notebook-answers`](https://github.com/AlexsLemonade/exercise-notebook-answers/pull/23), this closes https://github.com/AlexsLemonade/exercise-notebook-answers/issues/22