### PR TITLE
Add estimated times of completion to modules' `README`

### DIFF
--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -4,9 +4,14 @@ This CCDL-designed module covers the analysis of RNA-seq data using Salmon.
 It is designed to be taught in approximately 3.5 hours.
 It depends on knowledge gained in the [intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install).
 It covers quality control steps, gene expression abundance estimation, and certain downstream analyses.
-The notebooks that comprise this module are:
-* [Quality control, trim, and quantification with salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)
-* [Gene-level summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html)
-* [Exploratory analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html)
-* Differential expression analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [differential expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)
+
+The notebooks that comprise this module are (estimated time to complete notebook):
+
+* [Quality control, trim, and quantification with salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md) (1 hr 10 minutes)
+* [Gene-level summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html) (25 minutes)
+* [Exploratory analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) (35 minutes)
+* Differential expression analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) and [differential expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html) (25 minutes and 40 minutes, respectively)
 * [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)
+
+
+_Total estimated time to complete instruction notebooks: 3 hours 10 minutes_

--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -14,4 +14,4 @@ The notebooks that comprise this module are (estimated time to complete notebook
 * [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)
 
 
-_Total estimated time to complete instruction notebooks: 3 hours 10 minutes_
+_Total estimated time to complete instruction notebooks: 3 hours 15 minutes_

--- a/intro-to-R-tidyverse/README.md
+++ b/intro-to-R-tidyverse/README.md
@@ -4,11 +4,13 @@ This CCDL-designed module introduces the R programming language and some [tidyve
 The tidyverse is a collection of packages designed for data science.
 It goes through the basics of R _(including data types, data structures)_, ggplot2 visualizations, and other tidyverse data manipulation packages _(including dplyr pipes, common tidyverse functions)_, thus providing the tools needed to move onto the subsequent training modules.
 
-The notebooks that comprise this module are:
+The notebooks that comprise this module are (estimated time to complete notebook):
 
-* [Introduction to Base R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_base_R.nb.html)  
-* [Introduction to ggplot2](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html)
-* [Introduction to tidyverse](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html)
+* [Introduction to Base R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) (1 hr 40 minutes)
+* [Introduction to ggplot2](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) (45 minutes)
+* [Introduction to tidyverse](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) (1 hr 10 minutes)
 * [Additional exercises for introduction to R](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/04a-intro_to_R_exercise.Rmd)  
 * [Additional exercises for introduction to tidyverse part 1](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/04b-intro_to_tidyverse_exercise-part-1.Rmd)  
 * [Additional exercises for introduction to tidyverse part 2](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd)  
+
+_Total estimated time to complete instruction notebooks: 3 hours 35 minutes_

--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -10,8 +10,8 @@ The notebooks that comprise this module are (estimated time to complete notebook
 
 * [Heatmap](https://alexslemonade.github.io/training-modules/machine-learning/01-openpbta_heatmap.nb.html) (1 hr)
 * [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-openpbta_consensus_clustering.nb.html) (55 minutes)
-* [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-openpbta_PLIER.nb.html) (20 minutes)
-* [Group differences in latent variable (LV) expression](https://alexslemonade.github.io/training-modules/machine-learning/04-openpbta_plot_LV.nb.html)
+* [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-openpbta_PLIER.nb.html) (30 minutes)
+* [Group differences in latent variable (LV) expression](https://alexslemonade.github.io/training-modules/machine-learning/04-openpbta_plot_LV.nb.html) (30 minutes)
 * [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)
 
-_Total estimated time to complete instruction notebooks: 2 hours 15 minutes_
+_Total estimated time to complete instruction notebooks: 2 hours 55 minutes_

--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -6,10 +6,12 @@ OpenPBTA contains data from [Children's Brain Tumor Tissue Consortium](https://c
 This material depends on knowledge gained in the [Intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) module and analyses can be performed within a [Docker container](https://hub.docker.com/r/ccdl/training_rnaseq).
 It covers how to make heatmaps, perform consensus clustering, and obtain correlated patterns of expression in data or latent variables (LVs) through the implementation of PLIER (Pathway-Level Information Extractor).
 
-The notebooks that comprise this module are:
+The notebooks that comprise this module are (estimated time to complete notebook):
 
-* [Heatmap](https://alexslemonade.github.io/training-modules/machine-learning/01-openpbta_heatmap.nb.html)
-* [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-openpbta_consensus_clustering.nb.html)
-* [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-openpbta_PLIER.nb.html)
+* [Heatmap](https://alexslemonade.github.io/training-modules/machine-learning/01-openpbta_heatmap.nb.html) (1 hr)
+* [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-openpbta_consensus_clustering.nb.html) (55 minutes)
+* [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-openpbta_PLIER.nb.html) (20 minutes)
 * [Group differences in latent variable (LV) expression](https://alexslemonade.github.io/training-modules/machine-learning/04-openpbta_plot_LV.nb.html)
 * [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)
+
+_Total estimated time to complete instruction notebooks: 2 hours 15 minutes_

--- a/pathway-analysis/README.md
+++ b/pathway-analysis/README.md
@@ -4,9 +4,11 @@ This CCDL-designed module introduces training participants to three kinds of pat
 
 This module depends on the knowledge gained in the [Intro to R and the Tidyverse](../intro-to-R-tidyverse) module and uses data and/or results from the [scRNA-seq](../scRNA-seq) and [bulk RNA-seq](../RNA-seq) modules to illustrate pathway analysis concepts.
 
-The notebooks that comprise this module are:
+The notebooks that comprise this module are (estimated time to complete notebook):
 
-* [Over-representation analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/01-overrepresentation_analysis.nb.html)
-* [Gene Set Enrichment Analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/02-gene_set_enrichment_analysis.nb.html)
-* [Gene Set Variation Analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/03-gene_set_variation_analysis.nb.html)
+* [Over-representation analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/01-overrepresentation_analysis.nb.html) (45 minutes)
+* [Gene Set Enrichment Analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/02-gene_set_enrichment_analysis.nb.html) (30 minutes)
+* [Gene Set Variation Analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/03-gene_set_variation_analysis.nb.html) (30 minutes)
 * [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/pathway-analysis/04-pathway_analysis_exercise.Rmd)
+
+_Total estimated time to complete instruction notebooks: 1 hour 45 minutes_

--- a/scRNA-seq/README.md
+++ b/scRNA-seq/README.md
@@ -5,8 +5,11 @@ This CCDL-designed module covers the analysis of single-cell RNA-seq data using 
 It depends on knowledge gained in the [Intro to R](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse) and analyses are performed within a [Docker container](https://github.com/AlexsLemonade/training-modules/tree/master/docker-install) or on the CCDL RStudio server.
 It covers normalization and dimension reduction methods that can be used for both tag-based and full-length single-cell data, as well as the quantification of tag-based scRNA-seq data.
 
-The notebooks that comprise this module are:
-* [QC and filtering of single cell data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/01-filtering_scRNA-seq.nb.html)
-* [Normalization using scater/scran](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-normalizing_scRNA-seq.nb.html)
-* [Quantification of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-tag-based_scRNA-seq_processing.nb.html)
-* [Dimension reduction](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/05-dimension_reduction_scRNA-seq.nb.html)
+The notebooks that comprise this module are (estimated time to complete notebook):
+
+* [QC and filtering of single cell data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/01-filtering_scRNA-seq.nb.html) (1 hr 20 minutes)
+* [Normalization using scater/scran](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-normalizing_scRNA-seq.nb.html) (1 hr)
+* [Quantification of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-tag-based_scRNA-seq_processing.nb.html) (35 minutes)
+* [Dimension reduction](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/05-dimension_reduction_scRNA-seq.nb.html) (1 hr 20 minutes)
+
+_Total estimated time to complete instruction notebooks: 4 hours 15 minutes_


### PR DESCRIPTION
This PR addresses issue #325 by adding the estimated times to complete each instruction notebook to the each training module's `README.md` file, as well as the estimated total time of completion for that module (instruction wise).

Note that I used the latest vimeo instruction videos for each notebook to record said estimated times.
I excluded breaks, but included instances where we had to wait for a step to complete running (not sure if this time should also be excluded but I thought we might want it in there).

Also note that, for the last two notebooks of the machine learning module I added very rough estimates based on my time of completion (and the time taken to complete the previous module's notebooks) as the `03-openpbta_PLIER.Rmd` notebook was not completed in the instruction video and we do not have an instruction video for the `04-openpbta_plot_LV.Rmd` notebook.

Questions for reviewers:

- Does the way I've recorded the estimated times of completion in the `README` files make sense to you?
- Do you think the estimated time for the last two notebooks in the machine learning module seems reasonable?