### PR TITLE
Add Git configurations in GHA & update docker actions

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -4,7 +4,8 @@ name: Build Docker Image and Push to Dockerhub
 # Every time something is merged to master, the image will be rebuilt and pushed.
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -16,22 +17,22 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Login to Dockerhub
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_ID }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       # set up Docker build
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       # Build Docker image
       - name: Build Docker image
-        uses: docker/build-push-action@v2.2.2
+        uses: docker/build-push-action@v3
         with:
           push: true
           context: .
@@ -46,5 +47,5 @@ jobs:
           status: ${{ job.status }}
           notify_when: 'failure'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }} 
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
           SLACK_MESSAGE: 'Training build Docker & push workflow failed'

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,8 +4,14 @@ name: Build Docker
 # master when the Dockerfile or renv.lock file changes.
 on:
   pull_request:
-    branches: [ master ]
-    paths: [ Dockerfile, renv.lock ]
+    branches:
+      - master
+    paths:
+      - Dockerfile
+      - renv.lock
+  push:
+    branches:
+      - jashapiro/541-gha-git
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -17,28 +23,19 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # set up Docker build
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      # setup layer cache
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+        uses: docker/setup-buildx-action@v2
 
       # Build docker image
       - name: Build Docker image
-        uses: docker/build-push-action@v2.2.2
+        uses: docker/build-push-action@v3
         with:
           push: false
           context: .
           file: Dockerfile
           tags: ccdl/training_dev:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -9,9 +9,6 @@ on:
     paths:
       - Dockerfile
       - renv.lock
-  push:
-    branches:
-      - jashapiro/541-gha-git
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -20,7 +20,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
 
       - name: Set up AWS credentials
         if: github.event.inputs.rendering == 'TRUE'
@@ -64,7 +70,7 @@ jobs:
           reviewers: $GITHUB_ACTOR
 
 
-      # Spit out PR info
+      # Write PR info
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -3,8 +3,9 @@ name: Test render notebooks
 
 on:
   pull_request:
-    branches: [ master ]
-    paths: 
+    branches:
+      - master
+    paths:
       - '**.Rmd'
       - '!**-live.Rmd' # don't trigger for live-only changes
       - '!**/exercise*.Rmd' # or exercise notebooks
@@ -20,7 +21,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -5,7 +5,9 @@ name: Spell check R Markdown and Markdown files
 # Pull requests to master only.
 on:
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
+      - jashapiro/541-gha-git
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -17,8 +19,8 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
-          
+      - uses: actions/checkout@v3
+
       - name: Install packages
         run: Rscript --vanilla -e "install.packages('spelling', repos = c(CRAN = 'https://cloud.r-project.org'))"
 

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -5,11 +5,8 @@ name: Spell check R Markdown and Markdown files
 # Pull requests to master only.
 on:
   pull_request:
-    branches: 
-      - master
-  push:
     branches:
-      - jashapiro/541-gha-git
+      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -32,6 +29,7 @@ jobs:
           results=$(Rscript --vanilla "scripts/spell-check.R")
           echo "::set-output name=sp_chk_results::$results"
           cat spell_check_errors.tsv
+
       - name: Archive spelling errors
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: 
       - master
+  push:
+    branches:
       - jashapiro/541-gha-git
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
This PR adds git config instructions to allow commits and pushes in the `make-live` action. 

Closes #541

I also took the opportunity to update versions for a number of other actions, including docker build, which now natively uses the GHA cache for some simplification. Technically, this is experimental, but it seems to work well. 