### PR TITLE
Make an explicit CRAN entry in the repositories list

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -3,6 +3,10 @@
     "Version": "4.0.3",
     "Repositories": [
       {
+        "Name": "CRAN",
+        "URL": "https://packagemanager.rstudio.com/cran/2021-01-26"
+      },
+      {
         "Name": "RSPM",
         "URL": "https://packagemanager.rstudio.com/cran/2021-01-26"
       }


### PR DESCRIPTION
There was a bit of rabbit hole here about why MRAN is appearing when I install packages on my Mac, but it seems to be working out just fine... letting it install from MRAN did not modify the renv.lock in any way. 🤷‍♂️ 

So here I am adding an explicit CRAN entry, for what probably is no reason, but seems like a Good Thing™