### PR TITLE
Fix short_index link destination

### DIFF
--- a/scripts/link-data.sh
+++ b/scripts/link-data.sh
@@ -50,7 +50,7 @@ done
 
 ## link indexes
 mkdir -p RNA-seq/index/Homo_sapiens/
-hs_index_dest=RNA-seq/index/Homo_sapiens/Homo_sapiens.GRCh38.95_tx2gene.tsv
+hs_index_dest=RNA-seq/index/Homo_sapiens/short_index
 hs_index_source=${share_base}/reference/refgenie/hg38_cdna/salmon_index/short
 if [[ -L ${hs_index_dest} || ! -e ${hs_index_dest} ]]
 then


### PR DESCRIPTION
When I made the link-data.sh script, I had a small bug where I put the link destination for the salmon short index in the wrong place (where the tx2gene file should be!). This should fix that!