### PR TITLE
Add instructions for setup of links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ RNA-seq/07-bulk_rnaseq_exercise.nb.html
 intro-to-R-tidyverse/04a-intro_to_R_exercise.nb.html
 intro-to-R-tidyverse/04b-intro_to_tidyverse_exercise-part-1.nb.html
 intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.nb.html
-machine-learning/05-machine_learning_exercise.nb.html
-scRNA-seq/04-scrnaseq_exercise.nb.html
 
 #DS_Stores
 .DS_Store

--- a/scRNA-seq/.gitignore
+++ b/scRNA-seq/.gitignore
@@ -11,6 +11,9 @@ data/glioblastoma/filtered
 data/glioblastoma/normalized
 
 data/tabula-muris/alevin-quant
+data/tabula-muris/normalized/*
+!data/tabula-muris/normalized/.gitkeep
 
-# ignore live nb.html files
+# ignore live and exercise nb.html files
 *-live.nb.html
+*_exercise.nb.html

--- a/scRNA-seq/setup/README.md
+++ b/scRNA-seq/setup/README.md
@@ -7,11 +7,19 @@ Currently, these workflows do not include conda environments or docker, as those
 
 ## File locations
 
-The main location for the files needed for training data is `/shared/data/training-data`.
+On the RStudio server the main location for the files needed for training data is `/shared/data/training-data`.
 For users, this is generally symlinked from their home directories, so they can get to it from `~/shared-data/training-data`
 The files are then organized by dataset.
 
+After setup, the following symlinks should be established:
 
+```
+# cd scRNA-seq
+ln -s /shared/data/training-data/darmanis data/glioblastoma/preprocessed
+ln -s /shared/data/training-data/tabula-muris/fastq data/tabula-muris/fastq-raw
+ln -s /shared/data/training-data/tabula-muris/normalized/TM_normalized.rds data/tabula-muris/normalized/TM_normalized.rds
+
+```
 ## SmartSeq Data
 
 The SmartSeq data we are using comes from the following study: <https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE84465>, which corresponds to the SRA project SRP079058. 


### PR DESCRIPTION
This PR does some minor cleaning of .gitignore files and adds instructions to the setup module about what symbolic links need to be created for the scRNA-seq module after checking out the repository.



