### PR TITLE
Fix links to exercise notebooks in module READMEs

### DIFF
--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -10,9 +10,10 @@ The notebooks that comprise this module are (estimated time to complete notebook
 * [Quality control, trim, and quantification with salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md) (1 hr 10 minutes)
 * [Gene-level summaries with tximeta](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximeta.nb.html) (25 minutes)
 * [Exploratory analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) (35 minutes)
-* Differential expression analysis: [tximeta](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximeta.md) and [differential expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html) (25 minutes and 40 minutes, respectively)
-* [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)
-
+* Differential expression analysis: [tximeta (guided exercise)](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximeta.md) and [differential expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html) (25 minutes and 40 minutes, respectively)
+* Additional exercises
+  * [Exploratory data analysis](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/exercise_01-exploratory_data_analysis.Rmd)
+  * [DESeq2](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/exercise_02-bulk_rnaseq.Rmd)
 
 _Total estimated time to complete instruction notebooks: 3 hours 15 minutes_
 

--- a/intro-to-R-tidyverse/README.md
+++ b/intro-to-R-tidyverse/README.md
@@ -9,8 +9,9 @@ The notebooks that comprise this module are (estimated time to complete notebook
 * [Introduction to Base R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) (1 hr 40 minutes)
 * [Introduction to ggplot2](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) (45 minutes)
 * [Introduction to tidyverse](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) (1 hr 10 minutes)
-* [Additional exercises for introduction to R](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/04a-intro_to_R_exercise.Rmd)  
-* [Additional exercises for introduction to tidyverse part 1](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/04b-intro_to_tidyverse_exercise-part-1.Rmd)  
-* [Additional exercises for introduction to tidyverse part 2](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd)  
+* [Additional exercises for introduction to base R](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/exercise_01-intro_to_base_R.Rmd)
+* [Additional exercises for introduction to R](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)  
+* [Additional exercises for introduction to tidyverse part 1](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/exercise_03a-intro_to_tidyverse.Rmd)  
+* [Additional exercises for introduction to tidyverse part 2](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/exercise_03b-intro_to_tidyverse.Rmd)  
 
 _Total estimated time to complete instruction notebooks: 3 hours 35 minutes_

--- a/pathway-analysis/README.md
+++ b/pathway-analysis/README.md
@@ -6,9 +6,12 @@ This module depends on the knowledge gained in the [Intro to R and the Tidyverse
 
 The notebooks that comprise this module are (estimated time to complete notebook):
 
-* [Over-representation analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/01-overrepresentation_analysis.nb.html) (45 minutes)
+* [Over-representation Analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/01-overrepresentation_analysis.nb.html) (45 minutes)
 * [Gene Set Enrichment Analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/02-gene_set_enrichment_analysis.nb.html) (30 minutes)
 * [Gene Set Variation Analysis](https://alexslemonade.github.io/training-modules/pathway-analysis/03-gene_set_variation_analysis.nb.html) (30 minutes)
-* [Additional exercises](https://github.com/AlexsLemonade/training-modules/blob/master/pathway-analysis/04-pathway_analysis_exercise.Rmd)
+* Additional exercises
+  * [Over-representation Analysis](https://github.com/AlexsLemonade/training-modules/blob/master/pathway-analysis/exercise_01-ora.Rmd)
+  * [Gene Set Enrichment Analysis](https://github.com/AlexsLemonade/training-modules/blob/master/pathway-analysis/exercise_02-gsea.Rmd)
+  * [Gene Set Variation Analysis](https://github.com/AlexsLemonade/training-modules/blob/master/pathway-analysis/exercise_03-gsva.Rmd)
 
 _Total estimated time to complete instruction notebooks: 1 hour 45 minutes_

--- a/scRNA-seq/README.md
+++ b/scRNA-seq/README.md
@@ -13,7 +13,13 @@ The notebooks that comprise this module are:
 * [Dimension reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/04-dimension_reduction_scRNA.nb.html) 
 * [Clustering](https://alexslemonade.github.io/training-modules/scRNA-seq/05-clustering_markers_scRNA.nb.html)
 
-This directory also contains pathway analysis modules customized to these data
+This directory also contains pathway analysis modules customized to these data:
+
 * [Overrepresentation analysis](https://alexslemonade.github.io/training-modules/scRNA-seq/06-overrepresentation_analysis.nb.html)
 * [Gene set enrichment analysis](https://alexslemonade.github.io/training-modules/scRNA-seq/07-gene_set_enrichment_analysis.nb.html)
 
+Additional exercise notebooks:
+
+* [Quantification](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/exercise_01-scrna_quant.Rmd)
+* [Clustering](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/exercise_02-scrna_clustering.Rmd)
+* [Pathway analysis](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/exercise_03-scrna-seq_pathway.Rmd)


### PR DESCRIPTION
Closes #499. 

We changed our naming conventions for our exercise notebooks, so some of the links were broken. I went through all of the READMEs for material we've taught this year (read: not `machine-learning`) and updated the exercise notebook links. How we talk about these is not that consistent, but I figure that is a problem for another day and it is better to have links that are not broken!