### PR TITLE
Add docs bot token to make-live

### DIFF
--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Create PR with rendered notebooks
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
           commit-message: Live and rendered notebooks
           signoff: false
           branch: auto_render_live


### PR DESCRIPTION
This PR is an attempt to solve #381 by adding the docs bot token that we had already created to the pull request step of the make-live action. This should make a PR from this workflow trigger the spellcheck action.

I have not tested this, because it seemed like making the changes for automated running would be more trouble than it was worth. I though maybe we could just merge this, test it, and revert the changes if it doesn't work. 