### PR TITLE
Add renv.lock updates

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -165,12 +165,6 @@
       "Source": "Bioconductor",
       "Hash": "1a9c016231c53483de05bec235ff8bfd"
     },
-    "EnhancedVolcano": {
-      "Package": "EnhancedVolcano",
-      "Version": "1.8.0",
-      "Source": "Bioconductor",
-      "Hash": "d1eff56a3f663c3e5445382457715824"
-    },
     "FNN": {
       "Package": "FNN",
       "Version": "1.1.3",
@@ -418,13 +412,6 @@
       "Repository": "RSPM",
       "Hash": "f153432c4ca15b937ccfaa40f167c892"
     },
-    "Rttf2pt1": {
-      "Package": "Rttf2pt1",
-      "Version": "1.3.8",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "8c4137a9ab70de4787d57758f8190617"
-    },
     "S4Vectors": {
       "Package": "S4Vectors",
       "Version": "0.28.1",
@@ -493,13 +480,6 @@
       "Version": "1.12.0",
       "Source": "Bioconductor",
       "Hash": "3f89d2a4ad516fb1e77c06197c486fec"
-    },
-    "ash": {
-      "Package": "ash",
-      "Version": "1.0-15",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e16751c399be6260ddf41f8148a3f8ef"
     },
     "ashr": {
       "Package": "ashr",
@@ -884,20 +864,6 @@
       "RemoteSha": "a496662f8a8a2294366cae4d2f3547c50ac341f1",
       "Hash": "a5a91e3a3f03206b58ae5dbc6ee66f64"
     },
-    "extrafont": {
-      "Package": "extrafont",
-      "Version": "0.17",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7f2f50e8f998a4bea4b04650fc4f2ca8"
-    },
-    "extrafontdb": {
-      "Package": "extrafontdb",
-      "Version": "1.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "a861555ddec7451c653b40e713166c6f"
-    },
     "fansi": {
       "Package": "fansi",
       "Version": "0.4.2",
@@ -1020,13 +986,6 @@
       "Repository": "RSPM",
       "Hash": "ad68e3263f0bc9269aab8c2039440117"
     },
-    "ggalt": {
-      "Package": "ggalt",
-      "Version": "0.4.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bae53c310be0adce98458355c38ef1bf"
-    },
     "ggbeeswarm": {
       "Package": "ggbeeswarm",
       "Version": "0.6.0",
@@ -1054,13 +1013,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "2a189e5cd2bbfe687ed631be27c07462"
-    },
-    "ggrastr": {
-      "Package": "ggrastr",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b5241fff9ae746fefc3789af61f34384"
     },
     "ggrepel": {
       "Package": "ggrepel",
@@ -1332,13 +1284,6 @@
       "Repository": "RSPM",
       "Hash": "41287f1ac7d28a92f0a286ed507928d3"
     },
-    "maps": {
-      "Package": "maps",
-      "Version": "3.3.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "392212982257ea03c37b63547dc871b4"
-    },
     "markdown": {
       "Package": "markdown",
       "Version": "1.1",
@@ -1547,13 +1492,6 @@
       "Repository": "RSPM",
       "Hash": "14dc9f7a3c91ebb14ec5bb9208a07061"
     },
-    "proj4": {
-      "Package": "proj4",
-      "Version": "1.0-10",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "df4880a9408d75a23b8a8f7a2b18c429"
-    },
     "promises": {
       "Package": "promises",
       "Version": "1.1.1",
@@ -1586,13 +1524,6 @@
       "Version": "2.22.0",
       "Source": "Bioconductor",
       "Hash": "7ad7e5648b5f859c3d7b348003f092d1"
-    },
-    "ragg": {
-      "Package": "ragg",
-      "Version": "0.4.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "70bd921f54c3763f3dbec15106118828"
     },
     "rappdirs": {
       "Package": "rappdirs",
@@ -1886,26 +1817,12 @@
       "Repository": "RSPM",
       "Hash": "b227d13e29222b4574486cfcbde077fa"
     },
-    "systemfonts": {
-      "Package": "systemfonts",
-      "Version": "0.3.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "046e821d454edb3722192f588f4d7884"
-    },
     "testthat": {
       "Package": "testthat",
       "Version": "3.0.1",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "17826764cb92d8b5aae6619896e5a161"
-    },
-    "textshaping": {
-      "Package": "textshaping",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "a34d4aa94ca91a52710b1c0c36bcded6"
     },
     "tibble": {
       "Package": "tibble",


### PR DESCRIPTION
### Summary

Related to the penguins PR (#403) and issue and maybe also #405. 

Here I checked out the renv.lock file from master, ran `renv::restore()`, `install.packages("palmerpenguins")`, `renv::snapshot()` then committed the renv.lock file. 