### PR TITLE
Add AnnotationDBI packages for non-human organisms to lockfile

### DIFF
--- a/components/dependencies.R
+++ b/components/dependencies.R
@@ -16,3 +16,9 @@ library(Rtsne)
 
 # required for enrichplot::upsetplot
 library(ggupset)
+
+# Organisms we want to support but don't explicitly work with during instruction
+# or exercises
+library(org.Dr.eg.db)
+library(org.Cf.eg.db)
+

--- a/renv.lock
+++ b/renv.lock
@@ -249,7 +249,7 @@
       "Package": "GlobalOptions",
       "Version": "0.1.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "c3f7b221e60c28f5f3533d74c6fef024"
     },
     "HDF5Array": {
@@ -320,14 +320,14 @@
       "Package": "RColorBrewer",
       "Version": "1.1-2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "e031418365a7f7a766181ab5a41a5716"
     },
     "RCurl": {
       "Package": "RCurl",
       "Version": "1.98-1.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "cf29e1b71f8736960e0e851123a83e6f"
     },
     "RSQLite": {
@@ -341,7 +341,7 @@
       "Package": "RSpectra",
       "Version": "0.16-0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "a41329d24d5a98eaed2bd0159adb1b5f"
     },
     "Rcpp": {
@@ -512,14 +512,14 @@
       "Package": "askpass",
       "Version": "1.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
     "assertthat": {
       "Package": "assertthat",
       "Version": "0.2.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "50c838a310445e954bc13f26f26a6ecf"
     },
     "backports": {
@@ -533,7 +533,7 @@
       "Package": "base64enc",
       "Version": "0.1-3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
     "bbmle": {
@@ -560,7 +560,7 @@
       "Package": "beeswarm",
       "Version": "0.2.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "dc538ec663e38888807ef3034489403d"
     },
     "biomaRt": {
@@ -587,7 +587,7 @@
       "Package": "bitops",
       "Version": "1.0-6",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "0b118d5900596bae6c4d4865374536a6"
     },
     "blob": {
@@ -649,7 +649,7 @@
       "Package": "cellranger",
       "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "f61dbaec772ccd2e17705c1e872e9e7c"
     },
     "circlize": {
@@ -739,7 +739,7 @@
       "Package": "crayon",
       "Version": "1.3.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "0d57bc8e27b7ba9e45dba825ebc0de6b"
     },
     "crosstalk": {
@@ -753,7 +753,7 @@
       "Package": "curl",
       "Version": "4.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "2b7d10581cc730804e9ed178c8374bd6"
     },
     "data.table": {
@@ -774,7 +774,7 @@
       "Package": "desc",
       "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "6c8fe8fa26a23b79949375d372c7b395"
     },
     "diffobj": {
@@ -809,7 +809,7 @@
       "Package": "dqrng",
       "Version": "0.2.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "cc0d03e8383d407e9568855f8efbc07d"
     },
     "edgeR": {
@@ -855,7 +855,7 @@
       "Package": "estimability",
       "Version": "1.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "05901bd61be60fd3bfc5b7d7c3517d1d"
     },
     "etrunct": {
@@ -869,7 +869,7 @@
       "Package": "evaluate",
       "Version": "0.14",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
     },
     "exrcise": {
@@ -923,14 +923,14 @@
       "Package": "fastmatch",
       "Version": "1.1-0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "2cfe25650d69960c54e06840e4b5d8e4"
     },
     "fastqcr": {
       "Package": "fastqcr",
       "Version": "0.1.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "2abd00eb709c07fc87aa6b4132e17040"
     },
     "fftw": {
@@ -970,7 +970,7 @@
       "Package": "formatR",
       "Version": "1.7",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "ad36e26eeeb7393886d8a0e19bc6ee42"
     },
     "fs": {
@@ -984,14 +984,14 @@
       "Package": "futile.logger",
       "Version": "1.4.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "99f0ace8c05ec7d3683d27083c4f1e7e"
     },
     "futile.options": {
       "Package": "futile.options",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "0d9bf02413ddc2bbe8da9ce369dcdd2b"
     },
     "genefilter": {
@@ -1017,7 +1017,7 @@
       "Package": "getopt",
       "Version": "1.20.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "ad68e3263f0bc9269aab8c2039440117"
     },
     "ggalt": {
@@ -1031,7 +1031,7 @@
       "Package": "ggbeeswarm",
       "Version": "0.6.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "dd68b9b215b2d3119603549a794003c3"
     },
     "ggforce": {
@@ -1073,7 +1073,7 @@
       "Package": "ggsignif",
       "Version": "0.6.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "3e9b8a51dfdc95395632b25ce3ce8ebc"
     },
     "ggupset": {
@@ -1121,14 +1121,14 @@
       "Package": "gridExtra",
       "Version": "2.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "7d7f283939f563670a697165b2cf5560"
     },
     "gtable": {
       "Package": "gtable",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "ac5c6baf7822ce8732b343f14c072c4d"
     },
     "gtools": {
@@ -1149,7 +1149,7 @@
       "Package": "highr",
       "Version": "0.8",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "4dc5bb88961e347a0f4d8aad597cbfac"
     },
     "hms": {
@@ -1218,7 +1218,7 @@
       "Package": "irlba",
       "Version": "2.3.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "a9ad517358000d57022401ef18ee657a"
     },
     "isoband": {
@@ -1267,7 +1267,7 @@
       "Package": "lambda.r",
       "Version": "1.2.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "b1e925c4b9ffeb901bacf812cbe9a6ad"
     },
     "later": {
@@ -1288,7 +1288,7 @@
       "Package": "lazyeval",
       "Version": "0.2.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
     },
     "lifecycle": {
@@ -1308,7 +1308,7 @@
       "Package": "locfit",
       "Version": "1.5-9.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "760b5b542e8435237d1b3c253bfe18e7"
     },
     "lubridate": {
@@ -1343,7 +1343,7 @@
       "Package": "markdown",
       "Version": "1.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
     },
     "matrixStats": {
@@ -1357,7 +1357,7 @@
       "Package": "memoise",
       "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "58baa74e4603fcfb9a94401c58c8f9b1"
     },
     "mgcv": {
@@ -1399,14 +1399,14 @@
       "Package": "munsell",
       "Version": "0.5.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "6dfe8bf774944bd5595785e3229d8771"
     },
     "mvtnorm": {
       "Package": "mvtnorm",
       "Version": "1.1-1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "69fa7331e7410c2a2cb3f9868513904f"
     },
     "nlme": {
@@ -1420,7 +1420,7 @@
       "Package": "numDeriv",
       "Version": "2016.8-1.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
     "openssl": {
@@ -1437,29 +1437,11 @@
       "Repository": "RSPM",
       "Hash": "35beff0d8469fbb7037925dde658888c"
     },
-    "org.Cf.eg.db": {
-      "Package": "org.Cf.eg.db",
-      "Version": "3.12.0",
-      "Source": "Bioconductor",
-      "Hash": "6b12823b05e8be09e9275cf23a5dda50"
-    },
-    "org.Dr.eg.db": {
-      "Package": "org.Dr.eg.db",
-      "Version": "3.12.0",
-      "Source": "Bioconductor",
-      "Hash": "ab7c2fb8fa90a7f9ca785a0d7afae5d6"
-    },
     "org.Hs.eg.db": {
       "Package": "org.Hs.eg.db",
       "Version": "3.12.0",
       "Source": "Bioconductor",
       "Hash": "3d2aea7762e91aa3d5b7c267c56d9055"
-    },
-    "org.Mm.eg.db": {
-      "Package": "org.Mm.eg.db",
-      "Version": "3.12.0",
-      "Source": "Bioconductor",
-      "Hash": "4e4ee144dea09b789a4269a68306c0b5"
     },
     "palmerpenguins": {
       "Package": "palmerpenguins",
@@ -1472,7 +1454,7 @@
       "Package": "pheatmap",
       "Version": "1.0.12",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "db1fb0021811b6693741325bbe916e58"
     },
     "pillar": {
@@ -1493,7 +1475,7 @@
       "Package": "pkgconfig",
       "Version": "2.0.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
     "pkgload": {
@@ -1507,7 +1489,7 @@
       "Package": "plogr",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "09eb987710984fc2905c7129c7d85e65"
     },
     "plotly": {
@@ -1528,21 +1510,21 @@
       "Package": "png",
       "Version": "0.1-7",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "03b7076c234cb3331288919983326c55"
     },
     "polyclip": {
       "Package": "polyclip",
       "Version": "1.10-0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "cb167f328b3ada4ec5cf67a7df4c900a"
     },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "a555924add98c99d2f411e37e7d25e9f"
     },
     "preprocessCore": {
@@ -1569,7 +1551,7 @@
       "Package": "progress",
       "Version": "1.2.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "14dc9f7a3c91ebb14ec5bb9208a07061"
     },
     "proj4": {
@@ -1623,7 +1605,7 @@
       "Package": "rappdirs",
       "Version": "0.3.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "8c8298583adbbe76f3c2220eef71bebc"
     },
     "readr": {
@@ -1637,14 +1619,14 @@
       "Package": "readxl",
       "Version": "1.3.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "63537c483c2dbec8d9e3183b3735254a"
     },
     "rematch": {
       "Package": "rematch",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "c66b930d20bb6d858cd18e1cebcfae5c"
     },
     "rematch2": {
@@ -1677,7 +1659,7 @@
       "Package": "reprex",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "b06bfb3504cc8a4579fd5567646f745b"
     },
     "reshape2": {
@@ -1710,7 +1692,7 @@
       "Package": "rjson",
       "Version": "0.2.20",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "7d597f982ee6263716b6a2f28efd29fa"
     },
     "rlang": {
@@ -1745,7 +1727,7 @@
       "Package": "rsvd",
       "Version": "1.0.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "3a6b30449282b6a4b19ce267142c3299"
     },
     "rtracklayer": {
@@ -1758,7 +1740,7 @@
       "Package": "rvcheck",
       "Version": "0.1.8",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "11ebf2d3d4990e8bb9f28d5ab0c204fc"
     },
     "rvest": {
@@ -1811,7 +1793,7 @@
       "Package": "selectr",
       "Version": "0.4-2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
     },
     "shadowtext": {
@@ -1839,21 +1821,21 @@
       "Package": "sitmo",
       "Version": "2.0.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "0f9ba299f2385e686745b066c6d7a7c4"
     },
     "snow": {
       "Package": "snow",
       "Version": "0.4-3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "11b822ad6214111a4188d5e5fd1b144c"
     },
     "sourcetools": {
       "Package": "sourcetools",
       "Version": "0.1.7",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "947e4e02a79effa5d512473e10f41797"
     },
     "sparseMatrixStats": {
@@ -1887,7 +1869,7 @@
       "Package": "stringr",
       "Version": "1.4.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "0759e6b6c0957edb1311028a49a35e76"
     },
     "survival": {
@@ -1964,7 +1946,7 @@
       "Package": "tidyverse",
       "Version": "1.3.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "bd51be662f359fa99021f3d51e911490"
     },
     "tinytex": {
@@ -1985,7 +1967,7 @@
       "Package": "tweenr",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "fc77eb5297507cccfa3349a606061030"
     },
     "tximeta": {
@@ -2011,7 +1993,7 @@
       "Package": "utf8",
       "Version": "1.1.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "4a5081acfb7b81a572e4384a7aaf2af1"
     },
     "uwot": {
@@ -2032,21 +2014,21 @@
       "Package": "vipor",
       "Version": "0.4.5",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "ea85683da7f2bfa63a98dc6416892591"
     },
     "viridis": {
       "Package": "viridis",
       "Version": "0.5.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "6f6b49e5b3b5ee5a6d0c28bf1b4b9eb3"
     },
     "viridisLite": {
       "Package": "viridisLite",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "ce4f6271baa94776db692f1cb2055bee"
     },
     "vsn": {
@@ -2066,7 +2048,7 @@
       "Package": "whisker",
       "Version": "0.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "ca970b96d894e90397ed20637a0c1bbe"
     },
     "withr": {
@@ -2094,7 +2076,7 @@
       "Package": "xtable",
       "Version": "1.8-4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
     },
     "yaml": {

--- a/renv.lock
+++ b/renv.lock
@@ -249,7 +249,7 @@
       "Package": "GlobalOptions",
       "Version": "0.1.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "c3f7b221e60c28f5f3533d74c6fef024"
     },
     "HDF5Array": {
@@ -320,14 +320,14 @@
       "Package": "RColorBrewer",
       "Version": "1.1-2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "e031418365a7f7a766181ab5a41a5716"
     },
     "RCurl": {
       "Package": "RCurl",
       "Version": "1.98-1.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "cf29e1b71f8736960e0e851123a83e6f"
     },
     "RSQLite": {
@@ -341,7 +341,7 @@
       "Package": "RSpectra",
       "Version": "0.16-0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "a41329d24d5a98eaed2bd0159adb1b5f"
     },
     "Rcpp": {
@@ -512,14 +512,14 @@
       "Package": "askpass",
       "Version": "1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
     "assertthat": {
       "Package": "assertthat",
       "Version": "0.2.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "50c838a310445e954bc13f26f26a6ecf"
     },
     "backports": {
@@ -533,7 +533,7 @@
       "Package": "base64enc",
       "Version": "0.1-3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
     "bbmle": {
@@ -560,7 +560,7 @@
       "Package": "beeswarm",
       "Version": "0.2.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "dc538ec663e38888807ef3034489403d"
     },
     "biomaRt": {
@@ -587,7 +587,7 @@
       "Package": "bitops",
       "Version": "1.0-6",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "0b118d5900596bae6c4d4865374536a6"
     },
     "blob": {
@@ -649,7 +649,7 @@
       "Package": "cellranger",
       "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "f61dbaec772ccd2e17705c1e872e9e7c"
     },
     "circlize": {
@@ -739,7 +739,7 @@
       "Package": "crayon",
       "Version": "1.3.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "0d57bc8e27b7ba9e45dba825ebc0de6b"
     },
     "crosstalk": {
@@ -753,7 +753,7 @@
       "Package": "curl",
       "Version": "4.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "2b7d10581cc730804e9ed178c8374bd6"
     },
     "data.table": {
@@ -774,7 +774,7 @@
       "Package": "desc",
       "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "6c8fe8fa26a23b79949375d372c7b395"
     },
     "diffobj": {
@@ -809,7 +809,7 @@
       "Package": "dqrng",
       "Version": "0.2.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "cc0d03e8383d407e9568855f8efbc07d"
     },
     "edgeR": {
@@ -855,7 +855,7 @@
       "Package": "estimability",
       "Version": "1.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "05901bd61be60fd3bfc5b7d7c3517d1d"
     },
     "etrunct": {
@@ -869,7 +869,7 @@
       "Package": "evaluate",
       "Version": "0.14",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
     },
     "exrcise": {
@@ -923,14 +923,14 @@
       "Package": "fastmatch",
       "Version": "1.1-0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "2cfe25650d69960c54e06840e4b5d8e4"
     },
     "fastqcr": {
       "Package": "fastqcr",
       "Version": "0.1.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "2abd00eb709c07fc87aa6b4132e17040"
     },
     "fftw": {
@@ -970,7 +970,7 @@
       "Package": "formatR",
       "Version": "1.7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "ad36e26eeeb7393886d8a0e19bc6ee42"
     },
     "fs": {
@@ -984,14 +984,14 @@
       "Package": "futile.logger",
       "Version": "1.4.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "99f0ace8c05ec7d3683d27083c4f1e7e"
     },
     "futile.options": {
       "Package": "futile.options",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "0d9bf02413ddc2bbe8da9ce369dcdd2b"
     },
     "genefilter": {
@@ -1017,7 +1017,7 @@
       "Package": "getopt",
       "Version": "1.20.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "ad68e3263f0bc9269aab8c2039440117"
     },
     "ggalt": {
@@ -1031,7 +1031,7 @@
       "Package": "ggbeeswarm",
       "Version": "0.6.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "dd68b9b215b2d3119603549a794003c3"
     },
     "ggforce": {
@@ -1073,7 +1073,7 @@
       "Package": "ggsignif",
       "Version": "0.6.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "3e9b8a51dfdc95395632b25ce3ce8ebc"
     },
     "ggupset": {
@@ -1121,14 +1121,14 @@
       "Package": "gridExtra",
       "Version": "2.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "7d7f283939f563670a697165b2cf5560"
     },
     "gtable": {
       "Package": "gtable",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "ac5c6baf7822ce8732b343f14c072c4d"
     },
     "gtools": {
@@ -1149,7 +1149,7 @@
       "Package": "highr",
       "Version": "0.8",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "4dc5bb88961e347a0f4d8aad597cbfac"
     },
     "hms": {
@@ -1218,7 +1218,7 @@
       "Package": "irlba",
       "Version": "2.3.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "a9ad517358000d57022401ef18ee657a"
     },
     "isoband": {
@@ -1267,7 +1267,7 @@
       "Package": "lambda.r",
       "Version": "1.2.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "b1e925c4b9ffeb901bacf812cbe9a6ad"
     },
     "later": {
@@ -1288,7 +1288,7 @@
       "Package": "lazyeval",
       "Version": "0.2.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
     },
     "lifecycle": {
@@ -1308,7 +1308,7 @@
       "Package": "locfit",
       "Version": "1.5-9.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "760b5b542e8435237d1b3c253bfe18e7"
     },
     "lubridate": {
@@ -1343,7 +1343,7 @@
       "Package": "markdown",
       "Version": "1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
     },
     "matrixStats": {
@@ -1357,7 +1357,7 @@
       "Package": "memoise",
       "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "58baa74e4603fcfb9a94401c58c8f9b1"
     },
     "mgcv": {
@@ -1399,14 +1399,14 @@
       "Package": "munsell",
       "Version": "0.5.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "6dfe8bf774944bd5595785e3229d8771"
     },
     "mvtnorm": {
       "Package": "mvtnorm",
       "Version": "1.1-1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "69fa7331e7410c2a2cb3f9868513904f"
     },
     "nlme": {
@@ -1420,7 +1420,7 @@
       "Package": "numDeriv",
       "Version": "2016.8-1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
     "openssl": {
@@ -1437,11 +1437,29 @@
       "Repository": "RSPM",
       "Hash": "35beff0d8469fbb7037925dde658888c"
     },
+    "org.Cf.eg.db": {
+      "Package": "org.Cf.eg.db",
+      "Version": "3.12.0",
+      "Source": "Bioconductor",
+      "Hash": "6b12823b05e8be09e9275cf23a5dda50"
+    },
+    "org.Dr.eg.db": {
+      "Package": "org.Dr.eg.db",
+      "Version": "3.12.0",
+      "Source": "Bioconductor",
+      "Hash": "ab7c2fb8fa90a7f9ca785a0d7afae5d6"
+    },
     "org.Hs.eg.db": {
       "Package": "org.Hs.eg.db",
       "Version": "3.12.0",
       "Source": "Bioconductor",
       "Hash": "3d2aea7762e91aa3d5b7c267c56d9055"
+    },
+    "org.Mm.eg.db": {
+      "Package": "org.Mm.eg.db",
+      "Version": "3.12.0",
+      "Source": "Bioconductor",
+      "Hash": "4e4ee144dea09b789a4269a68306c0b5"
     },
     "palmerpenguins": {
       "Package": "palmerpenguins",
@@ -1454,7 +1472,7 @@
       "Package": "pheatmap",
       "Version": "1.0.12",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "db1fb0021811b6693741325bbe916e58"
     },
     "pillar": {
@@ -1475,7 +1493,7 @@
       "Package": "pkgconfig",
       "Version": "2.0.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
     "pkgload": {
@@ -1489,7 +1507,7 @@
       "Package": "plogr",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "09eb987710984fc2905c7129c7d85e65"
     },
     "plotly": {
@@ -1510,21 +1528,21 @@
       "Package": "png",
       "Version": "0.1-7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "03b7076c234cb3331288919983326c55"
     },
     "polyclip": {
       "Package": "polyclip",
       "Version": "1.10-0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "cb167f328b3ada4ec5cf67a7df4c900a"
     },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "a555924add98c99d2f411e37e7d25e9f"
     },
     "preprocessCore": {
@@ -1551,7 +1569,7 @@
       "Package": "progress",
       "Version": "1.2.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "14dc9f7a3c91ebb14ec5bb9208a07061"
     },
     "proj4": {
@@ -1605,7 +1623,7 @@
       "Package": "rappdirs",
       "Version": "0.3.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "8c8298583adbbe76f3c2220eef71bebc"
     },
     "readr": {
@@ -1619,14 +1637,14 @@
       "Package": "readxl",
       "Version": "1.3.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "63537c483c2dbec8d9e3183b3735254a"
     },
     "rematch": {
       "Package": "rematch",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "c66b930d20bb6d858cd18e1cebcfae5c"
     },
     "rematch2": {
@@ -1659,7 +1677,7 @@
       "Package": "reprex",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "b06bfb3504cc8a4579fd5567646f745b"
     },
     "reshape2": {
@@ -1692,7 +1710,7 @@
       "Package": "rjson",
       "Version": "0.2.20",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "7d597f982ee6263716b6a2f28efd29fa"
     },
     "rlang": {
@@ -1727,7 +1745,7 @@
       "Package": "rsvd",
       "Version": "1.0.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "3a6b30449282b6a4b19ce267142c3299"
     },
     "rtracklayer": {
@@ -1740,7 +1758,7 @@
       "Package": "rvcheck",
       "Version": "0.1.8",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "11ebf2d3d4990e8bb9f28d5ab0c204fc"
     },
     "rvest": {
@@ -1793,7 +1811,7 @@
       "Package": "selectr",
       "Version": "0.4-2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
     },
     "shadowtext": {
@@ -1821,21 +1839,21 @@
       "Package": "sitmo",
       "Version": "2.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "0f9ba299f2385e686745b066c6d7a7c4"
     },
     "snow": {
       "Package": "snow",
       "Version": "0.4-3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "11b822ad6214111a4188d5e5fd1b144c"
     },
     "sourcetools": {
       "Package": "sourcetools",
       "Version": "0.1.7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "947e4e02a79effa5d512473e10f41797"
     },
     "sparseMatrixStats": {
@@ -1869,7 +1887,7 @@
       "Package": "stringr",
       "Version": "1.4.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "0759e6b6c0957edb1311028a49a35e76"
     },
     "survival": {
@@ -1946,7 +1964,7 @@
       "Package": "tidyverse",
       "Version": "1.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "bd51be662f359fa99021f3d51e911490"
     },
     "tinytex": {
@@ -1967,7 +1985,7 @@
       "Package": "tweenr",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "fc77eb5297507cccfa3349a606061030"
     },
     "tximeta": {
@@ -1993,7 +2011,7 @@
       "Package": "utf8",
       "Version": "1.1.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "4a5081acfb7b81a572e4384a7aaf2af1"
     },
     "uwot": {
@@ -2014,21 +2032,21 @@
       "Package": "vipor",
       "Version": "0.4.5",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "ea85683da7f2bfa63a98dc6416892591"
     },
     "viridis": {
       "Package": "viridis",
       "Version": "0.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "6f6b49e5b3b5ee5a6d0c28bf1b4b9eb3"
     },
     "viridisLite": {
       "Package": "viridisLite",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "ce4f6271baa94776db692f1cb2055bee"
     },
     "vsn": {
@@ -2048,7 +2066,7 @@
       "Package": "whisker",
       "Version": "0.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "ca970b96d894e90397ed20637a0c1bbe"
     },
     "withr": {
@@ -2076,7 +2094,7 @@
       "Package": "xtable",
       "Version": "1.8-4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
     },
     "yaml": {

--- a/renv.lock
+++ b/renv.lock
@@ -1437,11 +1437,29 @@
       "Repository": "RSPM",
       "Hash": "35beff0d8469fbb7037925dde658888c"
     },
+    "org.Cf.eg.db": {
+      "Package": "org.Cf.eg.db",
+      "Version": "3.12.0",
+      "Source": "Bioconductor",
+      "Hash": "6b12823b05e8be09e9275cf23a5dda50"
+    },
+    "org.Dr.eg.db": {
+      "Package": "org.Dr.eg.db",
+      "Version": "3.12.0",
+      "Source": "Bioconductor",
+      "Hash": "ab7c2fb8fa90a7f9ca785a0d7afae5d6"
+    },
     "org.Hs.eg.db": {
       "Package": "org.Hs.eg.db",
       "Version": "3.12.0",
       "Source": "Bioconductor",
       "Hash": "3d2aea7762e91aa3d5b7c267c56d9055"
+    },
+    "org.Mm.eg.db": {
+      "Package": "org.Mm.eg.db",
+      "Version": "3.12.0",
+      "Source": "Bioconductor",
+      "Hash": "4e4ee144dea09b789a4269a68306c0b5"
     },
     "palmerpenguins": {
       "Package": "palmerpenguins",


### PR DESCRIPTION
In an upcoming PR, I will be using mouse data in a pathway analysis notebook and therefore require `org.Mm.eg.db`. We've installed `org.Dr.eg.db` and `org.Cf.eg.db` in the training image before, but we don't (yet) use them during instruction. I've added them to `components/dependencies.R` as a result.