### PR TITLE
Wrap make-live.R

### DIFF
--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -38,7 +38,9 @@ jobs:
       # Run the make-live.R script
       - name: Run make-live.R
         id: make_live
-        run: Rscript --vanilla scripts/make-live.R --rendering ${{ github.event.inputs.rendering }}
+        env:
+          RENDER_RMD: ${{ github.event.inputs.rendering }}
+        run: bash scripts/render-live.sh
 
       # Make changes to pull request here
       - name: Create PR with rendered notebooks

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -1,4 +1,4 @@
-name: Make Live
+name: Make Live Notebooks
 # Make live versions of .Rmd files in training modules and optionally rerender notebooks
 
 # This workflow only runs when it is manually dispatched
@@ -35,9 +35,7 @@ jobs:
         run: |
           aws s3 sync s3://ccdl-training-data/training-modules/ .
 
-      # Run the make-live.R script
-      - name: Run make-live.R
-        id: make_live
+      - name: Render notebooks
         env:
           RENDER_RMD: ${{ github.event.inputs.rendering }}
         run: bash scripts/render-live.sh
@@ -46,11 +44,11 @@ jobs:
       - name: Create PR with rendered notebooks
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: Run make-live.R
+          commit-message: Live and rendered notebooks
           signoff: false
-          branch: run_make-live.R
+          branch: auto_render_live
           delete-branch: true
-          title: 'GHA: Automated make live versions of the notebooks'
+          title: 'GHA: Automated live (rendered) versions of the notebooks'
           body: |
             ### Description:
             This PR auto-generated from github actions running make-live.R with:

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -1,13 +1,13 @@
 name: Test render notebooks
 # Before merging notebooks, check that they render
 
-# This workflow only runs when it is manually dispatched
 on:
   pull_request:
     branches: [ master ]
     paths: 
       - '**.Rmd'
       - 'scripts/make-live.R'
+      - 'scripts/render-live.sh'
 
 jobs:
   test-render:
@@ -34,4 +34,4 @@ jobs:
       # Run the make-live.R script
       - name: Run make-live.R
         id: make_live
-        run: Rscript --vanilla scripts/make-live.R --rendering TRUE
+        run: bash scripts/render-live.sh

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -31,7 +31,5 @@ jobs:
         run: |
           aws s3 sync s3://ccdl-training-data/training-modules/ .
 
-      # Run the make-live.R script
-      - name: Run make-live.R
-        id: make_live
+      - name: Render notebooks
         run: bash scripts/render-live.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ The spelling errors will be listed in `spell_check_errors.tsv` in the root of th
 
 ### Rendering Test
 
