### PR TITLE
Add workflow that builds and pushes the Docker image upon merges

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,0 +1,50 @@
+name: Build Docker Image and Push to Dockerhub
+
+# Controls when the action will run.
+# Every time something is merged to master, the image will be rebuilt and pushed.
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Login to Dockerhub
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_ID }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      # set up Docker build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build Docker image
+      - name: Build Docker image
+        uses: docker/build-push-action@v2.2.2
+        with:
+          push: true
+          context: .
+          file: Dockerfile
+          tags: ccdl/training_dev:latest
+
+      # If we have a failure, Slack us
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1.1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }} 
+          SLACK_MESSAGE: 'Training build Docker & push workflow failed'

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -4,7 +4,7 @@ name: Build Docker Image and Push to Dockerhub
 # Every time something is merged to master, the image will be rebuilt and pushed.
 on:
   push:
-    branches: [ master, jaclyn-taroni/build-and-push ]
+    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -4,7 +4,7 @@ name: Build Docker Image and Push to Dockerhub
 # Every time something is merged to master, the image will be rebuilt and pushed.
 on:
   push:
-    branches: [ master ]
+    branches: [ master, jaclyn-taroni/build-and-push ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,31 @@ In practice, this means that you will not need to add individual R packages to t
 
 ## Docker Image
 
+### Developing within the Docker container
+
+To use the Docker image for development, pull from Dockerhub with:
+
 ```
-TODO: Pulling the image once #303 goes in
+docker pull ccdl/training_dev:latest
 ```
+
+To run the contain and mount a local volume, use the following from the root of this repository:
+
+```
+docker run \
+  --mount type=bind,target=/home/rstudio/training-modules,source=$PWD \
+  -e PASSWORD=<PASSWORD> \
+  -p 8787:8787 \
+  ccdl/training_dev:latest
+```
+
+Replacing `<PASSWORD>` with the password of your choice.
+You can then navigate to `localhost:8787` in your browser and login with username `rstudio` and the password you just set via `docker run`.
 
 ### Testing Docker image builds via GitHub Actions
 
 When a pull request changes either the `Dockerfile` or `renv.lock`, a GitHub Action workflow (`build-docker.yml`) will be run to test that the image will successfully build.
+
+### Pushing to Dockerhub via GitHub Actions
+
+When a pull request is merged into `master`, the `build-and-push-docker.yml` GitHub Actions workflow will be triggered. The project Docker image will be rebuilt and pushed as `ccdl/training_dev:latest`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,4 +70,5 @@ When a pull request changes either the `Dockerfile` or `renv.lock`, a GitHub Act
 
 ### Pushing to Dockerhub via GitHub Actions
 
-When a pull request is merged into `master`, the `build-and-push-docker.yml` GitHub Actions workflow will be triggered. The project Docker image will be rebuilt and pushed as `ccdl/training_dev:latest`.
+When a pull request is merged into `master`, the `build-and-push-docker.yml` GitHub Actions workflow will be triggered. 
+The project Docker image will be rebuilt and pushed as `ccdl/training_dev:latest`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ You can then navigate to `localhost:8787` in your browser and login with usernam
 
 ### Testing Docker image builds via GitHub Actions
 
-When a pull request changes either the `Dockerfile` or `renv.lock`, a GitHub Action workflow (`build-docker.yml`) will be run to test that the image will successfully build.
+When a pull request changes either the `Dockerfile` or `renv.lock`, a GitHub Actions workflow (`build-docker.yml`) will be run to test that the image will successfully build.
 
 ### Pushing to Dockerhub via GitHub Actions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 # Contributing and Development Guidelines
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+
+- [Development with `renv`](#development-with-renv)
+  - [Typical development workflow](#typical-development-workflow)
+  - [How we use `renv` with Docker](#how-we-use-renv-with-docker)
+- [Docker Image](#docker-image)
+  - [Developing within the Docker container](#developing-within-the-docker-container)
+  - [Testing Docker image builds via GitHub Actions](#testing-docker-image-builds-via-github-actions)
+  - [Pushing to Dockerhub via GitHub Actions](#pushing-to-dockerhub-via-github-actions)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
 ## Development with `renv` 
 
 We use [`renv`](https://rstudio.github.io/renv/index.html) to manage R package dependencies for this project. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ To use the Docker image for development, pull from Dockerhub with:
 docker pull ccdl/training_dev:latest
 ```
 
-To run the contain and mount a local volume, use the following from the root of this repository:
+To run the container and mount a local volume, use the following from the root of this repository:
 
 ```
 docker run \
@@ -63,6 +63,8 @@ docker run \
 
 Replacing `<PASSWORD>` with the password of your choice.
 You can then navigate to `localhost:8787` in your browser and login with username `rstudio` and the password you just set via `docker run`.
+
+To work on the project, you should then open `training-modules/training-modules.Rproj` on the Rstudio server, then proceed as in the [typical development workflow](#typical-development-workflow).
 
 ### Testing Docker image builds via GitHub Actions
 


### PR DESCRIPTION
⚠️ **depends on #302, review that first** 🚨 stacked changes 🚨 

Here I'm adding a GHA that will build the Docker image and push it to Dockerhub every time a PR gets merged into `master` (`.github/workflows/build-and-push-docker.yml`). It doesn't use caching, which seems like it will not be a problem time-wise because one does not have to wait for it to run _before_ merging. 

Closes #298.