### PR TITLE
Add AWS and shrink Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,31 +6,33 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN apt-get install dialog apt-utils -y
 
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
+    autoconf \
     build-essential \
+    ca-certificates \
+    curl \
+    g++ \
+    gcc \
+    git \
+    groff \
+    less \
+    libboost-all-dev \
+    libbz2-dev \
+    libglpk-dev \
+    liblzma-dev \
+    libmagick++-dev \
+    libmariadbclient-dev \
+    libmariadbd-dev \
+    libpq-dev \
+    libsqlite-dev \
+    libssh2-1-dev \
     libxml2 \
     libxml2-dev \
-    libsqlite-dev \
-    libmariadbd-dev \
-    libmariadbclient-dev \
-    libpq-dev \
-    libssh2-1-dev \
-    pandoc \
-    libmagick++-dev \
-    time \
-    python3-pip \
-    git \
-    gcc \
     make \
-    g++ \
-    libboost-all-dev \
-    liblzma-dev \
-    libbz2-dev \
-    ca-certificates \
-    zlib1g-dev \
-    curl \
+    pandoc \
+    python3-pip \
+    time \
     unzip \
-    autoconf \
-    libglpk-dev
+    zlib1g-dev 
 
 # AWS
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,11 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     autoconf \
     libglpk-dev
 
+# AWS
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install
+
 # FastQC
 RUN apt update && apt install -y fastqc
 
@@ -41,7 +46,7 @@ RUN git clone https://github.com/OpenGene/fastp.git
 RUN cd fastp && \
     git checkout tags/v${FASTP_VERSION} -b v${FASTP_VERSION} && \
     make && \
-    sudo make install
+    make install 
 
 # MultiQC
 ENV MULTIQC_VERSION 1.9
@@ -67,6 +72,6 @@ RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
 WORKDIR /usr/local/renv
 COPY renv.lock renv.lock
 RUN R -e 'renv::consent(provided = TRUE)'
-RUN R -e 'renv::restore()'
+RUN R -e 'renv::restore()' && rm -r ~/.local/share/renv
 
 WORKDIR /home/rstudio


### PR DESCRIPTION
This PR adds the AWS command line tools which we need for syncing data to the `training_dev` docker image.

I also figured out that we can reduce the image size by getting rid of the cache that renv makes for the root user and is never actually used.
