### PR TITLE
Add colorblindr to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,13 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     autoconf \
     libglpk-dev
 
+# Need this package to make plots colorblind friendly
+RUN Rscript -e "remotes::install_github('clauswilke/colorblindr', ref = '1ac3d4d62dad047b68bb66c06cee927a4517d678', dependencies = TRUE)"
+
 # FastQC
 RUN apt update && apt install -y fastqc
 
-# fastp 
+# fastp
 ENV FASTP_VERSION 0.20.1
 RUN git clone https://github.com/OpenGene/fastp.git
 RUN cd fastp && \


### PR DESCRIPTION
### Background

Was trying to update exercise notebook names over on exercise-notebook-answers, but I did not have the scRNA-seq input files needed to do so. 

Tried to run `scRNA-seq/02-normalizing_scRNA-seq.Rmd` on the latest `ccdl/training-dev:latest` image that I pulled and it said it did not have `colorblindr`. The dockerfile does not appear to install it. So I'm adding that in here. Not sure if we lost it along the way somewhere.