### PR TITLE
Finish cell typing text

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -346,6 +346,7 @@ Sergushichev
 setosa
 SingleCellExperiment
 SingleCellExperiments
+SingleR
 Sirota
 snakemake
 SNE

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -227,6 +227,8 @@ MEK
 Menyhárt
 mer
 MetaCell
+metacell
+metacells
 mesoderm
 MF
 miQC
@@ -279,6 +281,7 @@ OSCA
 overexpressed
 overinterpret
 overrepresentation
+parallelize
 Patro
 Paugh
 PBMC

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -310,9 +310,9 @@ Note that while we applied this technique to assign cell types using the ADT dat
 
 However, what we did here was very ad-hoc and quite manual!
 We didn't calculate any statistics, and we had to look at every tag we were interested in to pick thresholds.
-A different data set might have different background levels, which would require different thresholds. 
+A different dataset might have different background levels, which would require different thresholds. 
 
-While this technique might be good for some simple experiments, and can be useful for manual curation, it might not translate well to more complex data sets with multiple samples.
+While this technique might be good for some simple experiments, and can be useful for manual curation, it might not translate well to more complex datasets with multiple samples.
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/release/bioc/html/AUCell.html).
@@ -324,7 +324,7 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 
 An alternative approach to using known marker genes for classification is to instead classify cells by way of comparison to a reference dataset.
 To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
