### PR TITLE
Remove duplicated word

### DIFF
--- a/scRNA-seq/07-gene_set_enrichment_analysis.Rmd
+++ b/scRNA-seq/07-gene_set_enrichment_analysis.Rmd
@@ -196,7 +196,7 @@ duplicated_gene_symbols <- markers_df %>%
   dplyr::pull(gene_symbol)
 ```
 
-Now we'll look at the values for the the duplicated gene symbols.
+Now we'll look at the values for the duplicated gene symbols.
 
 ```{r show_gene_dups}
 markers_df %>%


### PR DESCRIPTION
`the the` --> `the`, even though there is some play-on-words benefit to retaining both `the`s.