### PR TITLE
Lower number of spelling errors "allowed"

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -36,5 +36,5 @@ jobs:
 
       # If there are too many spelling errors, this will stop the workflow
       - name: Check spell check results - fail if too many errors
-        if: ${{ steps.spell_check_run.outputs.sp_chk_results > 1 }}
+        if: ${{ steps.spell_check_run.outputs.sp_chk_results > 0 }}
         run: exit 1

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -36,5 +36,5 @@ jobs:
 
       # If there are too many spelling errors, this will stop the workflow
       - name: Check spell check results - fail if too many errors
-        if: ${{ steps.spell_check_run.outputs.sp_chk_results > 3 }}
+        if: ${{ steps.spell_check_run.outputs.sp_chk_results > 1 }}
         run: exit 1

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -75,6 +75,7 @@ ENA
 Enricher
 Ensdb
 Ensembl
+Ensembl's
 ENSG
 Entrez
 et
@@ -145,6 +146,7 @@ Korotkevich
 Lafzi
 LFC
 Liberzon
+linkedTxome
 loadings
 lockfile
 log'd


### PR DESCRIPTION
We used to "allow" three spelling errors, partly because there was some kind of whitespace issue that caused extra "errors." This is no longer the case though, so I don't see a reason to have the number be as high as 3. 

If we take a look at the GHA results from #200: https://github.com/AlexsLemonade/training-modules/runs/1988578820?check_suite_focus=true

We have 3 spelling errors:
 
```
word	file	lines
AssayNames	RNA-seq-cheatsheet.md	77
Ensembl's	00c-tximeta_other_species.Rmd	66,74
linkedTxome	00c-tximeta_other_species.Rmd	42
```

With a lower spelling error tolerance, two of these would have probably been resolved during #372. Super minor thing, but my thought is it is better to add things to the custom dictionary as we need them (and/or the material is fresh in the PR author's head) rather than wait until the unlucky PR author that adds the 4th error has to fix them all. 