### PR TITLE
Add tximeta renv.lock changes

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -28,12 +28,6 @@
       "Source": "Bioconductor",
       "Hash": "ca5106b296b3aa6af713ce197be547c1"
     },
-    "AnnotationFilter": {
-      "Package": "AnnotationFilter",
-      "Version": "1.14.0",
-      "Source": "Bioconductor",
-      "Hash": "325dd37df49384d6b6b4771e364d45ec"
-    },
     "AnnotationHub": {
       "Package": "AnnotationHub",
       "Version": "2.22.0",
@@ -96,12 +90,6 @@
       "Source": "Bioconductor",
       "Hash": "ee4d027afb8f52fec1f46b9f0a8660e9"
     },
-    "Biostrings": {
-      "Package": "Biostrings",
-      "Version": "2.58.0",
-      "Source": "Bioconductor",
-      "Hash": "7025417314cfb2f1be19919998874466"
-    },
     "Cairo": {
       "Package": "Cairo",
       "Version": "1.5-12.2",
@@ -134,6 +122,18 @@
       "Source": "Bioconductor",
       "Hash": "70f50d662ec8f7c534dfd233c949e1d5"
     },
+    "DO.db": {
+      "Package": "DO.db",
+      "Version": "2.9",
+      "Source": "Bioconductor",
+      "Hash": "7d05e00472158bda5f124df351af0a49"
+    },
+    "DOSE": {
+      "Package": "DOSE",
+      "Version": "3.16.0",
+      "Source": "Bioconductor",
+      "Hash": "1a16437853dbade9c1096e3248be9380"
+    },
     "DT": {
       "Package": "DT",
       "Version": "0.17",
@@ -153,11 +153,42 @@
       "Source": "Bioconductor",
       "Hash": "1a9c016231c53483de05bec235ff8bfd"
     },
+    "FNN": {
+      "Package": "FNN",
+      "Version": "1.1.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "b56998fff55e4a4b4860ad6e8c67e0f9"
+    },
     "GEOquery": {
       "Package": "GEOquery",
       "Version": "2.58.0",
       "Source": "Bioconductor",
       "Hash": "b17420379c5ef4c956f52362d8f824c8"
+    },
+    "GO.db": {
+      "Package": "GO.db",
+      "Version": "3.12.1",
+      "Source": "Bioconductor",
+      "Hash": "1ed8d8ec3449f0c6fba5f1932ac333ae"
+    },
+    "GOSemSim": {
+      "Package": "GOSemSim",
+      "Version": "2.16.1",
+      "Source": "Bioconductor",
+      "Hash": "f73eccd90a8131c9798bd6675e442c5a"
+    },
+    "GSEABase": {
+      "Package": "GSEABase",
+      "Version": "1.52.1",
+      "Source": "Bioconductor",
+      "Hash": "c3fd12a7f8101f913b752b889dc93ed2"
+    },
+    "GSVA": {
+      "Package": "GSVA",
+      "Version": "1.38.2",
+      "Source": "Bioconductor",
+      "Hash": "369dfe423f79a4d38c0616c6462d9b09"
     },
     "GenomeInfoDb": {
       "Package": "GenomeInfoDb",
@@ -170,18 +201,6 @@
       "Version": "1.2.4",
       "Source": "Bioconductor",
       "Hash": "8e9c39ceac5f1d98d3267541853fca31"
-    },
-    "GenomicAlignments": {
-      "Package": "GenomicAlignments",
-      "Version": "1.26.0",
-      "Source": "Bioconductor",
-      "Hash": "b39d47616678079df56fb8fcf07c707d"
-    },
-    "GenomicFeatures": {
-      "Package": "GenomicFeatures",
-      "Version": "1.42.1",
-      "Source": "Bioconductor",
-      "Hash": "10c8a15846af2fd20d2645ce4edf74e3"
     },
     "GenomicRanges": {
       "Package": "GenomicRanges",
@@ -254,12 +273,6 @@
       "RemoteSha": "550b08c87b00ca8d55f3548fbd75265298f07a42",
       "Hash": "a5ef1066be1235490778c1f9fce13dcb"
     },
-    "ProtGenerics": {
-      "Package": "ProtGenerics",
-      "Version": "1.22.0",
-      "Source": "Bioconductor",
-      "Hash": "cb8bba73ee8d16f5ffdb27e0fc7939ee"
-    },
     "R6": {
       "Package": "R6",
       "Version": "2.5.0",
@@ -302,6 +315,13 @@
       "Repository": "RSPM",
       "Hash": "dbb5e436998a7eba5a9d682060533338"
     },
