### PR TITLE
Make make-live work: 1/n update renv for all modules

### DIFF
--- a/components/dependencies.R
+++ b/components/dependencies.R
@@ -5,3 +5,13 @@ library(magick)
 
 # Recommended by tximport
 library(fishpond)
+
+# Required for DESeq2::lfcShrink()
+library(apeglm)
+
+# Required for scater
+library(uwot)
+library(Rtsne)
+
+# required for enrichplot::upsetplot
+library(ggupset)

--- a/renv.lock
+++ b/renv.lock
@@ -122,6 +122,18 @@
       "Source": "Bioconductor",
       "Hash": "70f50d662ec8f7c534dfd233c949e1d5"
     },
+    "DO.db": {
+      "Package": "DO.db",
+      "Version": "2.9",
+      "Source": "Bioconductor",
+      "Hash": "7d05e00472158bda5f124df351af0a49"
+    },
+    "DOSE": {
+      "Package": "DOSE",
+      "Version": "3.16.0",
+      "Source": "Bioconductor",
+      "Hash": "1a16437853dbade9c1096e3248be9380"
+    },
     "DT": {
       "Package": "DT",
       "Version": "0.17",
@@ -141,11 +153,42 @@
       "Source": "Bioconductor",
       "Hash": "230e879420712830db7e0c055188dd68"
     },
+    "FNN": {
+      "Package": "FNN",
+      "Version": "1.1.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "b56998fff55e4a4b4860ad6e8c67e0f9"
+    },
     "GEOquery": {
       "Package": "GEOquery",
       "Version": "2.58.0",
       "Source": "Bioconductor",
       "Hash": "b17420379c5ef4c956f52362d8f824c8"
+    },
+    "GO.db": {
+      "Package": "GO.db",
+      "Version": "3.12.1",
+      "Source": "Bioconductor",
+      "Hash": "1ed8d8ec3449f0c6fba5f1932ac333ae"
+    },
+    "GOSemSim": {
+      "Package": "GOSemSim",
+      "Version": "2.16.1",
+      "Source": "Bioconductor",
+      "Hash": "f73eccd90a8131c9798bd6675e442c5a"
+    },
+    "GSEABase": {
+      "Package": "GSEABase",
+      "Version": "1.52.1",
+      "Source": "Bioconductor",
+      "Hash": "c3fd12a7f8101f913b752b889dc93ed2"
+    },
+    "GSVA": {
+      "Package": "GSVA",
+      "Version": "1.38.2",
+      "Source": "Bioconductor",
+      "Hash": "369dfe423f79a4d38c0616c6462d9b09"
     },
     "GenomeInfoDb": {
       "Package": "GenomeInfoDb",
@@ -272,6 +315,13 @@
       "Repository": "RSPM",
       "Hash": "dbb5e436998a7eba5a9d682060533338"
     },
+    "RcppAnnoy": {
+      "Package": "RcppAnnoy",
+      "Version": "0.0.18",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "4c61a26f751659e875f46045df6d5fad"
+    },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
       "Version": "0.10.1.2.2",
@@ -293,11 +343,32 @@
       "Repository": "RSPM",
       "Hash": "ce584c040a9cfa786ffb41f938f5ed19"
     },
+    "RcppNumerical": {
+      "Package": "RcppNumerical",
+      "Version": "0.4-0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "750f0527a0edaf99c29cf1e778b27a6f"
+    },
+    "RcppProgress": {
+      "Package": "RcppProgress",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "1c0aa18b97e6aaa17f93b8b866c0ace5"
+    },
     "Rhdf5lib": {
       "Package": "Rhdf5lib",
       "Version": "1.12.1",
       "Source": "Bioconductor",
       "Hash": "7dc9be3558a910226d64a2040520dc7f"
+    },
+    "Rtsne": {
+      "Package": "Rtsne",
+      "Version": "0.15",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "f153432c4ca15b937ccfaa40f167c892"
     },
     "S4Vectors": {
       "Package": "S4Vectors",
@@ -355,6 +426,12 @@
       "Source": "Bioconductor",
       "Hash": "3553333f7949ea3d722760136f3660ae"
     },
