### PR TITLE
Set repos in .Rprofile using the lockfile

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,2 @@
+library(renv)
 source("renv/activate.R")

--- a/.Rprofile
+++ b/.Rprofile
@@ -1,2 +1,27 @@
 library(renv)
 source("renv/activate.R")
+
+# Set the repos using the renv.lock file
+renv_json <- jsonlite::read_json("renv.lock")
+renv_r_repos <- renv_json$R$Repositories
+
+# Extract the names
+repo_names <- purrr::flatten_chr(
+  purrr::map(renv_r_repos,
+             ~ .x$Name)
+)
+
+# Extract the URLs
+repo_urls <- purrr::flatten_chr(
+  purrr::map(renv_r_repos,
+             ~ .x$URL)
+  )
+
+# Set the repo names
+names(repo_urls) <- repo_names
+
+# Set the options
+options(repos = repo_urls)
+  
+# Remove all these objects
+rm(renv_json, renv_r_repos, repo_names, repo_urls)

--- a/.Rprofile
+++ b/.Rprofile
@@ -15,7 +15,7 @@ repo_names <- purrr::flatten_chr(
 repo_urls <- purrr::flatten_chr(
   purrr::map(renv_r_repos,
              ~ .x$URL)
-  )
+)
 
 # Set the repo names
 names(repo_urls) <- repo_names

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ The steps for development are:
 4. Run `renv::snapshot()` at the end of your session to capture the additional dependencies.
 5. Commit any changes to `renv.lock`.
 
+Note that when you open up the `training-modules.Rproj`, the `.Rprofile` file makes it such that the `renv` library is loaded and the repositories in the `renv.lock` file will be set with `options(repos = ...)`.
+
 ### How we use `renv` with Docker
 
 We use the `renv.lock` file in this repository to install R dependencies on the image per the [`renv` documentation for creating Docker images](https://rstudio.github.io/renv/articles/docker.html#creating-docker-images-with-renv-1).

--- a/renv.lock
+++ b/renv.lock
@@ -1122,7 +1122,7 @@
       "Package": "remotes",
       "Version": "2.2.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "430a0908aee75b1fcba0e62857cab0ce"
     },
     "renv": {


### PR DESCRIPTION
I noticed this was needed while developing #304 using `ccdl/training_dev:latest`. Because we use a `rocker/tidyverse:4.0.3` base image, the RSPM URL is set by the container to `latest` until the next R version is released. That means when I went to install the libraries required for spell check, the RSPM URL would be "displaced" by the URL the base image is set to use in the lockfile. 

My solution to this, since we already have a lockfile tracked here, is to use the repositories in `renv.lock` to set the repos when you open the project by adding those steps to `.Rprofile`. We only have the RSPM repo at the moment, but I tried to do this in a way that is more general with `purrr`. I can say that this works as intended: when I use `install.packages("spelling")` and then `renv::snapshot()`, the repos portion of `renv.lock` is unaltered.

Also for whatever reason (this also came up in #300) if I don't load `renv` in `.Rprofile` I get an error. I added a brief note about both of these steps to `CONTRIBUTING.md`.

**For reviewers:** Are there any obvious downsides to this approach that I have not considered?
