### PR TITLE
add alevinQC to renv and minor version updates

### DIFF
--- a/components/dependencies.R
+++ b/components/dependencies.R
@@ -24,3 +24,6 @@ library(org.Cf.eg.db)
 
 # Required for vsn plots in RNA-seq exercise
 library(hexbin)
+
+# AlevinQC was not getting noticed for some reason
+library(alevinQC)

--- a/renv.lock
+++ b/renv.lock
@@ -36,9 +36,9 @@
     },
     "AnnotationHub": {
       "Package": "AnnotationHub",
-      "Version": "2.22.0",
+      "Version": "2.22.1",
       "Source": "Bioconductor",
-      "Hash": "6ece9b0d9e1179541d3c388ab4ac2065"
+      "Hash": "44f52c9c9fa7f6ac22c8a4334e2a5224"
     },
     "BH": {
       "Package": "BH",
@@ -61,9 +61,9 @@
     },
     "BiocGenerics": {
       "Package": "BiocGenerics",
-      "Version": "0.36.0",
+      "Version": "0.36.1",
       "Source": "Bioconductor",
-      "Hash": "1fe8a6250d04cfb040ebec87447770ba"
+      "Hash": "f628c51eadc74ffd838b801cd22d589a"
     },
     "BiocManager": {
       "Package": "BiocManager",
@@ -155,9 +155,9 @@
     },
     "DelayedArray": {
       "Package": "DelayedArray",
-      "Version": "0.16.2",
+      "Version": "0.16.3",
       "Source": "Bioconductor",
-      "Hash": "2fc4c41dfafe33346e759d05bc3b372f"
+      "Hash": "a87d32010153cba996c97fe2a52403e6"
     },
     "DelayedMatrixStats": {
       "Package": "DelayedMatrixStats",
@@ -183,6 +183,13 @@
       "Version": "2.58.0",
       "Source": "Bioconductor",
       "Hash": "b17420379c5ef4c956f52362d8f824c8"
+    },
+    "GGally": {
+      "Package": "GGally",
+      "Version": "2.1.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "170b6d99ad751c7702fe365df77c1e4b"
     },
     "GO.db": {
       "Package": "GO.db",
@@ -210,9 +217,9 @@
     },
     "GenomeInfoDb": {
       "Package": "GenomeInfoDb",
-      "Version": "1.26.2",
+      "Version": "1.26.7",
       "Source": "Bioconductor",
-      "Hash": "6082689b1694d67738f55795ec407d5b"
+      "Hash": "b8b4dfceea20ddae8893aa4ccb242dea"
     },
     "GenomeInfoDbData": {
       "Package": "GenomeInfoDbData",
@@ -228,9 +235,9 @@
     },
     "GenomicFeatures": {
       "Package": "GenomicFeatures",
-      "Version": "1.42.1",
+      "Version": "1.42.3",
       "Source": "Bioconductor",
-      "Hash": "10c8a15846af2fd20d2645ce4edf74e3"
+      "Hash": "6dc0d423611db813aa38c2a9fbe56426"
     },
     "GenomicRanges": {
       "Package": "GenomicRanges",
@@ -481,6 +488,12 @@
       "Version": "1.60.0",
       "Source": "Bioconductor",
       "Hash": "1c5d69af9526756efa3ee2fbcc08a5b1"
+    },
+    "alevinQC": {
+      "Package": "alevinQC",
+      "Version": "1.6.1",
+      "Source": "Bioconductor",
+      "Hash": "064a93f3273ab670ad2fef0194b07c16"
     },
     "annotate": {
       "Package": "annotate",
@@ -847,9 +860,9 @@
     },
     "ensembldb": {
       "Package": "ensembldb",
-      "Version": "2.14.0",
+      "Version": "2.14.1",
       "Source": "Bioconductor",
-      "Hash": "b433b752aafc4ae0b5523585cae1269c"
+      "Hash": "b264d0ead0b855fcd8fa712d40fabf58"
     },
     "estimability": {
       "Package": "estimability",
@@ -1687,6 +1700,13 @@
       "Repository": "RSPM",
       "Hash": "b06bfb3504cc8a4579fd5567646f745b"
     },
+    "reshape": {
+      "Package": "reshape",
+      "Version": "0.8.8",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "0f4d941129e00ed34a7d192b1da7ccef"
+    },
     "reshape2": {
       "Package": "reshape2",
       "Version": "1.4.4",
@@ -1709,9 +1729,9 @@
     },
     "rhdf5filters": {
       "Package": "rhdf5filters",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Bioconductor",
-      "Hash": "9dee5e2185e9a498c7d910f6b3f33150"
+      "Hash": "4e9258b05bbcbc1093eda53aa8051264"
     },
     "rjson": {
       "Package": "rjson",
@@ -1804,9 +1824,9 @@
     },
     "scran": {
       "Package": "scran",
-      "Version": "1.18.5",
+      "Version": "1.18.7",
       "Source": "Bioconductor",
-      "Hash": "3f935129e59f4cf0bb588ee776a0a570"
+      "Hash": "c327f8414fc0937c89b928174cabe46c"
     },
     "scuttle": {
       "Package": "scuttle",
@@ -1841,6 +1861,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "6e3b6ae7fe02b5859e4bb277f218b8ae"
+    },
+    "shinydashboard": {
+      "Package": "shinydashboard",
+      "Version": "0.7.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "133639dc106955eee4ffb8ec73edac37"
     },
     "sitmo": {
       "Package": "sitmo",
@@ -1997,9 +2024,9 @@
     },
     "tximeta": {
       "Package": "tximeta",
-      "Version": "1.8.4",
+      "Version": "1.8.5",
       "Source": "Bioconductor",
-      "Hash": "b654fcf33a11895ce4af13360c50447c"
+      "Hash": "e5daca57feaffbd4a4a96ca337fa2f78"
     },
     "tximport": {
       "Package": "tximport",


### PR DESCRIPTION
This PR just adds alevinQC to the training renv, but there were some other updates that came along as I did that, so I figured I might as well incorporate them as well.