### PR TITLE
Add penguins to renv.lock

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1443,6 +1443,13 @@
       "Source": "Bioconductor",
       "Hash": "3d2aea7762e91aa3d5b7c267c56d9055"
     },
+    "palmerpenguins": {
+      "Package": "palmerpenguins",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "9a455031890b2adf20e19784a114ddd4"
+    },
     "pheatmap": {
       "Package": "pheatmap",
       "Version": "1.0.12",


### PR DESCRIPTION
### Summary

Here's what I did per @jashapiro's recommendation to 'trick' renv into thinking we are using these packages that we aren't using on this branch but are using on #403 and #405

1. Checked out this new branch from master
2. `renv::restore()`
3. Installed `palmerpenguins` package
4. Added `palmerpenguins` and `EnhancedVolcano` to dependencies.R
5. Ran `renv::snapshot()` 
6. Then I commit only renv.lock