### PR TITLE
Add renv.lock that has tximeta

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -28,6 +28,12 @@
       "Source": "Bioconductor",
       "Hash": "ca5106b296b3aa6af713ce197be547c1"
     },
+    "AnnotationFilter": {
+      "Package": "AnnotationFilter",
+      "Version": "1.14.0",
+      "Source": "Bioconductor",
+      "Hash": "325dd37df49384d6b6b4771e364d45ec"
+    },
     "AnnotationHub": {
       "Package": "AnnotationHub",
       "Version": "2.22.0",
@@ -89,6 +95,12 @@
       "Version": "3.12.0",
       "Source": "Bioconductor",
       "Hash": "ee4d027afb8f52fec1f46b9f0a8660e9"
+    },
+    "Biostrings": {
+      "Package": "Biostrings",
+      "Version": "2.58.0",
+      "Source": "Bioconductor",
+      "Hash": "7025417314cfb2f1be19919998874466"
     },
     "Cairo": {
       "Package": "Cairo",
@@ -202,6 +214,18 @@
       "Source": "Bioconductor",
       "Hash": "8e9c39ceac5f1d98d3267541853fca31"
     },
+    "GenomicAlignments": {
+      "Package": "GenomicAlignments",
+      "Version": "1.26.0",
+      "Source": "Bioconductor",
+      "Hash": "b39d47616678079df56fb8fcf07c707d"
+    },
+    "GenomicFeatures": {
+      "Package": "GenomicFeatures",
+      "Version": "1.42.1",
+      "Source": "Bioconductor",
+      "Hash": "10c8a15846af2fd20d2645ce4edf74e3"
+    },
     "GenomicRanges": {
       "Package": "GenomicRanges",
       "Version": "1.42.0",
@@ -272,6 +296,12 @@
       "RemoteRef": "v0.1.4",
       "RemoteSha": "550b08c87b00ca8d55f3548fbd75265298f07a42",
       "Hash": "a5ef1066be1235490778c1f9fce13dcb"
+    },
+    "ProtGenerics": {
+      "Package": "ProtGenerics",
+      "Version": "1.22.0",
+      "Source": "Bioconductor",
+      "Hash": "cb8bba73ee8d16f5ffdb27e0fc7939ee"
     },
     "R6": {
       "Package": "R6",
@@ -362,6 +392,18 @@
       "Version": "1.12.1",
       "Source": "Bioconductor",
       "Hash": "7dc9be3558a910226d64a2040520dc7f"
+    },
+    "Rhtslib": {
+      "Package": "Rhtslib",
+      "Version": "1.22.0",
+      "Source": "Bioconductor",
+      "Hash": "bc1c8c2d34d2649ff80c22237c3a03ed"
+    },
+    "Rsamtools": {
+      "Package": "Rsamtools",
+      "Version": "2.6.0",
+      "Source": "Bioconductor",
+      "Hash": "7d5b0ec921f85730aafe82f0f94f76c0"
     },
     "Rtsne": {
       "Package": "Rtsne",
@@ -486,6 +528,12 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "dc538ec663e38888807ef3034489403d"
+    },
+    "biomaRt": {
+      "Package": "biomaRt",
+      "Version": "2.46.3",
+      "Source": "Bioconductor",
+      "Hash": "1dba821d9a19d3b70fa324cab2fb4d0b"
     },
     "bit": {
       "Package": "bit",
@@ -762,6 +810,12 @@
       "Version": "1.10.2",
       "Source": "Bioconductor",
       "Hash": "bfe9798d5d9be7c8bfb269c5f19dd957"
+    },
+    "ensembldb": {
+      "Package": "ensembldb",
+      "Version": "2.14.0",
+      "Source": "Bioconductor",
+      "Hash": "b433b752aafc4ae0b5523585cae1269c"
     },
     "estimability": {
       "Package": "estimability",
@@ -1565,6 +1619,12 @@
       "Repository": "RSPM",
       "Hash": "3a6b30449282b6a4b19ce267142c3299"
     },
+    "rtracklayer": {
+      "Package": "rtracklayer",
+      "Version": "1.50.0",
+      "Source": "Bioconductor",
+      "Hash": "3905c00eda8f95ab761abc0978ffa19d"
+    },
     "rvcheck": {
       "Package": "rvcheck",
       "Version": "0.1.8",
@@ -1777,6 +1837,12 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "fc77eb5297507cccfa3349a606061030"
+    },
+    "tximeta": {
+      "Package": "tximeta",
+      "Version": "1.8.3",
+      "Source": "Bioconductor",
+      "Hash": "1a8c1f3099fdc500c93ae1af4c3e7d0f"
     },
     "tximport": {
       "Package": "tximport",


### PR DESCRIPTION
### Background

Second attempt to add tximeta to the renv.lock file. #361 was the first attempt, cherry picking was not ideal. 

In this attempt, I created a branch of off master, then just git checked-out the renv.lock file from `cansavvy/tximeta`

`git checkout cansavvy/tximeta renv.lock`