### PR TITLE
Restrict rendering  test to notebook changes

### DIFF
--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -7,7 +7,7 @@ on:
     paths: 
       - '**.Rmd'
       - '!**-live.Rmd' # don't trigger for live-only changes
-      - '**exercise*.Rmd' # or exercise notebooks
+      - '!**exercise*.Rmd' # or exercise notebooks
       - 'scripts/make-live.R'
       - 'scripts/render-live.sh'
 

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -6,7 +6,8 @@ on:
     branches: [ master ]
     paths: 
       - '**.Rmd'
-      - '!**-live.Rmd' # skip live-only changes
+      - '!**-live.Rmd' # don't trigger for live-only changes
+      - '**exercise*.Rmd' # or exercise notebooks
       - 'scripts/make-live.R'
       - 'scripts/render-live.sh'
 

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master ]
     paths: 
       - '**.Rmd'
+      - '!**-live.Rmd' # skip live-only changes
       - 'scripts/make-live.R'
       - 'scripts/render-live.sh'
 

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -7,7 +7,7 @@ on:
     paths: 
       - '**.Rmd'
       - '!**-live.Rmd' # don't trigger for live-only changes
-      - '!**exercise*.Rmd' # or exercise notebooks
+      - '!**/exercise*.Rmd' # or exercise notebooks
       - 'scripts/make-live.R'
       - 'scripts/render-live.sh'
 


### PR DESCRIPTION
This PR is designed mostly to prevent PRs from auto-rendered scripts from triggering another rendering test. Those scripts will change the `-live` notebooks, but not the source notebooks. So if we exclude live notebooks, we should be able to merge auto-render PRs faster. 

For future use, I also exclude the exercise notebooks.