### PR TITLE
Use new pipe in advanced 01 notebook

### DIFF
--- a/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
+++ b/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
@@ -36,7 +36,6 @@ To start, we will load some of the libraries we will need later, and set a rando
 
 ```{r setup}
 # Load libraries
-library(magrittr) # the pipe (%>%) operator
 library(ggplot2) # plotting functions
 library(SingleCellExperiment) # our main class for storing Single Cell data
 
@@ -243,9 +242,9 @@ All we need now is the `gene_id`, and only for the genes that are present in our
 
 ```{r get mitochondrial genes}
 # read in a table of mitochondrial genes and extract ids
-mito_genes <- readr::read_tsv(mito_file) %>%
+mito_genes <- readr::read_tsv(mito_file) |>
   # filter to only the genes that are found in our dataset
-  dplyr::filter(gene_id %in% rownames(filtered_sce)) %>%
+  dplyr::filter(gene_id %in% rownames(filtered_sce)) |>
   # create a vector from the gene_id column
   dplyr::pull(gene_id)
 ```


### PR DESCRIPTION
A really small PR as part of #598: 

Here I am replacing `%>%` with `|>` in the advanced/01 notebook. Apparently only used it a couple of times in that notebook, and just in one chunk!