### PR TITLE
Add machine-learning Rproj

### DIFF
--- a/machine-learning/machine-learning.Rproj
+++ b/machine-learning/machine-learning.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: No
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+DisableExecuteRprofile: Yes


### PR DESCRIPTION
I am planning on using projects for both modules this training. I added one for `pathway-analysis` on the open PR for that module (https://github.com/AlexsLemonade/training-modules/pull/281/commits/376fa69e6df8e3c63e936a1dc12184a63cf1805c). 