### PR TITLE
Initial draft of CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ authors:
   - family-names: Taroni
     given-names: Jaclyn N.
     orcid: https://orcid.org/0000-0003-4734-4508
-title: "Childhood Cancer Data Lab"
+title: "Childhood Cancer Data Lab Training Modules"
 version: 2021-june
 date-released: 2021-06-22

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.1.0
+authors:
+  - family-names: Shapiro
+    given-names: Joshua A.
+    orcid: https://orcid.org/0000-0002-6224-0347
+  - family-names: Savonen
+    given-names: Candace L.
+    orcid: https://orcid.org/0000-0001-6331-7070
+  - family-names: Hawkins
+    given-names: Allegra
+    orcid: https://orcid.org/
+  - family-names: Bethell
+    given-names: Chante J.
+    orcid: https://orcid.org/0000-0001-9653-8128
+  - family-names: Venkatesh Prasad
+    given-names: Deepashree
+    orcid: https://orcid.org/0000-0001-5756-4083
+  - family-names: Greene
+    given-names: Casey S.
+    orcid: https://orcid.org/0000-0001-8713-9213
+  - family-names: Taroni
+    given-names: Jaclyn N.
+    orcid: https://orcid.org/0000-0003-4734-4508
+title: "Childhood Cancer Data Lab"
+version: 2021-june
+date-released: 2021-06-22

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Candace L.
     orcid: https://orcid.org/0000-0001-6331-7070
   - family-names: Hawkins
-    given-names: Allegra
+    given-names: Allegra G.
     orcid: https://orcid.org/0000-0001-6026-3660
   - family-names: Bethell
     given-names: Chante J.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
     orcid: https://orcid.org/0000-0001-6331-7070
   - family-names: Hawkins
     given-names: Allegra
-    orcid: https://orcid.org/
+    orcid: https://orcid.org/0000-0001-6026-3660
   - family-names: Bethell
     given-names: Chante J.
     orcid: https://orcid.org/0000-0001-9653-8128


### PR DESCRIPTION
Currently missing an ORCID and possibly a middle initial for @allyhawkins, but this is adding a `CITATION.cff` file to this repository. 

The order is in order of the contributors graph for this repository: https://github.com/AlexsLemonade/training-modules/graphs/contributors

With the exception that I am last author.