+    "apeglm": {
+      "Package": "apeglm",
+      "Version": "1.12.0",
+      "Source": "Bioconductor",
+      "Hash": "3f89d2a4ad516fb1e77c06197c486fec"
+    },
     "askpass": {
       "Package": "askpass",
       "Version": "1.1",
@@ -382,6 +459,20 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
+    },
+    "bbmle": {
+      "Package": "bbmle",
+      "Version": "1.0.23.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "89eef0faafa404fe20f23290c322bbeb"
+    },
+    "bdsmatrix": {
+      "Package": "bdsmatrix",
+      "Version": "1.3-4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "1012f2033c32d595e1a16bee3bb0b3e5"
     },
     "beachmat": {
       "Package": "beachmat",
@@ -514,6 +605,19 @@
       "Repository": "CRAN",
       "Hash": "db63a44aab5aadcb6bf2f129751d129a"
     },
+    "clusterProfiler": {
+      "Package": "clusterProfiler",
+      "Version": "3.18.1",
+      "Source": "Bioconductor",
+      "Hash": "5f344773b73f177d66183d4c807c2670"
+    },
+    "coda": {
+      "Package": "coda",
+      "Version": "0.19-4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "24b6d006b8b2343876cf230687546932"
+    },
     "codetools": {
       "Package": "codetools",
       "Version": "0.2-18",
@@ -534,6 +638,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
+    },
+    "cowplot": {
+      "Package": "cowplot",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "b418e8423699d11c7f2087c2bfd07da2"
     },
     "cpp11": {
       "Package": "cpp11",
@@ -598,6 +709,13 @@
       "Repository": "RSPM",
       "Hash": "a0cbe758a531d054b537d16dff4d58a1"
     },
+    "downloader": {
+      "Package": "downloader",
+      "Version": "0.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "f4f2a915e0dedbdf016a83b63477349f"
+    },
     "dplyr": {
       "Package": "dplyr",
       "Version": "1.0.3",
@@ -625,12 +743,51 @@
       "Repository": "RSPM",
       "Hash": "fd2844b3a43ae2d27e70ece2df1b4e2a"
     },
+    "emdbook": {
+      "Package": "emdbook",
+      "Version": "1.3.12",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "e95109c1d5610799fc5b8ee471fe342f"
+    },
+    "emmeans": {
+      "Package": "emmeans",
+      "Version": "1.5.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "f43c611673017ee687edbe97412ccd8c"
+    },
+    "enrichplot": {
+      "Package": "enrichplot",
+      "Version": "1.10.2",
+      "Source": "Bioconductor",
+      "Hash": "bfe9798d5d9be7c8bfb269c5f19dd957"
+    },
+    "estimability": {
+      "Package": "estimability",
+      "Version": "1.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "05901bd61be60fd3bfc5b7d7c3517d1d"
+    },
     "evaluate": {
       "Package": "evaluate",
       "Version": "0.14",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
+    },
+    "exrcise": {
+      "Package": "exrcise",
+      "Version": "0.1.0",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "exrcise",
+      "RemoteUsername": "AlexsLemonade",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "a496662f8a8a2294366cae4d2f3547c50ac341f1",
+      "Hash": "a5a91e3a3f03206b58ae5dbc6ee66f64"
     },
     "fansi": {
       "Package": "fansi",
@@ -653,12 +810,32 @@
       "Repository": "RSPM",
       "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
     },
+    "fastmatch": {
+      "Package": "fastmatch",
+      "Version": "1.1-0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "2cfe25650d69960c54e06840e4b5d8e4"
+    },
     "fastqcr": {
       "Package": "fastqcr",
       "Version": "0.1.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "2abd00eb709c07fc87aa6b4132e17040"
+    },
+    "fftw": {
+      "Package": "fftw",
+      "Version": "1.0-6",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "6bd00d1c7c902b36fdeaa0cc6e5360b5"
+    },
+    "fgsea": {
+      "Package": "fgsea",
+      "Version": "1.16.0",
+      "Source": "Bioconductor",
+      "Hash": "0ed01e7c1d5fef94d795abb1597aab86"
     },
     "fishpond": {
       "Package": "fishpond",
@@ -741,6 +918,13 @@
       "Repository": "RSPM",
       "Hash": "dd68b9b215b2d3119603549a794003c3"
     },
+    "ggforce": {
+      "Package": "ggforce",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "4adaf6b01b41f243ba0c62801de3331e"
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.3.3",
@@ -748,12 +932,33 @@
       "Repository": "RSPM",
       "Hash": "3eb6477d01eb5bbdc03f7d5f70f2733e"
     },