-We can then train a model based on this data set and look at each of the cells in our new data set to determine which (if any) of the known cell types has the most similar expression pattern.
+We can then train a model based on this dataset and look at each of the cells in our new dataset to determine which (if any) of the known cell types has the most similar expression pattern.
 The details of how such a model may be constructed and trained will vary by method, but this overall approach is widely applied. 
 
 For this section, we will focus on the `SingleR` package and its methods, which are described in detail in  [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
@@ -339,7 +339,7 @@ For `SingleR` that reference data can be from bulk RNA sequencing or from other 
 `SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available. 
 
 One convenient source of cell reference data is the `celldex` package, which is what we will use here.
-This package includes functions to download a variety of well-annotated reference data sets in a common format.  
+This package includes functions to download a variety of well-annotated reference datasets in a common format.  
 For more information on the datasets available, you will want to refer to [the `celldex` summary vignette](https://bioconductor.org/packages/3.16/data/experiment/vignettes/celldex/inst/doc/userguide.html).
 
 We will start by using a reference dataset of sorted immune cells from [GSE107011 (Monaco _et al._ 2019)](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE107011).
@@ -380,12 +380,12 @@ There are three main columns for the sample data:
 - `label.main` is a more general cell type assignment.  
 
 - `label.fine` is a fine-level cell type with more specific labels.
-The exact level of granularity of these `main` and `fine` designations (and indeed the label names themselves) will vary among data sets, so it is important to look at the reference to see whether it is suitable for your application.
+The exact level of granularity of these `main` and `fine` designations (and indeed the label names themselves) will vary among datasets, so it is important to look at the reference to see whether it is suitable for your application.
 
 - `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier. 
 Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop. 
 
-Another component we would like to explore is how many of each of these cell types we have in the data set. 
+Another component we would like to explore is how many of each of these cell types we have in the dataset. 
 A bit of quick `dplyr` wrangling can give us the answer.
 
 ```{r count cell types}
@@ -399,9 +399,9 @@ Most cell types have 4 replicates, which is more replicates than we often find.
 
 ### What does `SingleR` do?
 
-As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new data sets.
+As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new datasets.
 
-`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference data set. 
+`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference dataset. 
 It does this by performing pairwise comparisons among all of the cell types, and retaining the top set of genes differentiating each pair.
 The idea is that this set of genes will be the most informative for differentiating cell types.
 
@@ -426,7 +426,7 @@ In this case, we will use the argument `BiocParallel::MulticoreParam(4)` to spec
 # calculate SingleR results in one step
 singler_result <- SingleR::SingleR(
   sce, # our query SCE
-  ref = monaco_ref, # reference data set
+  ref = monaco_ref, # reference dataset
   labels = monaco_ref$label.main, # reference labels to use
   BPPARAM = BiocParallel::MulticoreParam(4) # multiprocessing
 )
@@ -456,7 +456,7 @@ scater::plotUMAP(sce, colour_by = "celltype_main")
 Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices, but this isn't a bad start!
 We seem to have a pretty good set of assignments, with most of the cell type assignments falling into groupings consistent with what we see in the UMAP plot.
 
-We can thank the fact that this is a PBMC sample and that we have a good reference data set for these cell types for the cleanliness of this plot.
+We can thank the fact that this is a PBMC sample and that we have a good reference dataset for these cell types for the cleanliness of this plot.
 Quite often with other kinds of samples (especially cancer cells!) things will be much less clean!
 
 We can also look to see how the cell type assignments are distributed using the base R function `table()`
@@ -468,7 +468,7 @@ table(singler_result$pruned.labels, useNA = "ifany")
 
 ### Exploring finer labels
 
-In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the data set in a bit more detail. 
+In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the dataset in a bit more detail. 
 
 We will also take this time to dive a bit deeper into the steps that `SingleR` performed. 
 As mentioned, the first step is training the model, during which we identify the genes that will be used for the correlation analysis later.
@@ -484,7 +484,7 @@ If we want to get really fancy, we could even provide a specific list of genes t
 We should note here that the reference dataset for `SingleR` does not need to be from a compendium like `celldex`!
 If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
 You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible. 
-You can even use a previously-annotated SingleCellExperiment as a reference for a new data set.
+You can even use a previously-annotated SingleCellExperiment as a reference for a new dataset.
 For more details about custom references, see  the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.13/OSCA.basic/cell-type-annotation.html#using-custom-references)
 
 We do want to be sure that the genes selected for the model will be among those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
@@ -715,7 +715,7 @@ We won't go into that depth here, but we can apply similar ideas.
 To begin, we will perform some fine-scale clustering, using a simpler clustering algorithm: K-means clustering.
 We will use the same `bluster` package, clustering based on the PCA results we have from earlier, but this algorithm allows us to specify the number of clusters we want to end up with.
 We have about 8000 cells, so let's cluster those into groups of approximately 80 cells, which works out to 100 clusters.
-While this is almost certainly more clusters than are "real" in this data set, our goal here is not to find differences among clusters, just to get homogeneous groups of cells.
+While this is almost certainly more clusters than are "real" in this dataset, our goal here is not to find differences among clusters, just to get homogeneous groups of cells.
 
 ```{r kmeans cluster}
 # perform k-means clustering

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -323,7 +323,7 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 ## Cell type annotation with `SingleR`
 
 An alternative approach to using known marker genes for classification is to instead classify cells by way of comparison to a known dataset.
-To do this, we will find a well-curated gene expresssion dataset that contains samples with known cell types.
+To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
 We can then train a model based on this data set, and then look at each of the cells in our new data set to determine which (if any) of the known cell types has the most similar expression pattern.
 The details of how such a model may be constructed and trained will vary by method, but this overall approach is widely applied. 
 
@@ -386,7 +386,7 @@ The exact level of granularity of these `main` and `fine` designations will vary
 Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop. 
 
 Another component we would like to explore is how many of each of these cell types we have in the data set. 
-A bit of quick `dplyr` wrangling can give us the answe.
+A bit of quick `dplyr` wrangling can give us the answer.
 
 ```{r}
 colData(monaco_ref) |> 
@@ -399,7 +399,7 @@ Most cell types have 4 replicates, which is more replicates than we often find.
 
 ### What does `SingleR` do?
 
-`As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new data sets.
+As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new data sets.
 
 `SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference data set. 
 It does this by performing pairwise comparisons among all of the cell types, and retaining the top set of genes differentiating each pair.
@@ -432,7 +432,7 @@ singler_result <- SingleR::SingleR(
 )
 ```
 
-`SingleR` provides a few nice visualizations for evaluating the statistics it calcualted and the assignments it makes.
+`SingleR` provides a few nice visualizations for evaluating the statistics it calculated and the assignments it makes.
 One is a heatmap of the scores for each cell, arranged by the cell type that was assigned to each.
 This is created with the `SingleR::plotScoreHeatmap()` function.
 
@@ -487,7 +487,7 @@ You can even use a previously-annotated SingleCellExperiment as a reference for 
 For more details about custom references, see  the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.13/OSCA.basic/cell-type-annotation.html#using-custom-references)
 
 We do want to be sure that the genes selected for the model will be among those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
-This step would happen automatically wiht the `SingleR::SingleR()` function, but we need to add it manually for this use case.
+This step would happen automatically with the `SingleR::SingleR()` function, but we need to add it manually for this use case.
 
 
 ```{r train finemodel, live=TRUE}
@@ -604,7 +604,7 @@ scater::plotUMAP(sce,
 Let's look at how the cell type assignments we have compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
 
 To do this, we will first use the very handy base R `table()` function to build a contingency table of the cell types and clusters that each cell was classified with. 
-Since we used the "pruned" cell type assignments and we'd still like to keep track of the cells that ended up as `NA`, we will include the `useNA = "ifany" argument.
+Since we used the "pruned" cell type assignments and we'd still like to keep track of the cells that ended up as `NA`, we will include the `useNA = "ifany"` argument.
 
 ```{r}
 # create a table of clusters & cell type counts

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -708,8 +708,8 @@ You may recall that clustering algorithms are quite sensitive to parameter choic
 
 ### MetaCell approaches
 
-As an intermediate step between the potentially messy single-cell cell type assignment and the almost certainly overconfident cluster-based assignment above, we can take an approach inspired by a paper by [Baran _et al._ (2019)](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1812-2) that they called _metacells_. 
-The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters for further analysis. 
+As a middle ground between the potentially messy single-cell cell type assignment and the almost-certainly overconfident cluster-based assignment above, we can take approach inspired by [Baran _et al._ (2019)](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1812-2) using something they called _metacells_. 
+The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters as "metacells" to use for further analysis. 
 The original paper includes a number of optimizations to make sure that the metacell clusters have desirable properties for downstream analysis.
 We won't go into that depth here, but we can apply similar ideas.
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -460,6 +460,7 @@ We can thank the fact that this is a PBMC sample and that we have a good referen
 Quite often with other kinds of samples (especially cancer cells!) things will be much less clean!
 
 We can also look to see how the cell type assignments are distributed using the base R function `table()`
+Since we like to keep track of the cells that ended up as `NA` in the pruned labels, we will include the `useNA = "ifany"` argument.
 
 ```{r cell type table}
 table(singler_result$pruned.labels, useNA = "ifany")
@@ -603,8 +604,7 @@ scater::plotUMAP(sce,
 
 Let's look at how the cell type assignments we have compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
 
-To do this, we will first use the very handy base R `table()` function to build a contingency table of the cell types and clusters that each cell was classified with. 
-Since we used the "pruned" cell type assignments and we'd still like to keep track of the cells that ended up as `NA`, we will include the `useNA = "ifany"` argument.
+To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with. 
 
 ```{r}
 # create a table of clusters & cell type counts
@@ -673,7 +673,7 @@ You can see that the resulting matrix still has the same number of rows we have 
 Now we can apply the same `SingleR` model to these results, using the new matrix as input along with the previously trained model.
 As there are only 20 clusters to classify, this will be very quick, and we don't need to parallelize it!
 
-```{r singler cluster, live = true}
+```{r singler cluster, live = TRUE}
 singler_cluster <- SingleR::classifySingleR(
   cluster_mat, 
   singler_finemodel

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -760,7 +760,7 @@ Is this more or less useful than the original cell-based clustering?
 To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there. 
 Instead we will just write out the cell information table (`colData`) as a TSV file.
 
-```{r save sce}
+```{r save cell info, live=TRUE}
 readr::write_tsv(as.data.frame(colData(sce)), file = cellinfo_file)
 ```
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -761,7 +761,9 @@ To save disk space (and time), we won't write out the whole SCE object, as we ha
 Instead we will just write out the cell information table (`colData`) as a TSV file.
 
 ```{r save cell info, live=TRUE}
-readr::write_tsv(as.data.frame(colData(sce)), file = cellinfo_file)
+colData(sce) |>
+  as.data.frame() |>
+  readr::write_tsv(file = cellinfo_file)
 ```
 
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -321,6 +321,13 @@ For more on that method, the OSCA chapter [Assigning cell labels from gene sets]
 
 ## Cell type annotation with `SingleR`
 
+An alternative approach to using known marker genes for classification is to instead classify cells by way of comparison to a known dataset.
+To do this, we will find a well-curated gene expresssion dataset that contains samples with known cell types.
+We can then train a model based on this data set, and then look at each of the cells in our new data set to determine which (if any) of the known cell types has the most similar expression pattern.
+The details of how such a model may be constructed and trained will vary by method, but this overall approach is widely applied. 
+
+For this section, we will focus on the `SingleR` package and its methods, which are described in detail in  [_The SingleR Book_](https://bioconductor.org/books/release/SingleRBook/).
+
 First, we need some reference data.
 Text about importance of reference data goes here!
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -138,7 +138,7 @@ Note that this PCA matrix and the UMAP built from it were derived from the gene 
 While we have the ADT data, it is _not_ being used for this stage of the analysis.
 
 
-```{r}
+```{r cluster cells}
 # perform clustering
 nn_clusters <- bluster::clusterRows(
   # PCA input
@@ -371,7 +371,7 @@ In fact, the `SingleCellExperiment` object is derived from a `SummarizedExperime
 
 What information do we have for the samples?
 
-```{r explore}
+```{r explore reference sample data}
 colData(monaco_ref)
 ```
 
@@ -388,7 +388,7 @@ Using the cell ontology can allow for more complex representations of the relati
 Another component we would like to explore is how many of each of these cell types we have in the data set. 
 A bit of quick `dplyr` wrangling can give us the answer.
 
-```{r}
+```{r count cell types}
 colData(monaco_ref) |> 
   as.data.frame() |>
   dplyr::count(label.main, label.fine)
@@ -416,7 +416,7 @@ If there are multiple cell types with high scores, an optional fine-tuning step 
 ### Running `SingleR`
 
 For our first run, we will do the marker gene selection (training) and classification in a single step, using the convenience function `SingleR::SingleR()`.
-For this we need only supply three main arguments: Our `sce` object, a reference matrix (here in `SummarizedExperiment` format), and the labels for each of the samples in the reference that we want to use.
+For this we need only supply three main arguments: Our SCE object, a reference matrix (here in `SummarizedExperiment` format), and the labels for each of the samples in the reference that we want to use.
 
 Because this function is doing many repetitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
 This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions. 
@@ -494,8 +494,8 @@ This step would happen automatically with the `SingleR::SingleR()` function, but
 ```{r train finemodel, live=TRUE}
 # build fine model
 singler_finemodel <- SingleR::trainSingleR(
-  monaco_ref,
-  labels = monaco_ref$label.fine,
+  monaco_ref, # reference dataset
+  labels = monaco_ref$label.fine, # labels for training dataset
   # use DE to select genes (default)
   genes = "de", 
   # only use genes in the sce object
@@ -510,7 +510,9 @@ Now we can perform the classification step, using our SCE object and the `Single
 ```{r classify fine, live=TRUE}
 # classify with fine model
 singler_result_fine <- SingleR::classifySingleR(
+  # our SCE object
   sce,
+  # the trained model object
   singler_finemodel,
   # perform fine tuning (default)
   fine.tune = TRUE,
@@ -593,7 +595,7 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
 
 Now that we have that set up, we can plot using our collapsed and ordered cell type labels.
 
-```{r}
+```{r plot collapsed, live=TRUE}
 sce$celltype_collapsed <- collapsed_labels
 scater::plotUMAP(sce, 
                  colour_by = "celltype_collapsed")
@@ -606,7 +608,7 @@ Let's look at how the cell type assignments we obtained using `SingleR` compare 
 
 To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with. 
 
-```{r}
+```{r type cluster table}
 # create a table of clusters & cell type counts
 type_cluster_tab <- table(sce$celltype_fine, sce$nn_cluster, useNA = "ifany")
 
@@ -639,7 +641,7 @@ type_cluster_tab[1:5, 1:5]
 Now we can plot these results as a heatmap, using the `pheatmap` package. 
 There is a lot of customization we could do here, but `pheatmap` (pretty heatmap) has good defaults, so we won't spend too much time on it for now.
 
-```{r}
+```{r cluster heatmap, live=TRUE}
 # plot with pheatmap
 pheatmap::pheatmap(type_cluster_tab)
 ```
@@ -673,10 +675,11 @@ You can see that the resulting matrix still has the same number of rows we have 
 Now we can apply the same `SingleR` model to these results, using the new matrix as input along with the previously trained model.
 As there are only 20 clusters to classify, this will be very quick, and we don't need to parallelize it!
 
-```{r singler cluster, live = TRUE}
+```{r singler cluster, live=TRUE}
+# run SingleR classification with previously trained model
 singler_cluster <- SingleR::classifySingleR(
-  cluster_mat, 
-  singler_finemodel
+  cluster_mat, # cluster expression matrix
+  singler_finemodel # pre-trained model
 )
 
 # view results
@@ -694,7 +697,7 @@ sce$celltype_cluster <- singler_cluster[sce$nn_cluster, "pruned.labels"]
 
 Now we can plot these cluster-based cell type assignments using the now familiar `plotUMAP()` function
 
-```{r}
+```{r plot cluster celltypes, live=TRUE}
 scater::plotUMAP(sce, colour_by = "celltype_cluster")
 ```
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -407,7 +407,7 @@ The idea is that this set of genes will be the most informative for differentiat
 
 Then, for each cell, `SingleR` calculates the Spearman correlation between expression of that cell and each cell type (using the only the genes chosen earlier).
 Notably, this is a non-parametric correlation, so the scaling and normalization that we apply (or don't) should not matter!
-(But if you have full-length transcripts from another technology, you will probably want to convert to Transcripts per Million (TPM).)
+Note that if you used a single-cell technology that produces full-length transcripts (i.e., SMART-seq), you will probably want to convert your counts to Transcripts per Million (TPM), to allow more consistent ranking among transcripts of different lengths. 
 
 The reference cell type with the highest correlation is then chosen as the cell type assignment for that cell.
 If there are multiple cell types with high scores, an optional fine-tuning step repeats the process using only the most relevant genes for those cell types.
@@ -624,7 +624,7 @@ Since the total number of cells differs across clusters, we'd like to convert th
 
 We'll do this by going through the table column by column and dividing each value by the sum for that cluster.
 To do that, we will use the `apply` function, which allows us to operate on a matrix row by row or column by column, applying a function to each "slice".
-Since the function we want to apply is very short, we will use R's new anonymous function shorthand: 
+Since the function we want to apply is very short, we will use R's new (as of  version 4.1) anonymous function shorthand: 
 `\(x) ...` can be used to define a function that that takes as input values `x` (where the `...` is where you would put the expression to calculate).
 Here we will apply the expression `x/sum(x)`, which will divide each element of a vector `x` by the sum of its values.
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -325,7 +325,7 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 An alternative approach to using known marker genes for classification is to instead classify cells by comparing them to a reference expression dataset.
 To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
 We can then train a model based on this dataset and look at each of the cells in our new dataset to determine which (if any) of the known cell types has the most similar expression pattern.
-The details of how such a model may be constructed and trained will vary by method, but this overall approach is widely applied. 
+The details of how such a model may be constructed and trained will vary by the specific method, but this overall approach is widely applied. 
 
 For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -328,151 +328,267 @@ The details of how such a model may be constructed and trained will vary by meth
 
 For this section, we will focus on the `SingleR` package and its methods, which are described in detail in  [_The SingleR Book_](https://bioconductor.org/books/release/SingleRBook/).
 
-First, we need some reference data.
-Text about importance of reference data goes here!
+### Reference datasets
 
+Selecting a reference dataset is one of the more critical steps for this enterprise.
+At the most basic level, if the reference dataset does not include the types of cells that we expect to see in our sample, it won't be useful.
+So we will want a data set that has as many as possible of the cell types that we expect to see, at a level of specificity that aligns with our goals.
 
-```{r}
-# Don't ask about creating the cache directories, just create them
+For `SingleR` that reference data can be from bulk sequencing or from other single-cell experiments.
+`SingleR` is also fairly robust to the method gene expression quantification, which means that we can use either RNA-seq data sets or microarrays, if those are more readily available. 
+
+One convenient source of cell reference data is the `celldex` package, which is what we will use here.
+This package includes functions to download a variety of well-annotated reference data sets in a common format.  
+For more information on the datasets available, you will want to refer to [the `celldex` summary vignette]( https://bioconductor.org/packages/3.16/data/experiment/vignettes/celldex/inst/doc/userguide.html).
+
+We will start by using a reference dataset of sorted immune cells from [GSE107011 (Monaco _et al._ 2019)](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE107011).
+This particular dataset was chosen as being well suited to PBMC data sets, with a good level of granularity.
+
+The `celldex` functions also have a convenient option to convert gene symbols to Ensembl ids, which we will use here so that our reference data uses the same gene identifiers as the single-cell data.
+
+```{r get monaco}
+# Bioconductor "Hub" packages provide the option to cache
+# downloads, but the interactive prompt can be annoying
+# when working with notebooks.
+# These options disable the prompt, giving permission 
+# to create the cache automatically
 ExperimentHub::setExperimentHubOption("ASK", FALSE)
 AnnotationHub::setAnnotationHubOption("ASK", FALSE)
 
-# Get Data from the Blueprint & Encode projects from celldex
-blueprint_encode <- celldex::BlueprintEncodeData(ensembl = TRUE)
+# Get Monaco 2019 data from celldex with Ensembl ids.
+monaco_ref <- celldex::MonacoImmuneData(ensembl = TRUE)
 ```
-What is this `blueprint_encode` object?
+What is this `monaco_ref` object?
 
-```{r}
-blueprint_encode
+```{r explore ref, live = TRUE}
+monaco_ref
 ```
 
-A `SummarizedExperiment` is very similar to a `SingleCellExperiment`, except rather than having each column as a cell, each column is a sample.
-Otherwise, the components are very similar: each row is still a gene, for example, and additional data about the samples
-are stored in the `colData`.
-In fact, the `SingleCellExperiment` is derived from a `SummarizedExperiment`, with some extra slots that are more relevant to single cell data.
+A `SummarizedExperiment` is very similar to a `SingleCellExperiment`, except rather than having one column per cell, each column is a *sample*.
+Otherwise, the components are very similar: each row is still a gene, for example, and additional data about the samples are stored in the `colData`.
+In fact, the `SingleCellExperiment` object is derived from a `SummarizedExperiment`, with some extra slots that are more relevant to single-cell data.
 
 What information do we have for the samples?
 
-```{r}
-colData(blueprint_encode)
+```{r explore}
+colData(monaco_ref)
 ```
 
-Let's see how many samples of each type we have:
+There are three main columns for the sample data:
+
+- `label.main` is a more general cell type assignment.  
+
+- `label.fine` is a fine-level cell type with more specific labels.
+The exact level of granularity of these `main` and `fine` designations will vary among data sets, so it is important to look at the reference to see whether it is suitable for your application.
+
+- `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier. 
+Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop. 
+
+Another component we would like to explore is how many of each of these cell types we have in the data set. 
+A bit of quick `dplyr` wrangling can give us the answe.
 
 ```{r}
-data.frame(colData(blueprint_encode)) %>% 
+colData(monaco_ref) %>% 
+  as.data.frame() %>%
   dplyr::count(label.main, label.fine)
 ```
 
+This is pretty good! 
+Most cell types have 4 replicates, which is more replicates than we often find.
+
 ### What does `SingleR` do?
 
-`SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new data sets.
-We will show how to separate these results
+`As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new data sets.
 
-This time we will do the training and classification in a single step, using the convenience function `SingleR::SingleR()`.
+`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference data set. 
+It does this by performing pairwise comparisons among all of the cell types, and retaining the top set of genes differentiating each pair.
+The idea is that this set of genes will be the most informative for differentiating cell types.
 
-```{r}
+Then, for each cell, `SingleR` then calculates the Spearman correlation between expression that cell and each cell type (using the only the genes chosen earlier).
+Notably, this is a non-parametric correlation, so the scaling and normalization that we apply (or don't) should not matter!
+(But if you have full-length transcripts from another technology though, you will probably want to convert to Transcripts per Million (TPM).)
+
+The reference cell type with the highest correlation is then chosen as the cell type assignment for that cell.
+If there are multiple cell types with high scores, an optional fine-tuning step repeats the process using only the most relevant genes for those cell types.
+
+
+### Running `SingleR`
+
+For our first run, we will do the marker gene selection (training) and classification in a single step, using the convenience function `SingleR::SingleR()`.
+For this we need only supply three main arguments: Our `sce` object, a reference matrix (here in `SummarizedExperiment` format), and the labels for each of the samples in the reference that we want to use.
+
+Because this function is doing many repeptitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
+This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions. 
+In this case, we will use the argument `BiocParallel::MulticoreParam(4)` to specify we want to use local multicore processing with 4 "workers".
+
+```{r simple SingleR, live=TRUE}
+# calculate SingleR results in one step
 singler_result <- SingleR::SingleR(
-  sce,
-  ref = blueprint_encode,
-  labels = blueprint_encode$label.main
+  sce, # our query SCE
+  ref = monaco_ref, # reference data set
+  labels = monaco_ref$label.main, # reference labels to use
+  BPPARAM = BiocParallel::MulticoreParam(4) # multiprocessing
 )
 ```
 
-Plot the results:
-```{r}
+`SingleR` provides a few nice visualizations for evaluating the statistics it calcualted and the assignments it makes.
+One is a heatmap of the scores for each cell, arranged by the cell type that was assigned to each.
+This is created with the `SingleR::plotScoreHeatmap()` function.
+
+```{r plot SingleR heatmap, live = TRUE}
 SingleR::plotScoreHeatmap(singler_result)
 ```
+We can also  pull out individual components of the results object for plotting in the context of our input SCE object.
+Here we will save the pruned labels (where low-quality assignments have been given an `NA` label), storing them back in our SCE object (specifically to a new column of the `colData` table).
 
 
-```{r}
+
+```{r save celltypes, live=TRUE}
 sce$celltype_main <- singler_result$pruned.labels
 ```
 
-```{r}
-scater::plotUMAP(sce, colour_by = "celltype_main")
+Now we can plot the cell type assignments onto our UMAP to see how they compare to the patterns we saw there before.
+
+```{r plot celltype umap, live=TRUE}
+scater::plotUMAP(sce, colour_by = "celltype_main") 
 ```
+Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices, but this isn't a bad start!
+We seem to have a pretty good set of assignments, with most of the cell type assignments falling into groupings consistent with what we see in the UMAP plot.
 
-This is a pretty clean plot, for which we can thank that this is a PBMC data set.
+We can thank the fact that this is a PBMC sample and that we have a good reference data set for these cell types for the cleanliness of this plot.
+Quite often with other kinds of samples (especially cancer cells!) things will be much less clean!
 
-```{r}
+We can also look to see how the cell type assignments are distributed using the base R function `table()`
+
+```{r cell type table}
 table(singler_result$pruned.labels, useNA = "ifany")
 ```
 
- 
-We can do some cleanup using `forcats`.
+### Exploring finer labels
 
-```{r}
-# combine all of the uncommon cell types
-common_labels <- singler_result$pruned.labels %>%
-  forcats::fct_lump_min(100)
-sce$celltype_common <- common_labels
-```
+In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the data set in a bit more detail. 
+
+We will also take this time to dive a bit deeper into the steps that `SingleR` performed. 
+As mentioned, the first step is training the model, during which we identify the genes that will be used for the correlation analysis later.
+While this step is not particularly slow, if we were classifying multiple samples, we would not want to have to repeat it for every sample.
+
+To do the training, we will use the `trainSingleR()` function. 
+For this we will start with our reference and the labels we want to train the model with.
+
+We can then specify the method used to select the genes that will be used for classification.
+The default method is `"de"`, which performs a differential expression analysis for each pair of labels, but we could also use `"sd"` to select the genes which are most variable across labels, or `"all"` to use all genes.
+If we want to get really fancy, we could even provide a specific list of genes to use.
+
+We also want to be sure that the genes selected will be those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
+This step would happen automatically wiht the `SingleR::SingleR()` function, but we need to add it manually for this use case.
 
 
-```{r}
-scater::plotUMAP(sce, colour_by = "celltype_common")
-```
-
-We can also use the finer-grained cell type data.
-
-If we were classifying multiple samples, we would want to do the training only once!
-
-So let's separate the training from the fitting.
-First fit the model.
-
-```{r}
+```{r train finemodel, live=TRUE}
+# build fine model
 singler_finemodel <- SingleR::trainSingleR(
-  blueprint_encode,
-  labels = blueprint_encode$label.fine,
+  monaco_ref,
+  labels = monaco_ref$label.fine,
   # use DE to select genes (default)
   genes = "de", 
   # only use genes in the sce object
   restrict = rownames(sce),
+  # parallel processing
   BPPARAM = BiocParallel::MulticoreParam(4)
 )
 ```
 
-Now classify the cells based on that model.
+Now we can perform the classification step, using our SCE object and the `SingleR` model that we just created.
 
-```{r}
+```{r classify fine, live=TRUE}
+# classify with fine model
 singler_result_fine <- SingleR::classifySingleR(
   sce,
   singler_finemodel,
+  # perform fine tuning (default)
+  fine.tune = TRUE,
+  # parallel processing
   BPPARAM = BiocParallel::MulticoreParam(4)
 )
 ```
 
 
-What labels were assigned, and how many?
+What labels were assigned, and how many of each?
 
-```{r}
+```{r table fine labels}
 table(singler_result_fine$pruned.labels, useNA = "ifany")
 ```
 
-```{r}
+```{r plot umap fine, live=TRUE}
+# add fine labels to SCE
 sce$celltype_fine <- singler_result_fine$pruned.labels
+# plot UMAP with fine labels
 scater::plotUMAP(sce, colour_by = "celltype_fine")
 ```
 
 That's a pretty messy plot.
-Let's collapse a bit more manually this time. 
+Mostly that is because there are _lots_ of cell types here, and not enough colors to represent them all.
+The `NA` cells also got taken off completely, which is not ideal.
 
-```{r}
+One thing we can do is to use some functions from the `tidyverse` package [`forcats`](https://forcats.tidyverse.org), which can be very handy for dealing with categorical variables like these cell types.
+
+We will use two of these functions in the chunk below: 
+First we will use `fct_collapse` to take some of the finer labels that we might not be as interested in and collapse them into logical groupings (in this case, the `main` label that they were part of).
+After that, we will use `fct_relevel` to put the remaining factor levels in the order we would like them to appear for plotting.
+
+```{r collapse labels}
 collapsed_labels <- singler_result_fine$pruned.labels %>%
   forcats::fct_collapse(
-    "HSC" = c("CLP","CMP", "GMP", "HSC", "Megakaryocytes", "MEP", "MPP"),
-    "B-cells" = c("Class-switched memory B-cells", "Memory B-cells", "naive B-cells", "Plasma cells")
+    "Monocytes" = c(
+        "Classical monocytes", 
+        "Intermediate monocytes", 	
+        "Non classical monocytes"),
+    "Dendritic cells" = c(
+        "Myeloid dendritic cells",
+        "Plasmacytoid dendritic cells"),
+    "T cells" = c(
+        "MAIT cells",
+        "Non-Vd2 gd T cells",
+        "Vd2 gd T cells"),
+    "Helper T cells" = c(
+        "Th1 cells",
+        "Th1/Th17 cells", 
+        "Th17 cells", 
+        "Th2 cells",
+        "Follicular helper T cells"),
+    "B cells" = c(
+        "Naive B cells",
+        "Switched memory B cells",
+        "Non-switched memory B cells",
+        "Exhausted B cells",
+        "Plasmablasts"		
+    )
   ) %>%
-  # Sort all CD4+ labels together at the start
-  forcats::fct_relevel("CD4+ T-cells", "CD4+ Tcm", "CD4+ Tem", "Tregs")
+  # order for plotting
+  forcats::fct_relevel(
+    "Helper T cells",
+    "T regulatory cells",
+    "Naive CD4 T cells",
+    "Terminal effector CD4 T cells",
+    "Naive CD8 T cells",
+    "Central memory CD8 T cells",
+    "Effector memory CD8 T cells",
+    "Terminal effector CD8 T cells",
+    "T cells",
+    "Natural killer cells",
+    "B cells",
+    "Monocytes",
+    "Dendritic cells",
+    "Progenitor cells",
+    "Low-density basophils"
+  )
 ```
 
-Now we plot.
+Now that we have that set up, we can now plot using our collapsed and ordered cell type labels.
 
 ```{r}
 sce$celltype_collapsed <- collapsed_labels
-scater::plotUMAP(sce, colour_by = "celltype_collapsed")
+scater::plotUMAP(sce, 
+                 colour_by = "celltype_collapsed")
 ```
 
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -138,7 +138,7 @@ Note that this PCA matrix and the UMAP built from it were derived from the gene 
 While we have the ADT data, it is _not_ being used for this stage of the analysis.
 
 
-```{r cluster cells}
+```{r cluster cells, live=TRUE}
 # perform clustering
 nn_clusters <- bluster::clusterRows(
   # PCA input
@@ -322,18 +322,18 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 
 ## Cell type annotation with `SingleR`
 
-An alternative approach to using known marker genes for classification is to instead classify cells by way of comparison to a reference dataset.
+An alternative approach to using known marker genes for classification is to instead classify cells by comparing them to a reference expression dataset.
 To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
 We can then train a model based on this dataset and look at each of the cells in our new dataset to determine which (if any) of the known cell types has the most similar expression pattern.
 The details of how such a model may be constructed and trained will vary by method, but this overall approach is widely applied. 
 
-For this section, we will focus on the `SingleR` package and its methods, which are described in detail in  [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
+For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
 
 ### Reference datasets
 
 Selecting a reference dataset is one of the more critical steps for this enterprise.
 At the most basic level, if the reference dataset does not include the types of cells that we expect to see in our sample, it won't be useful.
-So we will want a dataset that has as many as possible of the cell types that we expect to see, at a level of specificity that aligns with our goals.
+So we will want a reference dataset that has as many as possible of the cell types that we expect to find in our dataset, at a level of granularity that aligns with our goals.
 
 For `SingleR` that reference data can be from bulk RNA sequencing or from other single-cell experiments.
 `SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available. 
@@ -371,7 +371,7 @@ In fact, the `SingleCellExperiment` object is derived from a `SummarizedExperime
 
 What information do we have for the samples?
 
-```{r explore reference sample data}
+```{r explore reference sample data, live=TRUE}
 colData(monaco_ref)
 ```
 
@@ -417,6 +417,7 @@ If there are multiple cell types with high scores, an optional fine-tuning step 
 
 For our first run, we will do the marker gene selection (training) and classification in a single step, using the convenience function `SingleR::SingleR()`.
 For this we need only supply three main arguments: Our SCE object, a reference matrix (here in `SummarizedExperiment` format), and the labels for each of the samples in the reference that we want to use.
+We also need to be sure that our sample and the reference data use the same gene IDs, which is why we requested the Ensembl IDs when getting the reference dataset.
 
 Because this function is doing many repetitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
 This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions. 
@@ -439,7 +440,7 @@ This is created with the `SingleR::plotScoreHeatmap()` function.
 ```{r plot SingleR heatmap, live = TRUE}
 SingleR::plotScoreHeatmap(singler_result)
 ```
-We can also  pull out individual components of the results object for plotting in the context of our input SCE object.
+We can also pull out individual components of the results object for plotting in the context of our input SCE object.
 Here we will save the pruned labels (where low-quality assignments have been given an `NA` label), storing them back in our SCE object (specifically to a new column of the `colData` table).
 
 
@@ -453,13 +454,13 @@ Now we can plot the cell type assignments onto our UMAP to see how they compare 
 ```{r plot celltype umap, live=TRUE}
 scater::plotUMAP(sce, colour_by = "celltype_main") 
 ```
-Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices, but this isn't a bad start!
-We seem to have a pretty good set of assignments, with most of the cell type assignments falling into groupings consistent with what we see in the UMAP plot.
+Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices, but this plot isn't a bad start!
+We seem to have a pretty good set of cell type assignments, with most falling into groupings consistent with what we see in the UMAP plot.
 
 We can thank the fact that this is a PBMC sample and that we have a good reference dataset for these cell types for the cleanliness of this plot.
 Quite often with other kinds of samples (especially cancer cells!) things will be much less clean!
 
-We can also look to see how the cell type assignments are distributed using the base R function `table()`
+We can also look to see how the cell type assignments are distributed using the base R function `table()`.
 Since we like to keep track of the cells that ended up as `NA` in the pruned labels, we will include the `useNA = "ifany"` argument.
 
 ```{r cell type table}
@@ -485,7 +486,7 @@ We should note here that the reference dataset for `SingleR` does not need to be
 If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
 You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible. 
 You can even use a previously-annotated SingleCellExperiment as a reference for a new dataset.
-For more details about custom references, see  the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.13/OSCA.basic/cell-type-annotation.html#using-custom-references)
+For more details about custom references, see the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.13/OSCA.basic/cell-type-annotation.html#using-custom-references)
 
 We do want to be sure that the genes selected for the model will be among those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
 This step would happen automatically with the `SingleR::SingleR()` function, but we need to add it manually for this use case.
@@ -618,8 +619,8 @@ type_cluster_tab[1:5, 1:5]
 
 As you can see, this produced a table with rows for each cell type and columns for each cluster number.
 The values are the count of cells for each cluster/cell type combination.
-These raw counts of cells are not quite what we are going to want for visualization. 
-Since the total number of cells in each cluster will vary, we'd like to convert these counts into the proportions of each cell type in each cluster.
+However, these raw counts are not quite what we'll want for visualization. 
+Since the total number of cells differs across clusters, we'd like to convert these counts into the _proportions_ of each cell type in each cluster.
 
 We'll do this by going through the table column by column and dividing each value by the sum for that cluster.
 To do that, we will use the `apply` function, which allows us to operate on a matrix row by row or column by column, applying a function to each "slice".
@@ -658,7 +659,7 @@ If that is the case, then we should be able to combine the data for all cells ac
 This is similar to an approach we will return to later in the context of differential expression. 
 
 The first step here is to create a new matrix where we sum the counts across cells that are from the same type according to our clustering.
-Because `SingleR` is a non-parametric approach, we will perform this step with the raw counts matrix.
+Because `SingleR` is a non-parametric approach, we can perform this step with the raw counts matrix.
 There are a few different ways to do this, but we will use the function `DelayedArray::colsum()`, which can work directly on the sparse matrices that are often found in SCE objects.
 We will provide it with the matrix we need, and then a vector of the cluster assignments for each column of the matrix.
 The function will then sum expression values for each gene across all of the columns that have that value.
@@ -670,7 +671,7 @@ cluster_mat <- DelayedArray::colsum(counts(sce), sce$nn_cluster)
 dim(cluster_mat)
 ```
 
-You can see that the resulting matrix still has the same number of rows we have seen before, but now only has rows for the number of clusters that were assigned.
+You can see that the resulting matrix still has the same number of rows we have seen before, but now only has as many columns as the number of clusters that the cells were assigned to.
 
 Now we can apply the same `SingleR` model to these results, using the new matrix as input along with the previously trained model.
 As there are only 20 clusters to classify, this will be very quick, and we don't need to parallelize it!
@@ -701,7 +702,7 @@ Now we can plot these cluster-based cell type assignments using the now familiar
 scater::plotUMAP(sce, colour_by = "celltype_cluster")
 ```
 
-This sure looks nice, but what have we really done here? 
+This sure looks nice and clean, but what have we really done here? 
 We are _assuming_ that each cluster has only a single cell type, which is a pretty bold assumption, as we really aren't sure that the clusters we created were correct.
 You may recall that clustering algorithms are quite sensitive to parameter choice, so a different parameter choice could quite likely give a different result.
 
@@ -709,7 +710,7 @@ You may recall that clustering algorithms are quite sensitive to parameter choic
 
 As an intermediate step between the potentially messy single-cell cell type assignment and the almost certainly overconfident cluster-based assignment above, we can take an approach inspired by a paper by [Baran _et al._ (2019)](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1812-2) that they called _metacells_. 
 The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters for further analysis. 
-The original paper includes a number of optimizations to make sure that the metacell clusters have desired properties for downstream analysis.
+The original paper includes a number of optimizations to make sure that the metacell clusters have desirable properties for downstream analysis.
 We won't go into that depth here, but we can apply similar ideas.
 
 To begin, we will perform some fine-scale clustering, using a simpler clustering algorithm: K-means clustering.
@@ -754,7 +755,7 @@ What do you think of this plot?
 Is this more or less useful than the original cell-based clustering?
 
 
-### Save results
+## Save results
 
 To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there. 
 Instead we will just write out the cell information table (`colData`) as a TSV file.

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -12,7 +12,10 @@ output:
 
 This notebook will demonstrate how to:
 
-- 
+- Explore data from antibody-derived tags (CITE-seq)
+- Apply simple rule-based classification to identify cell types
+- Identify cell types by similarity to reference datasets with `SingleR`
+- Apply `SingleR` classification to groups of cells
 
 ---
 
@@ -161,7 +164,6 @@ Do they correspond to particular cell types that we are interested in?
 
 Does it bother you that we just used the default nearest-neighbor graph clustering parameters?
 Do you know what those were?
-
 
 ## Investigating cell types
 
@@ -314,7 +316,7 @@ While this technique might be good for some simple experiments, and can be usefu
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/release/bioc/html/AUCell.html).
-For more on that method, the OSCA chapter [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
+For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
 
 
 
@@ -416,7 +418,7 @@ If there are multiple cell types with high scores, an optional fine-tuning step 
 For our first run, we will do the marker gene selection (training) and classification in a single step, using the convenience function `SingleR::SingleR()`.
 For this we need only supply three main arguments: Our `sce` object, a reference matrix (here in `SummarizedExperiment` format), and the labels for each of the samples in the reference that we want to use.
 
-Because this function is doing many repeptitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
+Because this function is doing many repetitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
 This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions. 
 In this case, we will use the argument `BiocParallel::MulticoreParam(4)` to specify we want to use local multicore processing with 4 "workers".
 
@@ -478,7 +480,13 @@ We can then specify the method used to select the genes that will be used for cl
 The default method is `"de"`, which performs a differential expression analysis for each pair of labels, but we could also use `"sd"` to select the genes which are most variable across labels, or `"all"` to use all genes.
 If we want to get really fancy, we could even provide a specific list of genes to use.
 
-We also want to be sure that the genes selected will be those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
+We should note here that the reference dataset for `SingleR` does not need to be from a compendium like `celldex`!
+If you have any well-classified data set that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
+You will want to ensure that the cell types you expect to see are present in the reference data set, and data should be normalized, but otherwise the method can be quite flexible. 
+You can even use a previously-annotated SingleCellExperiment as a reference for a new data set.
+For more details about custom references, see  the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.13/OSCA.basic/cell-type-annotation.html#using-custom-references)
+
+We do want to be sure that the genes selected for the model will be among those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
 This step would happen automatically wiht the `SingleR::SingleR()` function, but we need to add it manually for this use case.
 
 

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -37,7 +37,6 @@ To start, we will load some of the libraries we will need later, and set a rando
 
 ```{r setup}
 # Load libraries
-library(magrittr) # the pipe (%>%) operator
 library(ggplot2) # plotting functions
 library(SingleCellExperiment) # our main class for storing Single Cell data
 
@@ -225,9 +224,9 @@ Because the SCE object stores the assay data matrices in a specialized format, w
 
 ```{r extract ADT}
 # convert logcounts data to a data frame
-adt_df <- logcounts(altExp(sce)) %>%
-  t() %>% # transpose
-  as.matrix() %>% # convert to matrix
+adt_df <- logcounts(altExp(sce)) |>
+  t() |> # transpose
+  as.matrix() |> # convert to matrix
   as.data.frame() # convert to data frame
 
 # view the data frame
@@ -247,13 +246,13 @@ which allows us to convert our data frame with one column per tag into a data fr
 Following conversion, we will filter to just the ADTs that we care about.
 
 ```{r pivot longer, live=TRUE}
-adt_df_long <- adt_df %>%
+adt_df_long <- adt_df |>
   # pivot to long format
   tidyr::pivot_longer(
     everything(), # use all columns
     names_to = "ADT", # convert row names to a column called "ADT"
     values_to = "logcount" # name the value column "logcount"
-  ) %>%
+  ) |>
   # filter to tags we are interested in
   dplyr::filter(ADT %in% c("CD3", "CD4", "CD8"))
 
@@ -282,7 +281,7 @@ The thresholds we are using here were found just "by eye", so this is not a part
 Here we are assigning only three cell types; cells that do not fit any of these criteria will be set as `NA`.
 
 ```{r threshold celltypes}
-adt_df <- adt_df %>%
+adt_df <- adt_df |>
   dplyr::mutate(
     celltype = dplyr::case_when(
       CD3 > 6.7 & CD4 > 8 ~ "CD4+ T-cell",
@@ -388,8 +387,8 @@ Another component we would like to explore is how many of each of these cell typ
 A bit of quick `dplyr` wrangling can give us the answe.
 
 ```{r}
-colData(monaco_ref) %>% 
-  as.data.frame() %>%
+colData(monaco_ref) |> 
+  as.data.frame() |>
   dplyr::count(label.main, label.fine)
 ```
 
@@ -536,7 +535,7 @@ First we will use `fct_collapse` to take some of the finer labels that we might 
 After that, we will use `fct_relevel` to put the remaining factor levels in the order we would like them to appear for plotting.
 
 ```{r collapse labels}
-collapsed_labels <- singler_result_fine$pruned.labels %>%
+collapsed_labels <- singler_result_fine$pruned.labels |>
   forcats::fct_collapse(
     "Monocytes" = c(
         "Classical monocytes", 
@@ -562,7 +561,7 @@ collapsed_labels <- singler_result_fine$pruned.labels %>%
         "Exhausted B cells",
         "Plasmablasts"		
     )
-  ) %>%
+  ) |>
   # order for plotting
   forcats::fct_relevel(
     "Helper T cells",

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -593,29 +593,39 @@ scater::plotUMAP(sce,
 
 ### Heatmap of cell types & clusters
 
+Let's look at how the cell type assignments we have compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
 
-Let's look at how the cell type assignments we have compare to the clusters we found from the data alone.
-
-To do this, we will first use `table` function to build a contingency table of the cell types and clusters that each cell was classified with. 
+To do this, we will first use the very handy base R `table()` function to build a contingency table of the cell types and clusters that each cell was classified with. 
+Since we used the "pruned" cell type assignments and we'd still like to keep track of the cells that ended up as `NA`, we will include the `useNA = "ifany" argument.
 
 ```{r}
 # create a table of clusters & cell type counts
 type_cluster_tab <- table(sce$celltype_fine, sce$nn_cluster, useNA = "ifany")
-type_cluster_tab
+
+# look at the top corner of the results
+type_cluster_tab[1:5, 1:5]
 ```
 
-Since the number of cells in each cluster will vary, we'd like to convert these counts into proportions. 
-We'll do this by dividing each cluster/cell type count by the total number of cells in that cluster.
+As you can see, this produced a table with rows for each cell type and columns for each cluster number.
+The values are the count of cells for each cluster/cell type combination.
+These raw counts of cells are not quite what we are going to want for visualization. 
+Since the total number of cells in each cluster will vary, we'd like to convert these counts into the proportions of each cell type in each cluster.
 
+We'll do this by going through the table column by column and dividing each value by the sum for that cluster.
+To do that, we will use the `apply` function, which allows us to operate on a matrix row by row or column by column, applying a function to each "slice".
+Since the function we want to apply is very short, we will use R's new anonymous function shorthand: 
+`\(x) ...` can be used to define a function that that takes as input values `x` (where the `...` is where you would put the expression to calculate).
+Here we will apply the expression `x/sum(x)`, which will divide each element of a vector `x` by the sum of its values.
 
-```{r}
+```{r normalize by column}
 # normalize by the number of cells in each cluster (columns)
 type_cluster_tab <- apply(
   type_cluster_tab, 
   2, # apply function to columns
-  function(x){x/sum(x)} # function to apply
+  \(x) x/sum(x) # function to apply
 )
-type_cluster_tab
+# print the normalized values
+type_cluster_tab[1:5, 1:5]
 ```
 
 Now we can plot these results as a heatmap, using the `pheatmap` package. 
@@ -626,89 +636,116 @@ There is a lot of customization we could do here, but `pheatmap` (pretty heatmap
 pheatmap::pheatmap(type_cluster_tab)
 ```
 
-
+We can see that most of our clusters are indeed defined by a single cell type, though there are some clusters (e.g., 1 & 9) that have a number of (related) cell types within them.
+There are also some places where single cell types are spread across a few different clusters (Classical monocytes, for example).
 
 ### Classifying by clusters
 
-This section inspired by the fact that `SingleR()` has a `clusters` argument.
+While most of the time we will want to classify single cells, sometimes the sparseness of the data may mean that individual cells do not provide reliable estimates of cell types. 
 
-First we will make a new matrix where we sum the counts across cells that are from the same type according to our clustering.
-The idea here is that we can reduce noise by combining a bunch of cells.
+An alternative approach is to classify the clusters as a whole, assuming that the clusters we have identified represent a single cell state.
+If that is the case, then we should be able to combine the data for all cells across each cluster, then apply our cell typing method to this group of cells. 
+This is similar to an approach we will return to later in the context of differential expression. 
 
-Note that in this case we are using raw counts. 
-`SingleR` is non-parametric, so it shouldn't matter! 
-(And adding log values felt bad.)
+The first step here is to create a new matrix where we sum the counts across cells that are from the same type according to our clustering.
+Because `SingleR` is a non-parametric approach, we will perform this step with the raw counts matrix.
+There are a few different ways to do this, but we will use the function `DelayedArray::colsum()`, which can work directly on the sparse matrices that are often found in SCE objects.
+We will provide it with the matrix we need, and then a vector of the cluster assignments for each column of the matrix.
+The function will then sum expression values for each gene across all of the columns that have that value.
 
-```{r}
-sce_cluster_mat <- DelayedArray::colsum(counts(sce), sce$nn_cluster)
-dim(sce_cluster_mat)
+```{r sum clusters}
+# sum count matrix by cluster
+cluster_mat <- DelayedArray::colsum(counts(sce), sce$nn_cluster)
+# print new dimensions
+dim(cluster_mat)
 ```
 
-```{r}
-singler_result_cluster <- SingleR::classifySingleR(
-  sce_cluster_mat, 
+You can see that the resulting matrix still has the same number of rows we have seen before, but now only has rows for the number of clusters that were assigned.
+
+Now we can apply the same `SingleR` model to these results, using the new matrix as input along with the previously trained model.
+As there are only 20 clusters to classify, this will be very quick, and we don't need to parallelize it!
+
+```{r singler cluster, live = true}
+singler_cluster <- SingleR::classifySingleR(
+  cluster_mat, 
   singler_finemodel
 )
+
+# view results
+head(singler_cluster)
 ```
 
-```{r}
-singler_result_cluster$labels
-```
-Add cluster labels to individual cells.
+The result is a fairly small table of results, but we are interested most in the labels, which we would like to assign back to our SCE object cell by cell for visualization.
+Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to. 
+(In this case the cluster names are all numbers, but that might not always be the case.)
+We'll select values repeatedly from the `singler_cluster` table, using the cluster assignment to pick a row, and then always picking the `pruned.labels` column.
 
-```{r}
-sce$celltype_cluster <- singler_result_cluster$labels[sce$nn_cluster]
+```{r assign cell labels}
+sce$celltype_cluster <- singler_cluster[sce$nn_cluster, "pruned.labels"]
 ```
 
-Plot with cluster labels.
+Now we can plot these cluster-based cell type assignments using the now familiar `plotUMAP()` function
 
 ```{r}
 scater::plotUMAP(sce, colour_by = "celltype_cluster")
 ```
 
-This sure looks nice, but what have we done here? 
-We are _assuming_ that each cluster has only a single cell type!
+This sure looks nice, but what have we really done here? 
+We are _assuming_ that each cluster has only a single cell type, which is a pretty bold assumption, as we really aren't sure that the clusters we created were correct.
+You may recall that clustering algorithms are quite sensitive to parameter choice, so a different parameter choice could quite likely give a different result.
 
+### MetaCell approaches
 
-### MetaCell-like
+As an intermediate step between the potentially messy single-cell cell type assignment and the almost certainly overconfident cluster-based assignment above, we can take an approach inspired by a paper by [Baran _et al._ (2019)](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1812-2) that they called _metacells_. 
+The idea is that we can perform fine-scaled clustering to identify groups of similar very similar cells, then sum the counts within those clusters  for further analysis. 
+The original paper includes a number of optimizations to make sure that the metacell clusters have desired properties for downstream analysis.
+We won't go into that depth here, but we can apply similar ideas.
 
-Inspired by https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1812-2 
-(I may refine to match methods better, but maybe this is good enough?)
+To begin, we will perform some fine-scale clustering, using a simpler clustering algorithm: K-means clustering.
+We will use the same `bluster` package, clustering based on the PCA results we have from earlier, but this algorithm allows us to specify the number of clusters we want to end up with.
+We have  about 8000 cells, so let's cluster those into groups of approximately 80 cells, which works out to 100 clusters.
+While this is almost certainly more clusters than are "real" in this data set, our goal here is not to find differences among clusters, just to get homogeneous groups of cells.
 
-Alternatively cluster cells with a fast algorithm to find neighbors, then assign types to those. 
-We have ~8000 cells, so lets cluster those into groups of ~40 cells, which means we want to make about 200 clusters.
-
-A quick way to do this is with k-means clustering.
-
-```{r}
+```{r kmeans cluster}
+# perform k-means clustering
 kclusters <- bluster::clusterRows(
   reducedDim(sce, "PCA"), 
   bluster::KmeansParam(
-    centers = 200,
+    centers = 100, # the number of clusters 
     iter.max = 100 # more iterations to be sure of convergence
   )
 )
 ```
 
-Now apply the same procedure, using these clusters:
+Now we can apply exactly the same approach we did when we had the 20 clusters we had identified with the earlier graph-based clustering.
 
-```{r}
-kcluster_mat <- DelayedArray::colsum(counts(sce), kclusters)
-kcluster_result <- SingleR::classifySingleR(
-  kcluster_mat, 
+```{r metacell singler}
+# create a "metacell" matrix by summing fine-scale clusters
+metacell_mat <- DelayedArray::colsum(counts(sce), kclusters)
+
+# apply SingleR model to metacell matrix
+metacell_singler <- SingleR::classifySingleR(
+  metacell_mat, 
   singler_finemodel
-  )
+)
 
-sce$celltype_kcluster <- kcluster_result$labels[kclusters]
+# apply metacell cell type assignments to individual cells
+sce$celltype_metacell <- metacell_singler[kclusters, "pruned.labels"]
 ```
 
-```{r}
-scater::plotUMAP(sce, colour_by = "celltype_kcluster")
+Now we can plot the results as we have done before.
+
+```{r metacell umap}
+scater::plotUMAP(sce, colour_by = "celltype_metacell")
 ```
+
+What do you think of this plot? 
+Is this more or less useful than the original cell-based clustering?
+
 
 ### Save results
 
-To save space, we won't write out the whole SCE object, as we haven't changed any of the core data there. 
+To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there. 
 Instead we will just write out the cell information table (`colData`) as a TSV file.
 
 ```{r save sce}

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -322,28 +322,28 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 
 ## Cell type annotation with `SingleR`
 
-An alternative approach to using known marker genes for classification is to instead classify cells by way of comparison to a known dataset.
+An alternative approach to using known marker genes for classification is to instead classify cells by way of comparison to a reference dataset.
 To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
-We can then train a model based on this data set, and then look at each of the cells in our new data set to determine which (if any) of the known cell types has the most similar expression pattern.
+We can then train a model based on this data set and look at each of the cells in our new data set to determine which (if any) of the known cell types has the most similar expression pattern.
 The details of how such a model may be constructed and trained will vary by method, but this overall approach is widely applied. 
 
-For this section, we will focus on the `SingleR` package and its methods, which are described in detail in  [_The SingleR Book_](https://bioconductor.org/books/release/SingleRBook/).
+For this section, we will focus on the `SingleR` package and its methods, which are described in detail in  [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
 
 ### Reference datasets
 
 Selecting a reference dataset is one of the more critical steps for this enterprise.
 At the most basic level, if the reference dataset does not include the types of cells that we expect to see in our sample, it won't be useful.
-So we will want a data set that has as many as possible of the cell types that we expect to see, at a level of specificity that aligns with our goals.
+So we will want a dataset that has as many as possible of the cell types that we expect to see, at a level of specificity that aligns with our goals.
 
-For `SingleR` that reference data can be from bulk sequencing or from other single-cell experiments.
-`SingleR` is also fairly robust to the method gene expression quantification, which means that we can use either RNA-seq data sets or microarrays, if those are more readily available. 
+For `SingleR` that reference data can be from bulk RNA sequencing or from other single-cell experiments.
+`SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available. 
 
 One convenient source of cell reference data is the `celldex` package, which is what we will use here.
 This package includes functions to download a variety of well-annotated reference data sets in a common format.  
-For more information on the datasets available, you will want to refer to [the `celldex` summary vignette]( https://bioconductor.org/packages/3.16/data/experiment/vignettes/celldex/inst/doc/userguide.html).
+For more information on the datasets available, you will want to refer to [the `celldex` summary vignette](https://bioconductor.org/packages/3.16/data/experiment/vignettes/celldex/inst/doc/userguide.html).
 
 We will start by using a reference dataset of sorted immune cells from [GSE107011 (Monaco _et al._ 2019)](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE107011).
-This particular dataset was chosen as being well suited to PBMC data sets, with a good level of granularity.
+This particular reference was chosen because it is well-suited to PBMC datasets, with a good level of granularity.
 
 The `celldex` functions also have a convenient option to convert gene symbols to Ensembl ids, which we will use here so that our reference data uses the same gene identifiers as the single-cell data.
 
@@ -351,7 +351,7 @@ The `celldex` functions also have a convenient option to convert gene symbols to
 # Bioconductor "Hub" packages provide the option to cache
 # downloads, but the interactive prompt can be annoying
 # when working with notebooks.
-# These options disable the prompt, giving permission 
+# These options disable the prompt by giving permission 
 # to create the cache automatically
 ExperimentHub::setExperimentHubOption("ASK", FALSE)
 AnnotationHub::setAnnotationHubOption("ASK", FALSE)
@@ -380,7 +380,7 @@ There are three main columns for the sample data:
 - `label.main` is a more general cell type assignment.  
 
 - `label.fine` is a fine-level cell type with more specific labels.
-The exact level of granularity of these `main` and `fine` designations will vary among data sets, so it is important to look at the reference to see whether it is suitable for your application.
+The exact level of granularity of these `main` and `fine` designations (and indeed the label names themselves) will vary among data sets, so it is important to look at the reference to see whether it is suitable for your application.
 
 - `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier. 
 Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop. 
@@ -405,9 +405,9 @@ As mentioned earlier, `SingleR` builds a model from a set of training data, and 
 It does this by performing pairwise comparisons among all of the cell types, and retaining the top set of genes differentiating each pair.
 The idea is that this set of genes will be the most informative for differentiating cell types.
 
-Then, for each cell, `SingleR` then calculates the Spearman correlation between expression that cell and each cell type (using the only the genes chosen earlier).
+Then, for each cell, `SingleR` calculates the Spearman correlation between expression of that cell and each cell type (using the only the genes chosen earlier).
 Notably, this is a non-parametric correlation, so the scaling and normalization that we apply (or don't) should not matter!
-(But if you have full-length transcripts from another technology though, you will probably want to convert to Transcripts per Million (TPM).)
+(But if you have full-length transcripts from another technology, you will probably want to convert to Transcripts per Million (TPM).)
 
 The reference cell type with the highest correlation is then chosen as the cell type assignment for that cell.
 If there are multiple cell types with high scores, an optional fine-tuning step repeats the process using only the most relevant genes for those cell types.
@@ -482,8 +482,8 @@ The default method is `"de"`, which performs a differential expression analysis 
 If we want to get really fancy, we could even provide a specific list of genes to use.
 
 We should note here that the reference dataset for `SingleR` does not need to be from a compendium like `celldex`!
-If you have any well-classified data set that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
-You will want to ensure that the cell types you expect to see are present in the reference data set, and data should be normalized, but otherwise the method can be quite flexible. 
+If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
+You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible. 
 You can even use a previously-annotated SingleCellExperiment as a reference for a new data set.
 For more details about custom references, see  the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.13/OSCA.basic/cell-type-annotation.html#using-custom-references)
 
@@ -591,7 +591,7 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
   )
 ```
 
-Now that we have that set up, we can now plot using our collapsed and ordered cell type labels.
+Now that we have that set up, we can plot using our collapsed and ordered cell type labels.
 
 ```{r}
 sce$celltype_collapsed <- collapsed_labels
@@ -602,7 +602,7 @@ scater::plotUMAP(sce,
 
 ### Heatmap of cell types & clusters
 
-Let's look at how the cell type assignments we have compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
+Let's look at how the cell type assignments we obtained using `SingleR` compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
 
 To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with. 
 
@@ -683,7 +683,7 @@ singler_cluster <- SingleR::classifySingleR(
 head(singler_cluster)
 ```
 
-The result is a fairly small table of results, but we are interested most in the labels, which we would like to assign back to our SCE object cell by cell for visualization.
+The result is a fairly small table of results, but we are most interested in the labels, which we would like to associate with each cell in our SCE object for visualization.
 Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to. 
 (In this case the cluster names are all numbers, but that might not always be the case.)
 We'll select values repeatedly from the `singler_cluster` table, using the cluster assignment to pick a row, and then always picking the `pruned.labels` column.
@@ -705,13 +705,13 @@ You may recall that clustering algorithms are quite sensitive to parameter choic
 ### MetaCell approaches
 
 As an intermediate step between the potentially messy single-cell cell type assignment and the almost certainly overconfident cluster-based assignment above, we can take an approach inspired by a paper by [Baran _et al._ (2019)](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1812-2) that they called _metacells_. 
-The idea is that we can perform fine-scaled clustering to identify groups of similar very similar cells, then sum the counts within those clusters  for further analysis. 
+The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters for further analysis. 
 The original paper includes a number of optimizations to make sure that the metacell clusters have desired properties for downstream analysis.
 We won't go into that depth here, but we can apply similar ideas.
 
 To begin, we will perform some fine-scale clustering, using a simpler clustering algorithm: K-means clustering.
 We will use the same `bluster` package, clustering based on the PCA results we have from earlier, but this algorithm allows us to specify the number of clusters we want to end up with.
-We have  about 8000 cells, so let's cluster those into groups of approximately 80 cells, which works out to 100 clusters.
+We have about 8000 cells, so let's cluster those into groups of approximately 80 cells, which works out to 100 clusters.
 While this is almost certainly more clusters than are "real" in this data set, our goal here is not to find differences among clusters, just to get homogeneous groups of cells.
 
 ```{r kmeans cluster}


### PR DESCRIPTION
This PR hopefully completes the Cell Typing instruction notebook, closing #567.

I added a fair amount of text, but also made a few other modifications, like switching the reference data set to the one that celldex specifically recommends for PBMCs. This meant a few changes to the ways I used `forcats`... Nothing too major, but that chunk got a lot longer. 

Other than that, a few smaller changes, but nothing too major. I briefly contemplating using `scater::ggcells()` to allow for easier customization of the plots (in particular color schemes), but decided to leave it as is for now. That didn't seem worth getting too hung up about. If somebody asks, we might want to have that in our back pockets though!

I do update to using `|>` throughout as well, and tried a brief explanation of `\(x) x/sum(x)` but probably failed there. 

I have also designated as `live` the chunks I think I will want to type live (notably not the refactoring!). If there are others that seem worth enlivening, please suggest!

Otherwise, I look forward to hearing what you think


