### PR TITLE
Fix renv conflicts

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,4 +1,3 @@
-library(renv)
 source("renv/activate.R")
 
 # Set the repos using the renv.lock file

--- a/renv/.gitignore
+++ b/renv/.gitignore
@@ -3,5 +3,3 @@ lock/
 python/
 staging/
 
-# This is not a file that renv documentation recommends we track
-settings.dcf

--- a/renv/settings.dcf
+++ b/renv/settings.dcf
@@ -1,0 +1,7 @@
+external.libraries:
+ignored.packages:
+package.dependency.fields: Imports, Depends, LinkingTo
+r.version:
+snapshot.type: implicit
+use.cache: FALSE
+vcs.ignore.library: TRUE


### PR DESCRIPTION
Apparently you should never use `libarary(renv)` because it masks `base::load()`, which does bad things. But if you don't the docker image gets unhappy, because it loses its connection to the cache when you start a new container. So we need to set `use.cache: FALSE` in `renv/settings.dcf`.

This means that the `renv/library` directory may get large, as it is keeping its own copy of all of the packages, but that is a local problem (hopefully). 