### PR TITLE
Update the machine learning README to reflect the changes

### DIFF
--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -1,13 +1,15 @@
-# Machine Learning Training Module 
+# Machine Learning Training Module
 
-This CCDL-designed module involves the analysis of primary medulloblastoma sample gene expression data from [Northcott, et al. _Nature._ 2012](https://www.ncbi.nlm.nih.gov/pubmed/22832581) using some machine learning methods.
-It is designed to be taught in approximately 1.5 hours.
-It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
-It covers conversion between different gene identifiers, hierarchical clustering, consensus clustering, and obtaining correlated patterns of expression in data or latent variables (LVs) through the implementation of PLIER (Pathway-Level Information Extractor).
+This CCDL-designed module analyzes pediatric brain tumor data from the [OpenPBTA project](https://github.com/AlexsLemonade/OpenPBTA-analysis) using some machine learning methods.
+OpenPBTA contains data from [Children's Brain Tumor Tissue Consortium](https://cbttc.org/) and the PNOC003 DIPG clinical trial from the [Pediatric Pacific Neuro-oncology Consortium](http://www.pnoc.us/).
+
+This material depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses can be performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
+It covers how to make heatmaps, perform consensus clustering, and obtain correlated patterns of expression in data or latent variables (LVs) through the implementation of PLIER (Pathway-Level Information Extractor).
+
 The notebooks that comprise this module are:
 
-* [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html)
-* [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html)
-* [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html)
-* [Group differences in latent variable (LV) expression](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)
+* [Heatmap](https://alexslemonade.github.io/training-modules/machine-learning/01-openpbta_heatmap.nb.html)
+* [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-openpbta_consensus_clustering.nb.html)
+* [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-openpbta_PLIER.nb.html)
+* [Group differences in latent variable (LV) expression](https://alexslemonade.github.io/training-modules/machine-learning/04-openpbta_plot_LV.nb.html)
 * [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)

--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -3,7 +3,7 @@
 This CCDL-designed module analyzes pediatric brain tumor data from the [OpenPBTA project](https://github.com/AlexsLemonade/OpenPBTA-analysis) using some machine learning methods.
 OpenPBTA contains data from [Children's Brain Tumor Tissue Consortium](https://cbttc.org/) and the PNOC003 DIPG clinical trial from the [Pediatric Pacific Neuro-oncology Consortium](http://www.pnoc.us/).
 
-This material depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses can be performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
+This material depends on knowledge gained in the [Intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses can be performed within a [Docker container](https://hub.docker.com/r/ccdl/training_rnaseq).
 It covers how to make heatmaps, perform consensus clustering, and obtain correlated patterns of expression in data or latent variables (LVs) through the implementation of PLIER (Pathway-Level Information Extractor).
 
 The notebooks that comprise this module are:


### PR DESCRIPTION
### Summary 

Origins: #257 

With the revamping of machine-learning module, the README needed to be updated in accordance. 

The main changes to the README here are: 
- Notebook list and its links updated for new material 
- Exchange Northcott et al summary for OpenPBTA dataset summary

All links work, except for the `Additional exercises` one because the notebook has not been merged yet (will be on #269 ) but it is the correct link for when that is merged. 
