### PR TITLE
Make `labs()` chunk live in intro to ggplot2

### DIFF
--- a/intro-to-R-tidyverse/02-intro_to_ggplot2.Rmd
+++ b/intro-to-R-tidyverse/02-intro_to_ggplot2.Rmd
@@ -284,7 +284,7 @@ ggplot(
 Alternatively, we can use the `ggplot2` function `labs()`, which takes individual arguments for each label we want want to set. 
 We can also include the argument `title` to add an overall plot title.
 
-```{r ggplot-label-2}
+```{r ggplot-label-2, live = TRUE}
 ggplot(
   tumor_normal_df,
   aes(


### PR DESCRIPTION
Closes #525 

Thanks @sjspielman for filing #525, as I noted on there (https://github.com/AlexsLemonade/training-modules/issues/525#issuecomment-1058110937), I do believe that the chunk with the first instance of the `labs()` function should be made live in the intro to ggplot2 notebook, and this is what this PR does.

I do not feel strongly about making the remaining chunks added in #522 live, but I would be happy to if other folks feel strongly about it!