+    "RcppAnnoy": {
+      "Package": "RcppAnnoy",
+      "Version": "0.0.18",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "4c61a26f751659e875f46045df6d5fad"
+    },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
       "Version": "0.10.1.2.2",
@@ -323,23 +343,32 @@
       "Repository": "RSPM",
       "Hash": "ce584c040a9cfa786ffb41f938f5ed19"
     },
+    "RcppNumerical": {
+      "Package": "RcppNumerical",
+      "Version": "0.4-0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "750f0527a0edaf99c29cf1e778b27a6f"
+    },
+    "RcppProgress": {
+      "Package": "RcppProgress",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "1c0aa18b97e6aaa17f93b8b866c0ace5"
+    },
     "Rhdf5lib": {
       "Package": "Rhdf5lib",
       "Version": "1.12.1",
       "Source": "Bioconductor",
       "Hash": "7dc9be3558a910226d64a2040520dc7f"
     },
-    "Rhtslib": {
-      "Package": "Rhtslib",
-      "Version": "1.22.0",
-      "Source": "Bioconductor",
-      "Hash": "bc1c8c2d34d2649ff80c22237c3a03ed"
-    },
-    "Rsamtools": {
-      "Package": "Rsamtools",
-      "Version": "2.6.0",
-      "Source": "Bioconductor",
-      "Hash": "7d5b0ec921f85730aafe82f0f94f76c0"
+    "Rtsne": {
+      "Package": "Rtsne",
+      "Version": "0.15",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "f153432c4ca15b937ccfaa40f167c892"
     },
     "S4Vectors": {
       "Package": "S4Vectors",
@@ -379,23 +408,17 @@
       "Repository": "RSPM",
       "Hash": "4f57884290cc75ab22f4af9e9d4ca862"
     },
-    "affy": {
-      "Package": "affy",
-      "Version": "1.68.0",
-      "Source": "Bioconductor",
-      "Hash": "1ca6c42192e20297d7d932c25ed9caab"
-    },
-    "affyio": {
-      "Package": "affyio",
-      "Version": "1.60.0",
-      "Source": "Bioconductor",
-      "Hash": "1c5d69af9526756efa3ee2fbcc08a5b1"
-    },
     "annotate": {
       "Package": "annotate",
       "Version": "1.68.0",
       "Source": "Bioconductor",
       "Hash": "3553333f7949ea3d722760136f3660ae"
+    },
+    "apeglm": {
+      "Package": "apeglm",
+      "Version": "1.12.0",
+      "Source": "Bioconductor",
+      "Hash": "3f89d2a4ad516fb1e77c06197c486fec"
     },
     "askpass": {
       "Package": "askpass",
@@ -425,6 +448,20 @@
       "Repository": "RSPM",
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
+    "bbmle": {
+      "Package": "bbmle",
+      "Version": "1.0.23.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "89eef0faafa404fe20f23290c322bbeb"
+    },
+    "bdsmatrix": {
+      "Package": "bdsmatrix",
+      "Version": "1.3-4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "1012f2033c32d595e1a16bee3bb0b3e5"
+    },
     "beachmat": {
       "Package": "beachmat",
       "Version": "2.6.4",
@@ -437,12 +474,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "dc538ec663e38888807ef3034489403d"
-    },
-    "biomaRt": {
-      "Package": "biomaRt",
-      "Version": "2.46.3",
-      "Source": "Bioconductor",
-      "Hash": "1dba821d9a19d3b70fa324cab2fb4d0b"
     },
     "bit": {
       "Package": "bit",
@@ -562,6 +593,19 @@
       "Repository": "CRAN",
       "Hash": "db63a44aab5aadcb6bf2f129751d129a"
     },
+    "clusterProfiler": {
+      "Package": "clusterProfiler",
+      "Version": "3.18.1",
+      "Source": "Bioconductor",
+      "Hash": "5f344773b73f177d66183d4c807c2670"
+    },
+    "coda": {
+      "Package": "coda",
+      "Version": "0.19-4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "24b6d006b8b2343876cf230687546932"
+    },
     "codetools": {
       "Package": "codetools",
       "Version": "0.2-18",
@@ -582,6 +626,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
+    },
+    "cowplot": {
+      "Package": "cowplot",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "b418e8423699d11c7f2087c2bfd07da2"
     },
     "cpp11": {
       "Package": "cpp11",
@@ -646,6 +697,13 @@
       "Repository": "RSPM",
       "Hash": "a0cbe758a531d054b537d16dff4d58a1"
     },
+    "downloader": {
+      "Package": "downloader",
+      "Version": "0.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "f4f2a915e0dedbdf016a83b63477349f"
+    },
     "dplyr": {
       "Package": "dplyr",
       "Version": "1.0.3",
@@ -673,11 +731,32 @@
       "Repository": "RSPM",
       "Hash": "fd2844b3a43ae2d27e70ece2df1b4e2a"
     },
-    "ensembldb": {
-      "Package": "ensembldb",
-      "Version": "2.14.0",
+    "emdbook": {
+      "Package": "emdbook",
+      "Version": "1.3.12",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "e95109c1d5610799fc5b8ee471fe342f"
+    },
+    "emmeans": {
+      "Package": "emmeans",
+      "Version": "1.5.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "f43c611673017ee687edbe97412ccd8c"
+    },
+    "enrichplot": {
+      "Package": "enrichplot",
+      "Version": "1.10.2",
       "Source": "Bioconductor",
-      "Hash": "b433b752aafc4ae0b5523585cae1269c"
+      "Hash": "bfe9798d5d9be7c8bfb269c5f19dd957"
+    },
+    "estimability": {
+      "Package": "estimability",
+      "Version": "1.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "05901bd61be60fd3bfc5b7d7c3517d1d"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -685,6 +764,18 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
+    },
+    "exrcise": {
+      "Package": "exrcise",
+      "Version": "0.1.0",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "exrcise",
+      "RemoteUsername": "AlexsLemonade",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "a496662f8a8a2294366cae4d2f3547c50ac341f1",
+      "Hash": "a5a91e3a3f03206b58ae5dbc6ee66f64"
     },
     "fansi": {
       "Package": "fansi",
@@ -707,12 +798,32 @@
       "Repository": "RSPM",
       "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
     },
+    "fastmatch": {
+      "Package": "fastmatch",
+      "Version": "1.1-0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "2cfe25650d69960c54e06840e4b5d8e4"
+    },
     "fastqcr": {
       "Package": "fastqcr",
       "Version": "0.1.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "2abd00eb709c07fc87aa6b4132e17040"
+    },
+    "fftw": {
+      "Package": "fftw",
+      "Version": "1.0-6",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "6bd00d1c7c902b36fdeaa0cc6e5360b5"
+    },
+    "fgsea": {
+      "Package": "fgsea",
+      "Version": "1.16.0",
+      "Source": "Bioconductor",
+      "Hash": "0ed01e7c1d5fef94d795abb1597aab86"
     },
     "fishpond": {
       "Package": "fishpond",
@@ -795,6 +906,13 @@
       "Repository": "RSPM",
       "Hash": "dd68b9b215b2d3119603549a794003c3"
     },
+    "ggforce": {
+      "Package": "ggforce",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "4adaf6b01b41f243ba0c62801de3331e"
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.3.3",
@@ -802,12 +920,33 @@
       "Repository": "RSPM",
       "Hash": "3eb6477d01eb5bbdc03f7d5f70f2733e"
     },
+    "ggraph": {
+      "Package": "ggraph",
+      "Version": "2.0.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "2a189e5cd2bbfe687ed631be27c07462"
+    },
+    "ggrepel": {
+      "Package": "ggrepel",
+      "Version": "0.9.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "08ab869f37e6a7741a64ab9069bcb67d"
+    },
     "ggsignif": {
       "Package": "ggsignif",
       "Version": "0.6.0",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "3e9b8a51dfdc95395632b25ce3ce8ebc"
+    },
+    "ggupset": {
+      "Package": "ggupset",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "8e9eb92bf465601c07d17c5e8b75dce1"
     },
     "glmnet": {
       "Package": "glmnet",
@@ -829,6 +968,19 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "e65e5d5dea4cbb9ba822dcd782b2ee1f"
+    },
+    "graph": {
+      "Package": "graph",
+      "Version": "1.68.0",
+      "Source": "Bioconductor",
+      "Hash": "38322867731e9e137d21b13778a96b5f"
+    },
+    "graphlayouts": {
+      "Package": "graphlayouts",
+      "Version": "0.7.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "2a0d18b9395cd27066d209b83bb29ea6"
     },
     "gridExtra": {
       "Package": "gridExtra",
@@ -1094,12 +1246,26 @@
       "Repository": "RSPM",
       "Hash": "6dfe8bf774944bd5595785e3229d8771"
     },
+    "mvtnorm": {
+      "Package": "mvtnorm",
+      "Version": "1.1-1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "69fa7331e7410c2a2cb3f9868513904f"
+    },
     "nlme": {
       "Package": "nlme",
       "Version": "3.1-151",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "42c8ba2b6a32a6bf0874e93e3bd86a43"
+    },
+    "numDeriv": {
+      "Package": "numDeriv",
+      "Version": "2016.8-1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
     "openssl": {
       "Package": "openssl",
@@ -1184,18 +1350,19 @@
       "Repository": "RSPM",
       "Hash": "03b7076c234cb3331288919983326c55"
     },
+    "polyclip": {
+      "Package": "polyclip",
+      "Version": "1.10-0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "cb167f328b3ada4ec5cf67a7df4c900a"
+    },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "a555924add98c99d2f411e37e7d25e9f"
-    },
-    "preprocessCore": {
-      "Package": "preprocessCore",
-      "Version": "1.52.1",
-      "Source": "Bioconductor",
-      "Hash": "d5c78cf1defde79ad72d44ac0e2276de"
     },
     "prettyunits": {
       "Package": "prettyunits",
@@ -1238,6 +1405,12 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
+    },
+    "qusage": {
+      "Package": "qusage",
+      "Version": "2.24.0",
+      "Source": "Bioconductor",
+      "Hash": "bc463180c83b4777e753f3a240c40be2"
     },
     "qvalue": {
       "Package": "qvalue",
@@ -1374,11 +1547,12 @@
       "Repository": "RSPM",
       "Hash": "3a6b30449282b6a4b19ce267142c3299"
     },
-    "rtracklayer": {
-      "Package": "rtracklayer",
-      "Version": "1.50.0",
-      "Source": "Bioconductor",
-      "Hash": "3905c00eda8f95ab761abc0978ffa19d"
+    "rvcheck": {
+      "Package": "rvcheck",
+      "Version": "0.1.8",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "11ebf2d3d4990e8bb9f28d5ab0c204fc"
     },
     "rvest": {
       "Package": "rvest",
@@ -1407,6 +1581,13 @@
       "Source": "Bioconductor",
       "Hash": "0fe8d0094951d12105d37747af4eada8"
     },
+    "scatterpie": {
+      "Package": "scatterpie",
+      "Version": "0.1.5",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "d96eeb2f420d63edf1a6bfee068543e9"
+    },
     "scran": {
       "Package": "scran",
       "Version": "1.18.5",
@@ -1425,6 +1606,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
+    },
+    "shadowtext": {
+      "Package": "shadowtext",
+      "Version": "0.0.7",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "59c332a398fa940a85094cf3bbcb4443"
     },
     "shape": {
       "Package": "shape",
@@ -1530,6 +1718,13 @@
       "Repository": "RSPM",
       "Hash": "a1958587eb651a02273d685fff3819b1"
     },
+    "tidygraph": {
+      "Package": "tidygraph",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "5375980d0787633ca62c265b28bedb41"
+    },
     "tidyr": {
       "Package": "tidyr",
       "Version": "1.1.2",
@@ -1558,11 +1753,12 @@
       "Repository": "RSPM",
       "Hash": "f0b0ba735febac9a8344253ae6fa93f5"
     },
-    "tximeta": {
-      "Package": "tximeta",
-      "Version": "1.8.3",
-      "Source": "Bioconductor",
-      "Hash": "1a8c1f3099fdc500c93ae1af4c3e7d0f"
+    "tweenr": {
+      "Package": "tweenr",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "fc77eb5297507cccfa3349a606061030"
     },
     "tximport": {
       "Package": "tximport",
@@ -1583,6 +1779,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "4a5081acfb7b81a572e4384a7aaf2af1"
+    },
+    "uwot": {
+      "Package": "uwot",
+      "Version": "0.1.10",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "a9737c75f5f949695617b05e78281b2f"
     },
     "vctrs": {
       "Package": "vctrs",
@@ -1611,12 +1814,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "ce4f6271baa94776db692f1cb2055bee"
-    },
-    "vsn": {
-      "Package": "vsn",
-      "Version": "3.58.0",
-      "Source": "Bioconductor",
-      "Hash": "93fcbe7855ba2e1c0af7c2ab7ec3fb56"
     },
     "waldo": {
       "Package": "waldo",

--- a/renv.lock
+++ b/renv.lock
@@ -28,6 +28,12 @@
       "Source": "Bioconductor",
       "Hash": "ca5106b296b3aa6af713ce197be547c1"
     },
+    "AnnotationFilter": {
+      "Package": "AnnotationFilter",
+      "Version": "1.14.0",
+      "Source": "Bioconductor",
+      "Hash": "325dd37df49384d6b6b4771e364d45ec"
+    },
     "AnnotationHub": {
       "Package": "AnnotationHub",
       "Version": "2.22.0",
@@ -90,6 +96,12 @@
       "Source": "Bioconductor",
       "Hash": "ee4d027afb8f52fec1f46b9f0a8660e9"
     },
+    "Biostrings": {
+      "Package": "Biostrings",
+      "Version": "2.58.0",
+      "Source": "Bioconductor",
+      "Hash": "7025417314cfb2f1be19919998874466"
+    },
     "Cairo": {
       "Package": "Cairo",
       "Version": "1.5-12.2",
@@ -122,18 +134,6 @@
       "Source": "Bioconductor",
       "Hash": "70f50d662ec8f7c534dfd233c949e1d5"
     },
-    "DO.db": {
-      "Package": "DO.db",
-      "Version": "2.9",
-      "Source": "Bioconductor",
-      "Hash": "7d05e00472158bda5f124df351af0a49"
-    },
-    "DOSE": {
-      "Package": "DOSE",
-      "Version": "3.16.0",
-      "Source": "Bioconductor",
-      "Hash": "1a16437853dbade9c1096e3248be9380"
-    },
     "DT": {
       "Package": "DT",
       "Version": "0.17",
@@ -149,46 +149,15 @@
     },
     "DelayedMatrixStats": {
       "Package": "DelayedMatrixStats",
-      "Version": "1.12.2",
+      "Version": "1.12.3",
       "Source": "Bioconductor",
-      "Hash": "230e879420712830db7e0c055188dd68"
-    },
-    "FNN": {
-      "Package": "FNN",
-      "Version": "1.1.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b56998fff55e4a4b4860ad6e8c67e0f9"
+      "Hash": "1a9c016231c53483de05bec235ff8bfd"
     },
     "GEOquery": {
       "Package": "GEOquery",
       "Version": "2.58.0",
       "Source": "Bioconductor",
       "Hash": "b17420379c5ef4c956f52362d8f824c8"
-    },
-    "GO.db": {
-      "Package": "GO.db",
-      "Version": "3.12.1",
-      "Source": "Bioconductor",
-      "Hash": "1ed8d8ec3449f0c6fba5f1932ac333ae"
-    },
-    "GOSemSim": {
-      "Package": "GOSemSim",
-      "Version": "2.16.1",
-      "Source": "Bioconductor",
-      "Hash": "f73eccd90a8131c9798bd6675e442c5a"
-    },
-    "GSEABase": {
-      "Package": "GSEABase",
-      "Version": "1.52.1",
-      "Source": "Bioconductor",
-      "Hash": "c3fd12a7f8101f913b752b889dc93ed2"
-    },
-    "GSVA": {
-      "Package": "GSVA",
-      "Version": "1.38.2",
-      "Source": "Bioconductor",
-      "Hash": "369dfe423f79a4d38c0616c6462d9b09"
     },
     "GenomeInfoDb": {
       "Package": "GenomeInfoDb",
@@ -201,6 +170,18 @@
       "Version": "1.2.4",
       "Source": "Bioconductor",
       "Hash": "8e9c39ceac5f1d98d3267541853fca31"
+    },
+    "GenomicAlignments": {
+      "Package": "GenomicAlignments",
+      "Version": "1.26.0",
+      "Source": "Bioconductor",
+      "Hash": "b39d47616678079df56fb8fcf07c707d"
+    },
+    "GenomicFeatures": {
+      "Package": "GenomicFeatures",
+      "Version": "1.42.1",
+      "Source": "Bioconductor",
+      "Hash": "10c8a15846af2fd20d2645ce4edf74e3"
     },
     "GenomicRanges": {
       "Package": "GenomicRanges",
@@ -224,9 +205,9 @@
     },
     "HDF5Array": {
       "Package": "HDF5Array",
-      "Version": "1.18.0",
+      "Version": "1.18.1",
       "Source": "Bioconductor",
-      "Hash": "15f329f2c5f34d0ea8fc1c636d63df5d"
+      "Hash": "07fd74c160b1265137c0cdd815dc42b5"
     },
     "IRanges": {
       "Package": "IRanges",
@@ -273,6 +254,12 @@
       "RemoteSha": "550b08c87b00ca8d55f3548fbd75265298f07a42",
       "Hash": "a5ef1066be1235490778c1f9fce13dcb"
     },
+    "ProtGenerics": {
+      "Package": "ProtGenerics",
+      "Version": "1.22.0",
+      "Source": "Bioconductor",
+      "Hash": "cb8bba73ee8d16f5ffdb27e0fc7939ee"
+    },
     "R6": {
       "Package": "R6",
       "Version": "2.5.0",
@@ -296,10 +283,10 @@
     },
     "RSQLite": {
       "Package": "RSQLite",
-      "Version": "2.2.2",
+      "Version": "2.2.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "d48cf88a07ffea3e82c2e7c42299da3f"
+      "Hash": "a281e35445a1c4fc7ccfc62f01bb1e2d"
     },
     "RSpectra": {
       "Package": "RSpectra",
@@ -314,13 +301,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "dbb5e436998a7eba5a9d682060533338"
-    },
-    "RcppAnnoy": {
-      "Package": "RcppAnnoy",
-      "Version": "0.0.18",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "4c61a26f751659e875f46045df6d5fad"
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
@@ -343,32 +323,23 @@
       "Repository": "RSPM",
       "Hash": "ce584c040a9cfa786ffb41f938f5ed19"
     },
-    "RcppNumerical": {
-      "Package": "RcppNumerical",
-      "Version": "0.4-0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "750f0527a0edaf99c29cf1e778b27a6f"
-    },
-    "RcppProgress": {
-      "Package": "RcppProgress",
-      "Version": "0.4.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "1c0aa18b97e6aaa17f93b8b866c0ace5"
-    },
     "Rhdf5lib": {
       "Package": "Rhdf5lib",
       "Version": "1.12.1",
       "Source": "Bioconductor",
       "Hash": "7dc9be3558a910226d64a2040520dc7f"
     },
-    "Rtsne": {
-      "Package": "Rtsne",
-      "Version": "0.15",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f153432c4ca15b937ccfaa40f167c892"
+    "Rhtslib": {
+      "Package": "Rhtslib",
+      "Version": "1.22.0",
+      "Source": "Bioconductor",
+      "Hash": "bc1c8c2d34d2649ff80c22237c3a03ed"
+    },
+    "Rsamtools": {
+      "Package": "Rsamtools",
+      "Version": "2.6.0",
+      "Source": "Bioconductor",
+      "Hash": "7d5b0ec921f85730aafe82f0f94f76c0"
     },
     "S4Vectors": {
       "Package": "S4Vectors",
@@ -426,12 +397,6 @@
       "Source": "Bioconductor",
       "Hash": "3553333f7949ea3d722760136f3660ae"
     },
-    "apeglm": {
-      "Package": "apeglm",
-      "Version": "1.12.0",
-      "Source": "Bioconductor",
-      "Hash": "3f89d2a4ad516fb1e77c06197c486fec"
-    },
     "askpass": {
       "Package": "askpass",
       "Version": "1.1",
@@ -460,20 +425,6 @@
       "Repository": "RSPM",
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
-    "bbmle": {
-      "Package": "bbmle",
-      "Version": "1.0.23.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "89eef0faafa404fe20f23290c322bbeb"
-    },
-    "bdsmatrix": {
-      "Package": "bdsmatrix",
-      "Version": "1.3-4",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "1012f2033c32d595e1a16bee3bb0b3e5"
-    },
     "beachmat": {
       "Package": "beachmat",
       "Version": "2.6.4",
@@ -486,6 +437,12 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "dc538ec663e38888807ef3034489403d"
+    },
+    "biomaRt": {
+      "Package": "biomaRt",
+      "Version": "2.46.3",
+      "Source": "Bioconductor",
+      "Hash": "1dba821d9a19d3b70fa324cab2fb4d0b"
     },
     "bit": {
       "Package": "bit",
@@ -605,19 +562,6 @@
       "Repository": "CRAN",
       "Hash": "db63a44aab5aadcb6bf2f129751d129a"
     },
-    "clusterProfiler": {
-      "Package": "clusterProfiler",
-      "Version": "3.18.1",
-      "Source": "Bioconductor",
-      "Hash": "5f344773b73f177d66183d4c807c2670"
-    },
-    "coda": {
-      "Package": "coda",
-      "Version": "0.19-4",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "24b6d006b8b2343876cf230687546932"
-    },
     "codetools": {
       "Package": "codetools",
       "Version": "0.2-18",
@@ -638,13 +582,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
-    },
-    "cowplot": {
-      "Package": "cowplot",
-      "Version": "1.1.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b418e8423699d11c7f2087c2bfd07da2"
     },
     "cpp11": {
       "Package": "cpp11",
@@ -709,13 +646,6 @@
       "Repository": "RSPM",
       "Hash": "a0cbe758a531d054b537d16dff4d58a1"
     },
-    "downloader": {
-      "Package": "downloader",
-      "Version": "0.4",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f4f2a915e0dedbdf016a83b63477349f"
-    },
     "dplyr": {
       "Package": "dplyr",
       "Version": "1.0.3",
@@ -743,32 +673,11 @@
       "Repository": "RSPM",
       "Hash": "fd2844b3a43ae2d27e70ece2df1b4e2a"
     },
-    "emdbook": {
-      "Package": "emdbook",
-      "Version": "1.3.12",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e95109c1d5610799fc5b8ee471fe342f"
-    },
-    "emmeans": {
-      "Package": "emmeans",
-      "Version": "1.5.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f43c611673017ee687edbe97412ccd8c"
-    },
-    "enrichplot": {
-      "Package": "enrichplot",
-      "Version": "1.10.2",
+    "ensembldb": {
+      "Package": "ensembldb",
+      "Version": "2.14.0",
       "Source": "Bioconductor",
-      "Hash": "bfe9798d5d9be7c8bfb269c5f19dd957"
-    },
-    "estimability": {
-      "Package": "estimability",
-      "Version": "1.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "05901bd61be60fd3bfc5b7d7c3517d1d"
+      "Hash": "b433b752aafc4ae0b5523585cae1269c"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -776,18 +685,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
-    },
-    "exrcise": {
-      "Package": "exrcise",
-      "Version": "0.1.0",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteRepo": "exrcise",
-      "RemoteUsername": "AlexsLemonade",
-      "RemoteRef": "HEAD",
-      "RemoteSha": "a496662f8a8a2294366cae4d2f3547c50ac341f1",
-      "Hash": "a5a91e3a3f03206b58ae5dbc6ee66f64"
     },
     "fansi": {
       "Package": "fansi",
@@ -810,32 +707,12 @@
       "Repository": "RSPM",
       "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
     },
-    "fastmatch": {
-      "Package": "fastmatch",
-      "Version": "1.1-0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2cfe25650d69960c54e06840e4b5d8e4"
-    },
     "fastqcr": {
       "Package": "fastqcr",
       "Version": "0.1.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "2abd00eb709c07fc87aa6b4132e17040"
-    },
-    "fftw": {
-      "Package": "fftw",
-      "Version": "1.0-6",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "6bd00d1c7c902b36fdeaa0cc6e5360b5"
-    },
-    "fgsea": {
-      "Package": "fgsea",
-      "Version": "1.16.0",
-      "Source": "Bioconductor",
-      "Hash": "0ed01e7c1d5fef94d795abb1597aab86"
     },
     "fishpond": {
       "Package": "fishpond",
@@ -918,13 +795,6 @@
       "Repository": "RSPM",
       "Hash": "dd68b9b215b2d3119603549a794003c3"
     },
-    "ggforce": {
-      "Package": "ggforce",
-      "Version": "0.3.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "4adaf6b01b41f243ba0c62801de3331e"
-    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.3.3",
@@ -932,33 +802,12 @@
       "Repository": "RSPM",
       "Hash": "3eb6477d01eb5bbdc03f7d5f70f2733e"
     },
-    "ggraph": {
-      "Package": "ggraph",
-      "Version": "2.0.4",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2a189e5cd2bbfe687ed631be27c07462"
-    },
-    "ggrepel": {
-      "Package": "ggrepel",
-      "Version": "0.9.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "08ab869f37e6a7741a64ab9069bcb67d"
-    },
     "ggsignif": {
       "Package": "ggsignif",
       "Version": "0.6.0",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "3e9b8a51dfdc95395632b25ce3ce8ebc"
-    },
-    "ggupset": {
-      "Package": "ggupset",
-      "Version": "0.3.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "8e9eb92bf465601c07d17c5e8b75dce1"
     },
     "glmnet": {
       "Package": "glmnet",
@@ -980,19 +829,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "e65e5d5dea4cbb9ba822dcd782b2ee1f"
-    },
-    "graph": {
-      "Package": "graph",
-      "Version": "1.68.0",
-      "Source": "Bioconductor",
-      "Hash": "38322867731e9e137d21b13778a96b5f"
-    },
-    "graphlayouts": {
-      "Package": "graphlayouts",
-      "Version": "0.7.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2a0d18b9395cd27066d209b83bb29ea6"
     },
     "gridExtra": {
       "Package": "gridExtra",
@@ -1258,26 +1094,12 @@
       "Repository": "RSPM",
       "Hash": "6dfe8bf774944bd5595785e3229d8771"
     },
-    "mvtnorm": {
-      "Package": "mvtnorm",
-      "Version": "1.1-1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "69fa7331e7410c2a2cb3f9868513904f"
-    },
     "nlme": {
       "Package": "nlme",
       "Version": "3.1-151",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "42c8ba2b6a32a6bf0874e93e3bd86a43"
-    },
-    "numDeriv": {
-      "Package": "numDeriv",
-      "Version": "2016.8-1.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
     "openssl": {
       "Package": "openssl",
@@ -1362,13 +1184,6 @@
       "Repository": "RSPM",
       "Hash": "03b7076c234cb3331288919983326c55"
     },
-    "polyclip": {
-      "Package": "polyclip",
-      "Version": "1.10-0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "cb167f328b3ada4ec5cf67a7df4c900a"
-    },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
@@ -1423,12 +1238,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
-    },
-    "qusage": {
-      "Package": "qusage",
-      "Version": "2.24.0",
-      "Source": "Bioconductor",
-      "Hash": "bc463180c83b4777e753f3a240c40be2"
     },
     "qvalue": {
       "Package": "qvalue",
@@ -1565,12 +1374,11 @@
       "Repository": "RSPM",
       "Hash": "3a6b30449282b6a4b19ce267142c3299"
     },
-    "rvcheck": {
-      "Package": "rvcheck",
-      "Version": "0.1.8",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "11ebf2d3d4990e8bb9f28d5ab0c204fc"
+    "rtracklayer": {
+      "Package": "rtracklayer",
+      "Version": "1.50.0",
+      "Source": "Bioconductor",
+      "Hash": "3905c00eda8f95ab761abc0978ffa19d"
     },
     "rvest": {
       "Package": "rvest",
@@ -1599,18 +1407,11 @@
       "Source": "Bioconductor",
       "Hash": "0fe8d0094951d12105d37747af4eada8"
     },
-    "scatterpie": {
-      "Package": "scatterpie",
-      "Version": "0.1.5",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "d96eeb2f420d63edf1a6bfee068543e9"
-    },
     "scran": {
       "Package": "scran",
-      "Version": "1.18.3",
+      "Version": "1.18.5",
       "Source": "Bioconductor",
-      "Hash": "32fb15efc8fb42223369a1d9e6b62740"
+      "Hash": "3f935129e59f4cf0bb588ee776a0a570"
     },
     "scuttle": {
       "Package": "scuttle",
@@ -1624,13 +1425,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
-    },
-    "shadowtext": {
-      "Package": "shadowtext",
-      "Version": "0.0.7",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "59c332a398fa940a85094cf3bbcb4443"
     },
     "shape": {
       "Package": "shape",
@@ -1669,9 +1463,9 @@
     },
     "sparseMatrixStats": {
       "Package": "sparseMatrixStats",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Bioconductor",
-      "Hash": "5ac668b7d66a3f0d20fbb02853aa7dd6"
+      "Hash": "1841edbaa151c369bd671a1b61bad097"
     },
     "spelling": {
       "Package": "spelling",
@@ -1736,13 +1530,6 @@
       "Repository": "RSPM",
       "Hash": "a1958587eb651a02273d685fff3819b1"
     },
-    "tidygraph": {
-      "Package": "tidygraph",
-      "Version": "1.2.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "5375980d0787633ca62c265b28bedb41"
-    },
     "tidyr": {
       "Package": "tidyr",
       "Version": "1.1.2",
@@ -1766,17 +1553,16 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.28",
+      "Version": "0.29",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "ff73961a77fba606fbf944dc3468e5b9"
+      "Hash": "f0b0ba735febac9a8344253ae6fa93f5"
     },
-    "tweenr": {
-      "Package": "tweenr",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "fc77eb5297507cccfa3349a606061030"
+    "tximeta": {
+      "Package": "tximeta",
+      "Version": "1.8.3",
+      "Source": "Bioconductor",
+      "Hash": "1a8c1f3099fdc500c93ae1af4c3e7d0f"
     },
     "tximport": {
       "Package": "tximport",
@@ -1797,13 +1583,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "4a5081acfb7b81a572e4384a7aaf2af1"
-    },
-    "uwot": {
-      "Package": "uwot",
-      "Version": "0.1.10",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "a9737c75f5f949695617b05e78281b2f"
     },
     "vctrs": {
       "Package": "vctrs",


### PR DESCRIPTION
### Background

The tximeta renv.lock changes need to be added before #343 will be able to pass. 

I cherry picked this commit from `cansavvy/tximeta`. 
