### PR TITLE
Add link for data used in scRNA-seq day 1 exercise notebook

### DIFF
--- a/scripts/link-data.sh
+++ b/scripts/link-data.sh
@@ -61,6 +61,7 @@ link_locs=(
   scRNA-seq/data/glioblastoma/preprocessed
   scRNA-seq/data/hodgkins/cellranger
   scRNA-seq/data/tabula-muris/alevin-quant/10X_P4_3
+  scRNA-seq/data/tabula-muris/alevin-quant/10X_P7_12
   scRNA-seq/data/tabula-muris/fastq
   scRNA-seq/data/tabula-muris/normalized/TM_normalized.rds
   machine-learning/data/open-pbta

--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -32,6 +32,7 @@ sync_dirs=(
   RNA-seq/data/open-pbta
   scRNA-seq/data/hodgkins/cellranger
   scRNA-seq/data/tabula-muris/alevin-quant/10X_P4_3
+  scRNA-seq/data/tabula-muris/alevin-quant/10X_P7_12
   scRNA-seq/index/Mus_musculus
   machine-learning/data/open-pbta/processed
   pathway-analysis/data/leukemia


### PR DESCRIPTION
This PR links the data for `alevin-quant/10X_P7_12` to the training-modules directory. This is the mammary gland data that we will be using for the scRNA-seq day 1 exercise notebook. 