-Every pull request to `master` that changes `.Rmd` files (or `scripts/make-live.R`) will be tested via a GitHub Actions workflow (`render-rmds.yml`) to ensure that the `.Rmd` files can be run successfully. 
+Every pull request to `master` that changes `.Rmd` files (or one of the rendering scripts) will be tested via a GitHub Actions workflow (`render-rmds.yml`) to ensure that the `.Rmd` files can be run successfully. 
 This action first downloads input files for the notebooks from S3, so if there are changes to the input files, these should be made first, with associated changes as needed to `syncup-s3.sh` (see [Files stored on S3](#files-stored-on-s3)).
 
 

--- a/scripts/make-live.R
+++ b/scripts/make-live.R
@@ -14,73 +14,39 @@ library(optparse)
 # Set up optparse options
 option_list <- list(
   make_option(
-    opt_str = "--rendering", type = "character", metavar = "character",
-    default = "TRUE", help = "Needs a 'TRUE/FALSE' to determine whether the markdown::render() steps will be run for all notebooks."
+    opt_str = "--notebook", type = "character",
+    help = "The notebook file to process."),
+  make_option(
+    opt_str = "--render", type = "character",
+    default = "TRUE", help = "Needs a 'TRUE/FALSE' to determine whether the markdown::render() step will be run."
   )
 )
 
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
+if (! tolower(opt$render) %in% c("true", "false", "t", "f")){
+  stop("--render option must be TRUE or FALSE")
+}
+
 # Turn character into logical
-opt$rendering <- as.logical(opt$rendering)
+render <- as.logical(opt$render)
 
 # Install exrcise package if needed.
 if (!"exrcise" %in% installed.packages()){
   remotes::install_github("AlexsLemonade/exrcise", dependencies = TRUE, upgrade = "never")
 }
 
-# Function to render and clean up after rendering
-render_clean <- function(file, base_dir = ""){
-  # get loaded packages
-  package_set <- search()
-  message("Rendering ", stringr::str_replace(file, paste0("^", base_dir, "/"), "")) # hide root
-  rmarkdown::render(file, envir = new.env(), quiet = TRUE)
-  # remove packages that could cause conflicts
-  for (package in search()){
-    if (! package %in% package_set){
-      unloadNamespace(package) 
-    }
-  }
-}
 
-# find the project root
-root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
-
-# list of files to transform
-infiles <- c(file.path(root_dir, "intro-to-R-tidyverse",
-                       c("01-intro_to_base_R.Rmd",
-                         "02-intro_to_ggplot2.Rmd",
-                         "03-intro_to_tidyverse.Rmd")),
-             file.path(root_dir, "RNA-seq",
-                       c("02-gastric_cancer_tximeta.Rmd",
-                         "03-gastric_cancer_exploratory.Rmd",
-                         "05-nb_cell_line_DESeq2.Rmd")),
-             file.path(root_dir, "scRNA-seq",
-                       c("01-filtering_scRNA-seq.Rmd",
-                         "02-normalizing_scRNA-seq.Rmd",
-                         "04-tag-based_scRNA-seq_processing.Rmd",
-                         "05-dimension_reduction_scRNA-seq.Rmd")),
-             file.path(root_dir,  "machine-learning",
-                       c("01-openpbta_heatmap.Rmd",
-                         "02-openpbta_consensus_clustering.Rmd")),
-                        #  "03-openpbta_PLIER.Rmd",
-                        #  "04-openpbta_plot_LV.Rmd")),
-             file.path(root_dir, "pathway-analysis",
-                       c("01-overrepresentation_analysis.Rmd",
-                         "02-gene_set_enrichment_analysis.Rmd",
-                         "03-gene_set_variation_analysis.Rmd"))
-             )
-
+message("Processing ", opt$notebook)
 # Rerender notebooks if --rendering is TRUE
-if (opt$rendering) {
-  # capture to avoid printing to stdout
-  rendered <- purrr::map(infiles, render_clean, base_dir = root_dir)
+if (render) {
+  rmarkdown::render(opt$notebook, env = new.env(), quiet = TRUE)
 }
 
 # new files will be made with -live.Rmd suffix
-outfiles <- stringr::str_replace(infiles, "(.*)\\.Rmd$", "\\1-live.Rmd")
+outfile <- stringr::str_replace(opt$notebook, "(.*)\\.Rmd$", "\\1-live.Rmd")
 
 # Generate live versions
 # capture to avoid printing to stdout
-out <- purrr::map2(infiles, outfiles, exrcise::exrcise, replace_flags = "live")
+exrcise::exrcise(opt$notebook, outfile, replace_flags = "live")

--- a/scripts/make-live.R
+++ b/scripts/make-live.R
@@ -5,7 +5,7 @@
 # Replaces code in chunks with a chunk option of `live = TRUE`
 # Comments are preserved
 #
-# If --rendering option is FALSE, the rendering is skipped.
+# If --render option is FALSE, the rendering is skipped.
 # Default is TRUE -- rendering is not skipped.
 
 # Load library:
@@ -25,12 +25,18 @@ option_list <- list(
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
+# Check that render is TRUE or FALSE (or an obvious variant)
 if (! tolower(opt$render) %in% c("true", "false", "t", "f")){
-  stop("--render option must be TRUE or FALSE")
+  stop("`--render` option must be TRUE or FALSE")
 }
 
 # Turn character into logical
 render <- as.logical(opt$render)
+
+# Check that the file is an Rmarkdown file:
+if (! stringr::str_detect(opt$notebook, "\\.Rmd$")){
+  stop(opt$notebook, " is not a `.Rmd` notebook")
+}
 
 # Install exrcise package if needed.
 if (!"exrcise" %in% installed.packages()){
@@ -39,7 +45,7 @@ if (!"exrcise" %in% installed.packages()){
 
 
 message("Processing ", opt$notebook)
-# Rerender notebooks if --rendering is TRUE
+# Rerender notebooks if --render is TRUE
 if (render) {
   rmarkdown::render(opt$notebook, env = new.env(), quiet = TRUE)
 }

--- a/scripts/render-live.sh
+++ b/scripts/render-live.sh
@@ -7,29 +7,28 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # move back up to the training modules root
 cd ..
 
-# WE will render if the $RENDER_RMD environment variable is TRUE
+# We will render if the $RENDER_RMD environment variable is TRUE (or set it)
 render="${RENDER_RMD:-TRUE}"
-echo $render
 
 # array of files to transform
 files=(
   intro-to-R-tidyverse/01-intro_to_base_R.Rmd
-  # intro-to-R-tidyverse/02-intro_to_ggplot2.Rmd
-  # intro-to-R-tidyverse/03-intro_to_tidyverse.Rmd
-  # RNA-seq/02-gastric_cancer_tximeta.Rmd
-  # RNA-seq/03-gastric_cancer_exploratory.Rmd
-  # RNA-seq/05-nb_cell_line_DESeq2.Rmd
-  # scRNA-seq/01-filtering_scRNA-seq.Rmd
-  # scRNA-seq/02-normalizing_scRNA-seq.Rmd
-  # scRNA-seq/04-tag-based_scRNA-seq_processing.Rmd
-  # scRNA-seq/05-dimension_reduction_scRNA-seq.Rmd
-  # machine-learning/01-openpbta_heatmap.Rmd
-  # machine-learning/02-openpbta_consensus_clustering.Rmd
-  # #  machine-learning/03-openpbta_PLIER.Rmd
-  # #  machine-learning/04-openpbta_plot_LV.Rmd
-  # pathway-analysis/01-overrepresentation_analysis.Rmd
-  # pathway-analysis/02-gene_set_enrichment_analysis.Rmd
-  # pathway-analysis/03-gene_set_variation_analysis.Rmd
+  intro-to-R-tidyverse/02-intro_to_ggplot2.Rmd
+  intro-to-R-tidyverse/03-intro_to_tidyverse.Rmd
+  RNA-seq/02-gastric_cancer_tximeta.Rmd
+  RNA-seq/03-gastric_cancer_exploratory.Rmd
+  RNA-seq/05-nb_cell_line_DESeq2.Rmd
+  scRNA-seq/01-filtering_scRNA-seq.Rmd
+  scRNA-seq/02-normalizing_scRNA-seq.Rmd
+  scRNA-seq/04-tag-based_scRNA-seq_processing.Rmd
+  scRNA-seq/05-dimension_reduction_scRNA-seq.Rmd
+  machine-learning/01-openpbta_heatmap.Rmd
+  machine-learning/02-openpbta_consensus_clustering.Rmd
+  #  machine-learning/03-openpbta_PLIER.Rmd
+  #  machine-learning/04-openpbta_plot_LV.Rmd
+  pathway-analysis/01-overrepresentation_analysis.Rmd
+  pathway-analysis/02-gene_set_enrichment_analysis.Rmd
+  pathway-analysis/03-gene_set_variation_analysis.Rmd
 )
 for file in ${files[@]}
 do

--- a/scripts/render-live.sh
+++ b/scripts/render-live.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+set -euo pipefail
+
+
+# Set the working directory to the directory of this file
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# move back up to the training modules root
+cd ..
+
+# Render if the $RENDER_RMD environment variable is set
+
+render="${RENDER_RMD:-TRUE}"
+
+# array of files to transform
+files=(
+  intro-to-R-tidyverse/01-intro_to_base_R.Rmd
+  intro-to-R-tidyverse/02-intro_to_ggplot2.Rmd
+  intro-to-R-tidyverse/03-intro_to_tidyverse.Rmd
+  RNA-seq/02-gastric_cancer_tximeta.Rmd
+  RNA-seq/03-gastric_cancer_exploratory.Rmd
+  RNA-seq/05-nb_cell_line_DESeq2.Rmd
+  scRNA-seq/01-filtering_scRNA-seq.Rmd
+  scRNA-seq/02-normalizing_scRNA-seq.Rmd
+  scRNA-seq/04-tag-based_scRNA-seq_processing.Rmd
+  scRNA-seq/05-dimension_reduction_scRNA-seq.Rmd
+  machine-learning/01-openpbta_heatmap.Rmd
+  machine-learning/02-openpbta_consensus_clustering.Rmd
+  #  machine-learning/03-openpbta_PLIER.Rmd
+  #  machine-learning/04-openpbta_plot_LV.Rmd
+  pathway-analysis/01-overrepresentation_analysis.Rmd
+  pathway-analysis/02-gene_set_enrichment_analysis.Rmd
+  pathway-analysis/03-gene_set_variation_analysis.Rmd
+)
+for file in ${files[@]}
+do
+  Rscript --vanilla scripts/make-live.R --notebook ${file} --render ${render}
+done

--- a/scripts/render-live.sh
+++ b/scripts/render-live.sh
@@ -28,8 +28,8 @@ files=(
   scRNA-seq/05-dimension_reduction_scRNA-seq.Rmd
   machine-learning/01-openpbta_heatmap.Rmd
   machine-learning/02-openpbta_consensus_clustering.Rmd
-  #  machine-learning/03-openpbta_PLIER.Rmd
-  #  machine-learning/04-openpbta_plot_LV.Rmd
+  machine-learning/03-openpbta_PLIER.Rmd
+  machine-learning/04-openpbta_plot_LV.Rmd
   pathway-analysis/01-overrepresentation_analysis.Rmd
   pathway-analysis/02-gene_set_enrichment_analysis.Rmd
   pathway-analysis/03-gene_set_variation_analysis.Rmd

--- a/scripts/render-live.sh
+++ b/scripts/render-live.sh
@@ -7,29 +7,29 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # move back up to the training modules root
 cd ..
 
-# Render if the $RENDER_RMD environment variable is set
-
+# WE will render if the $RENDER_RMD environment variable is TRUE
 render="${RENDER_RMD:-TRUE}"
+echo $render
 
 # array of files to transform
 files=(
   intro-to-R-tidyverse/01-intro_to_base_R.Rmd
-  intro-to-R-tidyverse/02-intro_to_ggplot2.Rmd
-  intro-to-R-tidyverse/03-intro_to_tidyverse.Rmd
-  RNA-seq/02-gastric_cancer_tximeta.Rmd
-  RNA-seq/03-gastric_cancer_exploratory.Rmd
-  RNA-seq/05-nb_cell_line_DESeq2.Rmd
-  scRNA-seq/01-filtering_scRNA-seq.Rmd
-  scRNA-seq/02-normalizing_scRNA-seq.Rmd
-  scRNA-seq/04-tag-based_scRNA-seq_processing.Rmd
-  scRNA-seq/05-dimension_reduction_scRNA-seq.Rmd
-  machine-learning/01-openpbta_heatmap.Rmd
-  machine-learning/02-openpbta_consensus_clustering.Rmd
-  #  machine-learning/03-openpbta_PLIER.Rmd
-  #  machine-learning/04-openpbta_plot_LV.Rmd
-  pathway-analysis/01-overrepresentation_analysis.Rmd
-  pathway-analysis/02-gene_set_enrichment_analysis.Rmd
-  pathway-analysis/03-gene_set_variation_analysis.Rmd
+  # intro-to-R-tidyverse/02-intro_to_ggplot2.Rmd
+  # intro-to-R-tidyverse/03-intro_to_tidyverse.Rmd
+  # RNA-seq/02-gastric_cancer_tximeta.Rmd
+  # RNA-seq/03-gastric_cancer_exploratory.Rmd
+  # RNA-seq/05-nb_cell_line_DESeq2.Rmd
+  # scRNA-seq/01-filtering_scRNA-seq.Rmd
+  # scRNA-seq/02-normalizing_scRNA-seq.Rmd
+  # scRNA-seq/04-tag-based_scRNA-seq_processing.Rmd
+  # scRNA-seq/05-dimension_reduction_scRNA-seq.Rmd
+  # machine-learning/01-openpbta_heatmap.Rmd
+  # machine-learning/02-openpbta_consensus_clustering.Rmd
+  # #  machine-learning/03-openpbta_PLIER.Rmd
+  # #  machine-learning/04-openpbta_plot_LV.Rmd
+  # pathway-analysis/01-overrepresentation_analysis.Rmd
+  # pathway-analysis/02-gene_set_enrichment_analysis.Rmd
+  # pathway-analysis/03-gene_set_variation_analysis.Rmd
 )
 for file in ${files[@]}
 do

--- a/scripts/render-live.sh
+++ b/scripts/render-live.sh
@@ -1,6 +1,10 @@
 #! /bin/bash
 set -euo pipefail
 
+# render-live.sh renders and/or converts to "live" a set of .Rmd notebooks by 
+# calling `make-live.R` for each notebook in turn.
+# Rendering is done by default, but can be skipped  by setting the RENDER_RMD to FALSE:
+# For example: RENDER_RMD=FALSE bash render-live.sh
 
 # Set the working directory to the directory of this file
 cd "$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
This PR aims to simplify make-live.R to work on only one notebook at a time, moving the list of files and loop to `render-live.sh`. The goal here is to allow each notebook to run in its own very clean notebook environment. 

~~*Draft status means that documentation updates and application to all workflows are still incoming, but I want to test the mechanics!*~~

This seems to work now, so let's go!

closes #377

Have a look, let me know if there is more documentation to add.

~~I am going to save checking the PLIER notebooks for whoever wants to try their hand at #356; it may be as simple as uncommenting those notebooks!~~
Tested uncommenting, and it seems to run! (Not speedy, but it runs!)
Two 🐦 one 🍞 ! 
Closes #356 (it seems)
