### PR TITLE
Compress rds files in rms setup

### DIFF
--- a/scRNA-seq-advanced/setup/rms/integrate_rms.R
+++ b/scRNA-seq-advanced/setup/rms/integrate_rms.R
@@ -134,4 +134,4 @@ combined_sce <- scater::runUMAP(combined_sce,
                                 name = "fastmnn_UMAP")
 
 # write out combined SCE file with added integration PCs
-readr::write_rds(combined_sce, opt$integrated_sce_file)
+readr::write_rds(combined_sce, opt$integrated_sce_file, compress = "gz")

--- a/scRNA-seq-advanced/setup/rms/prepare_rms_library.R
+++ b/scRNA-seq-advanced/setup/rms/prepare_rms_library.R
@@ -109,7 +109,7 @@ if (all(rownames(celltype_coldata) == colnames(norm_sce))){
 ### Save -------------------
 
 # Write the SCE file
-readr::write_rds(norm_sce, opts$output_sce_file)
+readr::write_rds(norm_sce, opts$output_sce_file, compress = "gz")
 
 
 


### PR DESCRIPTION
A very small PR to compress the SCE object files during the setup scripts. Using gzip compression because it is the fastest to decompress. 