### PR TITLE
Species --> species

### DIFF
--- a/intro-to-R-tidyverse/01-intro_to_base_R.Rmd
+++ b/intro-to-R-tidyverse/01-intro_to_base_R.Rmd
@@ -460,7 +460,7 @@ We can also calculate the full summary statistics for a single column directly.
 summary(penguins$bill_length_mm)
 ```
 
-Extract `Species` as a vector and subset it to see a preview.
+Extract `species` as a vector and subset it to see a preview.
 
 ```{r penguins-col-subset, live = TRUE}
 # get the first 10 values of the species column


### PR DESCRIPTION
Should be lowercase! This is probably from when the notebook used `iris` instead of `penguins`.