### PR TITLE
Fix typo in `01b-intro_to_base_R_exercise.Rmd`

### DIFF
--- a/intro-to-R-tidyverse/01b-intro_to_base_R_exercise.Rmd
+++ b/intro-to-R-tidyverse/01b-intro_to_base_R_exercise.Rmd
@@ -18,7 +18,7 @@ We'll start with some basic manipulations of values and variables.
 In the chunk below calculate the product of 1.563 and 4.678.
 
 ```{r multiply, solution = TRUE}
-
+1.563 * 4.678
 ```
 
 Now assign the value 5.89 to a variable `numerator` and 2.2x10¹² to `denominator` and calculate their quotient. 
@@ -117,7 +117,7 @@ How many rows and columns are there in the `metadata` data frame?
 ```
 
 What type of data is in the `data_row_count` column?
-What about the `refine_bio_accession_code` column?
+What about the `refinebio_accession_code` column?
 Use `$` notation to select these columns and check their types.
 
 ```{r column-type, solution = TRUE}

--- a/intro-to-R-tidyverse/01b-intro_to_base_R_exercise.Rmd
+++ b/intro-to-R-tidyverse/01b-intro_to_base_R_exercise.Rmd
@@ -18,7 +18,7 @@ We'll start with some basic manipulations of values and variables.
 In the chunk below calculate the product of 1.563 and 4.678.
 
 ```{r multiply, solution = TRUE}
-1.563 * 4.678
+
 ```
 
 Now assign the value 5.89 to a variable `numerator` and 2.2x10¹² to `denominator` and calculate their quotient. 


### PR DESCRIPTION
During the first day of the PGH workshop, one of the participants noticed a typo in the `01b-intro_to_base_R_exercise.Rmd` file. 

This PR fixes the typo at [line 120](https://github.com/AlexsLemonade/training-modules/blob/ddc9c76e03aaf147fb2f011490ea6aec835de064/intro-to-R-tidyverse/01b-intro_to_base_R_exercise.Rmd#L120): "What about the `refine_bio_accession_code` column?" 
where `refine_bio_accession_code` should be `refinebio_accession_code`. 

Note that I also filed a PR to fix this in the `exercise-notebook-answers` repo: AlexsLemonade/exercise-notebook-answers#42