+    "ggraph": {
+      "Package": "ggraph",
+      "Version": "2.0.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "2a189e5cd2bbfe687ed631be27c07462"
+    },
+    "ggrepel": {
+      "Package": "ggrepel",
+      "Version": "0.9.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "08ab869f37e6a7741a64ab9069bcb67d"
+    },
     "ggsignif": {
       "Package": "ggsignif",
       "Version": "0.6.0",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "3e9b8a51dfdc95395632b25ce3ce8ebc"
+    },
+    "ggupset": {
+      "Package": "ggupset",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "8e9eb92bf465601c07d17c5e8b75dce1"
     },
     "glmnet": {
       "Package": "glmnet",
@@ -775,6 +980,19 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "e65e5d5dea4cbb9ba822dcd782b2ee1f"
+    },
+    "graph": {
+      "Package": "graph",
+      "Version": "1.68.0",
+      "Source": "Bioconductor",
+      "Hash": "38322867731e9e137d21b13778a96b5f"
+    },
+    "graphlayouts": {
+      "Package": "graphlayouts",
+      "Version": "0.7.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "2a0d18b9395cd27066d209b83bb29ea6"
     },
     "gridExtra": {
       "Package": "gridExtra",
@@ -1040,12 +1258,26 @@
       "Repository": "RSPM",
       "Hash": "6dfe8bf774944bd5595785e3229d8771"
     },
+    "mvtnorm": {
+      "Package": "mvtnorm",
+      "Version": "1.1-1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "69fa7331e7410c2a2cb3f9868513904f"
+    },
     "nlme": {
       "Package": "nlme",
       "Version": "3.1-151",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "42c8ba2b6a32a6bf0874e93e3bd86a43"
+    },
+    "numDeriv": {
+      "Package": "numDeriv",
+      "Version": "2016.8-1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
     "openssl": {
       "Package": "openssl",
@@ -1130,6 +1362,13 @@
       "Repository": "RSPM",
       "Hash": "03b7076c234cb3331288919983326c55"
     },
+    "polyclip": {
+      "Package": "polyclip",
+      "Version": "1.10-0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "cb167f328b3ada4ec5cf67a7df4c900a"
+    },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
@@ -1184,6 +1423,12 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
+    },
+    "qusage": {
+      "Package": "qusage",
+      "Version": "2.24.0",
+      "Source": "Bioconductor",
+      "Hash": "bc463180c83b4777e753f3a240c40be2"
     },
     "qvalue": {
       "Package": "qvalue",
@@ -1320,6 +1565,13 @@
       "Repository": "RSPM",
       "Hash": "3a6b30449282b6a4b19ce267142c3299"
     },
+    "rvcheck": {
+      "Package": "rvcheck",
+      "Version": "0.1.8",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "11ebf2d3d4990e8bb9f28d5ab0c204fc"
+    },
     "rvest": {
       "Package": "rvest",
       "Version": "0.3.6",
@@ -1347,6 +1599,13 @@
       "Source": "Bioconductor",
       "Hash": "0fe8d0094951d12105d37747af4eada8"
     },
+    "scatterpie": {
+      "Package": "scatterpie",
+      "Version": "0.1.5",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "d96eeb2f420d63edf1a6bfee068543e9"
+    },
     "scran": {
       "Package": "scran",
       "Version": "1.18.3",
@@ -1365,6 +1624,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
+    },
+    "shadowtext": {
+      "Package": "shadowtext",
+      "Version": "0.0.7",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "59c332a398fa940a85094cf3bbcb4443"
     },
     "shape": {
       "Package": "shape",
@@ -1470,6 +1736,13 @@
       "Repository": "RSPM",
       "Hash": "a1958587eb651a02273d685fff3819b1"
     },
+    "tidygraph": {
+      "Package": "tidygraph",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "5375980d0787633ca62c265b28bedb41"
+    },
     "tidyr": {
       "Package": "tidyr",
       "Version": "1.1.2",
@@ -1498,6 +1771,13 @@
       "Repository": "RSPM",
       "Hash": "ff73961a77fba606fbf944dc3468e5b9"
     },
+    "tweenr": {
+      "Package": "tweenr",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "fc77eb5297507cccfa3349a606061030"
+    },
     "tximport": {
       "Package": "tximport",
       "Version": "1.18.0",
@@ -1517,6 +1797,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "4a5081acfb7b81a572e4384a7aaf2af1"
+    },
+    "uwot": {
+      "Package": "uwot",
+      "Version": "0.1.10",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "a9737c75f5f949695617b05e78281b2f"
     },
     "vctrs": {
       "Package": "vctrs",


### PR DESCRIPTION
This PR updates renv and dependencies.R to add modules and hidden dependencies required for running all notebooks. 

This is the first of several stacked PRs that will hopefully result in make-live.R working on the server current package versions and linked files. 