### PR TITLE
Fix typo in output file name in 01 read and filter notebook

### DIFF
--- a/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
+++ b/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
@@ -92,7 +92,7 @@ if (!dir.exists(normalized_dir)) {
 }
 
 # output RDS file for normalized data
-output_sce_file <- file.path(normalized_dir, "gliobastoma_normalized_sce.rds")
+output_sce_file <- file.path(normalized_dir, "glioblastoma_normalized_sce.rds")
 ```
 
 


### PR DESCRIPTION
In working on the cell type exercise and using the output from the read and filter notebook, I noticed a typo in defining the output file. There was an `l` missing in `glioblastoma`. I fixed that here. 