### PR TITLE
Add rendering of the full notebook to make-live script

### DIFF
--- a/scripts/make-live.R
+++ b/scripts/make-live.R
@@ -19,8 +19,14 @@ infiles <- c(file.path(root_dir, "intro-to-R-tidyverse",
                          "02-intro_to_ggplot2.Rmd",
                          "03-intro_to_tidyverse.Rmd"))
 )
+
+# Rerender notebooks
+purrr::map(infiles, rmarkdown::render, envir = new.env(), quiet = TRUE)
+
+
 # new files will be made with -live.Rmd suffix
 outfiles <- stringr::str_replace(infiles, "(.*)\\.Rmd$", "\\1-live.Rmd")
 
+# Generate live versions
 # capture to avoid printing to stdout
 out <- purrr::map2(infiles, outfiles, exrcise::exrcise, replace_flags = "live")


### PR DESCRIPTION
Before we turn notebook rendering into part of a github action as proposed in #226, I thought we could do the first step of https://github.com/AlexsLemonade/training-modules/pull/223#issuecomment-638170906 and make rerendering the html part of the make-live script. So here it is.

I had a thought about making this optional, but decided it was better to just have it run every time, even if that is potentially a bit slow. If we are running this script, we should be just about to push our latest changes, so rerunning everything cleanly seems a good idea.