### PR TITLE
Integration notebook: live chunks, pipe, and cleanups

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -409,6 +409,7 @@ UPGMA
 UpSet
 vaccinee
 vectorization
+vectorized
 versicolor
 virginica
 VST

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -27,8 +27,8 @@ Specifically, we'll have a look at four samples from the [`SCPCP000005` project]
 The particular libraries we'll integrate come from two rhabdomyosarcoma (RMS) patients, with two samples from each of two patients, all sequenced with 10Xv3 technology.
 Each library is from a separate biological sample.
 
-We'll be integrating these libraries with two different tools, [`fastMNN`](http://www.bioconductor.org/packages/release/bioc/html/batchelor.html) ([Haghverdi _et al._ (2018)](https://doi.org/10.1038/nbt.4091)) and [`harmony`](https://portals.broadinstitute.org/harmony/) ([Korsunsky _et al._ (2019)](https://doi.org/10.1038/s41592-019-0619-0)). 
-Integration corrects for batch effects that arise from different library preparations, genetic backgrounds, and other sample-specific factors, so that datasets can be jointly analyzed. 
+We'll be integrating these samples with two different tools, [`fastMNN`](http://www.bioconductor.org/packages/release/bioc/html/batchelor.html) ([Haghverdi _et al._ (2018)](https://doi.org/10.1038/nbt.4091)) and [`harmony`](https://portals.broadinstitute.org/harmony/) ([Korsunsky _et al._ (2019)](https://doi.org/10.1038/s41592-019-0619-0)). 
+Integration corrects for batch effects that arise from different library preparations, genetic backgrounds, and other sample-specific factors, so that datasets can be jointly analyzed at the cell-level. 
 `fastMNN` corrects for batch effects using a faster variant of the mutual-nearest neighbors algorithm, the technical details of which you can learn more about from this [vignette by Lun (2019)](https://marionilab.github.io/FurtherMNN2018/theory/description.html).
 `harmony`, on the other hand, corrects for batch effects using an iterative clustering approach, and unlike `fastMNN`, it is also able to consider additional covariates beyond just the batch groupings.
 
@@ -79,7 +79,7 @@ integrated_sce_file <- file.path(output_dir, "rms_integrated_subset.rds")
 
 We can use the `dir()` function to list all contents of a given directory, for example to see all the files in our `input_dir`:
 
-```{r input_dir}
+```{r input_dir, live = TRUE}
 dir(input_dir)
 ```
 
@@ -103,8 +103,10 @@ purrr::map(<input vector or list>,
 
 Let's see a very simple example in action by quickly taking the square root of a vector of values:
 
-```{r map_example}
-squares <- c(4, 9, 16, 25, 36)
+```{r map_example, life = TRUE}
+
+# Define a vector of squares
+squares <- c(4, 9, 16)
 
 # get the square root of each number without purrr
 sqrt(squares[1])
@@ -118,13 +120,13 @@ purrr::map(squares, # vector to map over
 
 The output from running `purr::map()` is always a list (but note that there are other `purrr::map()` relatives which return other object types, as you can read about in [the `purrr::map()` documentation](https://purrr.tidyverse.org/reference/index.html)).
 
-We'll note that, in this case, it's possible to simply run `sqrt()` directly on the `squares` vector itself:
+We'll note that, in this case, it's possible to simply run `sqrt()` directly on the `squares` vector itself since this function is already vectorized, but not all functions behave this way.
 
 ```{r quick_squares}
 sqrt(squares)
 ```
 
-But more involved scenarios (as we'll see!) will necessitate the use of `map()`, in particular when the input is a list itself.
+More involved scenarios as we'll see shortly will necessitate the use of `map()`, in particular when the input is a list itself.
 
 
 One other new coding strategy we'll learn in this notebook is using the [`glue`](https://glue.tidyverse.org/) package to combine strings.
@@ -174,10 +176,11 @@ sce_paths <- file.path(input_dir,
 sce_paths
 ```
 
-We can now read these files in and create a list of four SCE objects:
+We can now read these files in and create a list of four SCE objects.
+Since `readr::read_rds()` can only operate on one input at a time (unlike `sqrt()` which can operate across a vector), we'll need to use `purrr::map()` to run in simultaneously on all input file paths.
 
 ```{r read_sce_paths, live = TRUE}
-# Use purrr::map() to read all files into a list at once:
+# Use purrr::map() to read all files into a list at once
 sce_list <- purrr::map(
   sce_paths, 
   readr::read_rds
@@ -185,6 +188,7 @@ sce_list <- purrr::map(
 ```
 
 Let's have a look at our list of SCE objects:
+
 ```{r print_sce_list, live=TRUE}
 # Print sce_list
 sce_list
@@ -204,11 +208,11 @@ sce_list
 ```
 
 If you look closely at the printed SCE objects, you may notice that they all contain `colData` table columns `celltype_fine` and `celltype_broad`.
-These columns (which we added to SCE objects during pre-processing) contain putative _cell type annotations_ as assigned in [Patel _et al._ (2022)](https://doi.org/10.1016/j.devcel.2022.04.003). 
+These columns (which we added to SCE objects during [pre-processing](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq-advanced/setup/rms)) contain putative _cell type annotations_ as assigned in [Patel _et al._ (2022)](https://doi.org/10.1016/j.devcel.2022.04.003). 
 We will end up leveraging these cell type annotations to explore how successful our integration is; after integration, we expect cell types from different samples to group together, rather than being separated by batches. 
 
 That said, the integration methods we will be applying _do not actually use_ these cell type annotations.
-If we have annotations, they are a helpful "bonus" for assessing the integration's success, but they are not part of the procedure itself.
+If we have annotations, they are a helpful "bonus" for assessing the integration's success, but they are not part of the integration itself.
 
 
 ## Prepare the SCE list for integration
@@ -222,7 +226,8 @@ Overall we'll want to take care of these items:
 
 1. We should be able to trace sample-specific information back to the originating sample, including...
     - Cell-level information: Which sample is each cell from? 
-    - Library-specific feature statistics, e.g. gene-level statistics for a given library found in `rowData`
+    - Library-specific feature statistics, e.g. gene-level statistics for a given library found in `rowData`.
+    Which sample is a given feature statistic from?
 2. SCE objects should contain the same genes: Each SCE object should have the same row names.
 3. SCE cell metadata columns should match: The `colData` for each SCE object should have the same column names.
 
@@ -238,15 +243,15 @@ How will we be able to tell which sample a given cell came from?
 
 The best way to do this is simply to add a `colData` column with the sample information, so that we can know which sample each row came from.
 
-In addition, we want to pay some attention to the SCE object's column names (the cell ids), which must remain unique after merging since duplicate ids will cause an R error.
+In addition, we want to pay some attention to the SCE object's column names (the cell IDs), which must remain unique after merging since duplicate IDs will cause an R error.
 In this case, the SCE column names are barcodes (which is usually but not always the case in SCE objects), which are only guaranteed to be unique _within_ a sample but may be repeated across samples.
 So, after merging, it's technically possible that multiple cells will have the same barcode.
 This would be a problem for two reasons: 
-First, the cell id would not be able to point us back to cell's originating sample.
+First, the cell ID would not be able to point us back to cell's originating sample.
 Second, it would literally cause an error in R, which does not allow duplicate column names.
 
 
-One way to ensure that cell ids remain unique even after merging is to actually modify them by _prepending_ the relevant sample name. 
+One way to ensure that cell IDs remain unique even after merging is to actually modify them by _prepending_ the relevant sample name. 
 For example, consider these barcodes for the `SCPCL000479` sample:
 
 ```{r barcodes, live = TRUE}
@@ -256,7 +261,7 @@ colnames(sce_list$SCPCL000479) |>
   head()
 ```
 
-These IDs will be updated `SCPCL000479-GGGACCTCAAGCGGAT`, `SCPCL000479-CACAGATAGTGAGTGC`, and so on, thereby ensuring fully unique ids for all cells across all samples.
+These IDs will be updated `SCPCL000479-GGGACCTCAAGCGGAT`, `SCPCL000479-CACAGATAGTGAGTGC`, and so on, thereby ensuring fully unique IDs for all cells across all samples.
 
 #### Preserving sample information at the gene level
 
@@ -270,7 +275,7 @@ rowData(sce_list$SCPCL000479) |>
 Here, the rownames are Ensembl gene IDs, and columns are `gene_symbol`, `mean`, and `detected`. 
 The `gene_symbol` column is general information about all genes, not specific to any library or experiment, but `mean` and `detected` are library-specific gene statistics. 
 So, `gene_symbol` does not need to be traced back to its originating sample, but `mean` and `detected` do.
-To this end, we can take a similar approach to what we'll do for cell ids: 
+To this end, we can take a similar approach to what we'll do for cell IDs: 
 We can change the sample-specific `rowData` column names by prepending the sample name.
 For example, rather than being called `mean`, this column will be named `SCPCL000478-mean` for the `SCPCL000478` sample.
 
@@ -288,7 +293,7 @@ purrr::map(sce_list,
 #### Ensuring that only shared genes are used
 
 The next step in ensuring SCE compatibility is to make sure they all contain the same genes, which are stored as the SCE object's row names (these names are also found the `rowData` slot's row names). 
-Here, those gene ids are unique Ensembl gene ids.
+Here, those gene IDs are unique Ensembl gene IDs.
 
 We can use some `purrr` magic to quickly find the set of shared genes among our samples:
 
@@ -307,7 +312,7 @@ head(shared_genes)
 ```
 
 In this case, we happen to know that all SCE objects we're working with already contained the same genes. 
-We can quickly confirm that this is true by looking at the number of rows across SCE objects, and we'll see that they are all the same:
+We do a quick-and-dirty check for this by looking at the number of rows across SCE objects, and we'll see that they are all the same:
 
 ```{r check_shared_genes, live = TRUE}
 # The number of genes in an SCE corresponds to its number of rows:
@@ -340,10 +345,11 @@ Based on our exploration, here is a schematic of how one of the SCE objects will
 
 
 We'll write a _custom function_ (seen in the chunk below) tailored to our wrangling steps that prepares a single SCE object for merging.
-We'll then use our new `purrr::map()` programming skills to run this function over the `sce_list` to end up with a formatted version of `sce_list` that we can merge.
-It's important to remember that this is not a function for general use - it's been precisely written to match the processing we need to do for _these_ SCEs, and different SCEs in the wild will require different types of processing.
+We'll then use our new `purrr::map()` programming skills to run this function over the `sce_list`.
+This will give us a new list of formatted SCEs that we can proceed to merge.
+It's important to remember that the `format_sce()` function written below is not a function for general use - it's been precisely written to match the processing we need to do for _these_ SCEs, and different SCEs in the wild will require different types of processing.
 
-```{r format_, live = TRUEfunction}
+```{r format_sce_function, live = TRUE}
 format_sce <- function(sce, sample_name) {
   # Input arguments:
   ## sce: An SCE object to format
@@ -356,8 +362,8 @@ format_sce <- function(sce, sample_name) {
   sce$sample <- sample_name
   
   
-  ###### Ensure cell ids will be unique ######
-  # Update the SCE object column names (cell ids) by prepending `sample_name`
+  ###### Ensure cell IDs will be unique ######
+  # Update the SCE object column names (cell IDs) by prepending `sample_name`
  colnames(sce) <- glue::glue("{sample_name}-{colnames(sce)}")
         
   
@@ -396,8 +402,7 @@ sce_list_formatted
 (Psst, like `purrr` and want to dive deeper? Check out [the `purrr::imap()` function](https://purrr.tidyverse.org/reference/imap.html)!)
 
 
-At long last, we are ready to merge the SCEs!
-We'll use the R function `cbind()` for this.
+At long last, we are ready to merge the SCEs, which we'll do using the R function `cbind()`.
 The `cbind()` function is often used to combine data frames or matrices by column, i.e. "stack" them next to each other.
 The same principle applies here, but when run on SCE objects, `cbind()` will create a new SCE object by combining `counts` and `logcounts` matrices by column.
 Following that structure, other SCE slots (`colData`, `rowData`, reduced dimensions, and other metadata) are combined appropriately.
@@ -411,7 +416,7 @@ merged_sce <- do.call(cbind, sce_list_formatted)
 
 
 ```{r print_merged_sce, live = TRUE}
-# Print the merged_sce
+# Print the merged_sce object
 merged_sce
 ```
 
@@ -423,7 +428,7 @@ Let's take a peek at some of the innards of this new SCE object:
 # What are the unique values in the `sample` column?
 unique( colData(merged_sce)$sample )
 
-# What are the new cell ids (column names)?
+# What are the new cell IDs (column names)?
 head( colnames(merged_sce) )
 
 # What does rowData look like?
@@ -435,9 +440,8 @@ head( rowData(merged_sce) )
 
 So far, we've created a `merged_sce` object which is (almost!) ready for integration.
 
-The integration methods we'll be using here actually perform batch correction on a reduced dimension representation of the normalized gene expression values.
-`fastMNN` and `harmony` specifically use PCA for this, but be aware that different integration methods may use other kinds of reduced dimensions!
-The main reason for using reduced dimensions is efficiency.
+The integration methods we'll be using here actually perform batch correction on a reduced dimension representation of the normalized gene expression values, which is more efficient.
+`fastMNN` and `harmony` specifically use PCA for this, but be aware that different integration methods may use other kinds of reduced dimensions.
 
 You'll notice that the merged SCE object object already contains PCA and UMAP reduced dimensions, which were calculated during our pre-processing:
 
@@ -450,7 +454,7 @@ These represent the original dimension reductions that were performed on _each i
 
 Why can't we use the sample-specific PCA and UMAP matrices? 
 Part of these calculations themselves involves scaling the raw data to center the mean.
-When samples are separately centered but plotting together, you will see samples "overlapping" in space, but this placement is an artifact of the individual centering.
+When samples are separately centered but plotting together, you will see samples "overlapping" in space, but this placement is actually just an artifact of the individual centering.
 In addition, the mathematical relationship between the original expression data and reduced dimension version of that data will differ across samples, meaning we can't interpret them all together.
 To see how this looks, let's look at the UMAP when calculated from individual samples:
 
@@ -572,13 +576,14 @@ What similarities do you think the integrated UMAP will have to this plot?
 
 ### Integration with `fastMNN`
 
-Finally, we're ready to integrate!
+Finally, we're ready to integrate.
 To start, we'll use the `fastMNN` approach from the Bioconductor [`batchelor` package](http://www.bioconductor.org/packages/3.16/bioc/html/batchelor.html).
 
-`fastMNN` takes as input the `merged_sce` object to integrate, and the first step it performs is actually to run `batchelor::multiBatchPCA()` on that SCE!
-It then uses that PCA matrix to perform the actual batch correction.
+`fastMNN` takes as input the `merged_sce` object to integrate, and the first step it performs is actually to run `batchelor::multiBatchPCA()` on that SCE.
+It then uses that batch-weighted PCA matrix to perform the actual batch correction.
 The `batch` argument is used to specify the different groupings within the `merged_sce` (i.e. the original sample that each cell belongs to), and the `subset.row` argument can optionally be used to provide a vector of high-variance genes that should be considered for this PCA calculation.
 `fastMNN` will return an SCE object that contains a batch-corrected PCA.
+Let's run it and save the result to a variable called `integrated_sce`.
 
 
 ```{r run_fastmnn, live = TRUE}
@@ -596,6 +601,7 @@ integrated_sce <- batchelor::fastMNN(
 Let's have a look at the result:
 
 ```{r fastmnn_result, live = TRUE}
+# Print the integrated_sce object
 integrated_sce
 ```
 
@@ -603,10 +609,10 @@ There are couple pieces of information here of interest:
 
 - The `corrected` reduced dimension represents the batch-corrected PCA that `fastMNN` calculated. 
 - The `reconstructed` assay represents the batch-corrected normalized expression values, which `fastMNN` "back-calculated" from the batch-corrected PCA (`corrected`).
-Generally speaking, these expression values are not stand-alone values that you should use for other applications like differential gene expression.
-If the `subset.row` argument was provided (as it was here), only genes present in `subset.row` are included in these reconstructed expression values, but this can be overridden so that all genes have reconstructed expression with the argument `correct.all = TRUE`.
+Generally speaking, these expression values are not stand-alone values that you should use for other applications like differential gene expression, as described in [_Orchestrating Single Cell Analyses_](http://bioconductor.org/books/3.16/OSCA.multisample/using-corrected-values.html).
+If the `subset.row` argument is provided (as it was here), only genes present in `subset.row` will be included in these reconstructed expression values, but this setting can be overridden so that all genes have reconstructed expression with the argument `correct.all = TRUE`.
 
-We're mostly interested in the PCA that `fastMNN` calculated, so let's save that information (with an informative and unique name!) into our `merged_sce` object:
+We're mostly interested in the PCA that `fastMNN` calculated, so let's save that information (with an informative and unique name) into our `merged_sce` object:
 
 ```{r fastmnn_pcs, live = TRUE}
 # Make a new reducedDim named fastmnn_PCA from the corrected reducedDim in integrated_sce
@@ -655,7 +661,7 @@ Recall from earlier that we conveniently have cell type annotations in our SCEs,
 Let's take a quick detour to see what kinds of cell types are in this data by making a barplot of the cell types across samples:
 
 ```{r explore_celltypes, live = TRUE}
-# Cell types are stored in the `celltype_broad` and `celltype_fine` columns in the SCE
+# Cell types are in the `celltype_broad` and `celltype_fine` columns
 merged_sce_df <-  as.data.frame(colData(merged_sce)) 
 
 # Use ggplot2 to make a barplot the cell types across samples 
@@ -701,27 +707,28 @@ scater::plotReducedDim(merged_sce,
                        point_size = 0.5,
                        point_alpha = 0.2,
                        # Allow for faceting by a variable using `other_fields`:
-                       other_fields = "celltype_broad") +
+                       other_fields = "sample") +
   guides(colour = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP after integration with fastMNN") +
-  # Facet by celltype_broad
-  facet_wrap(vars(celltype_broad)) +
+  # Facet by sample
+  facet_wrap(vars(sample)) +
   # Use a theme with background grid to more easily compare panel coordinates
   theme_bw() 
 ```
 
-All `Tumor` cell types appear to group with one another, with the main exception of `Tumor_Mesoderm` (along with what looks like one `Tumor_Myoblast` cell) for which a small number of cells are located with healthy muscle tissue.
+What trends do you observe between Tumor and healthy tissues among these integrated samples?
+
 
 ### Integration with `harmony`
 
-`fastMNN` is only one of many approaches to perform integration, and different methods have different capabilities and are not unlikely to give different results.
-For example, some methods can accommodate additional covariates (e.g., technology, patient, diagnosis, etc.) that may influence integration. 
+`fastMNN` is only one of many approaches to perform integration, and different methods have different capabilities and may give different results.
+For example, some methods can accommodate additional covariates (e.g., technology, patient, diagnosis, etc.) that can influence integration. 
 In fact the data we are using has a known _patient_ covariate; `SCPCL000479` and `SCPCL000480` are from the first patient, and `SCPCL000481` and `SCPCL000482` are from the second patient.
 
 So, let's perform integration with a method that can use this information - [`harmony`](https://portals.broadinstitute.org/harmony/)!
 
 To begin setting up for `harmony` integration, we need to add explicit patient information into our merged SCE.
-We'll create a new column `patient` whose value is either "A" or "B" depending on the given sample name, using the [`dplyr::case_when()`](https://dplyr.tidyverse.org/reference/case_when.html).
+We'll create a new column `patient` whose value is either "A" or "B" depending on the given sample name, using the [`dplyr::case_when()`](https://dplyr.tidyverse.org/reference/case_when.html) function.
 
 ```{r add_patient_info, live = TRUE}
 # Create patient column with values "A" or "B" for the two patients
@@ -739,26 +746,27 @@ Like `fastMNN`, `harmony` performs integration on a merged PCA matrix.
 However, unlike `fastMNN`, `harmony` does not "back-calculate" corrected expression from the corrected PCA matrix and it only returns the corrected PCA matrix itself.
 For input, `harmony` needs a couple pieces of information:
 
-- First, `harmony` can either take a matrix of normalized expression values, from which it will calculate a PCA matrix to batch-correct, or it can take a PCA matrix directly to perform batch-correction on.
-Since we already calculated a batch-aware PCA matrix (the `merged_PCA` reduced dimension), we'll provide this information directly.
+- First, `harmony` can either take a matrix of normalized expression values, from which it will calculate a batch-weighted PCA matrix to integrate, or it can take a batch-weighted PCA matrix directly to perform integration.
+Since we already calculated a batch-weighted PCA matrix (our `merged_PCA` reduced dimension), we'll provide this information directly.
   - We will need to specify the additional argument `do_pca=FALSE` to tell `harmony` that the input matrix we provided already is a PCA matrix.
 - Second, we need to tell `harmony` about the covariates to use - `sample` and `patient`. 
 To do this, we provide two arguments:
-  - `meta_data`, a data frame that contains covariates across samples. We can simply specify the SCE `colData` here since it contains `sample` and `patient` columns.
+  - `meta_data`, a data frame that contains covariates across samples. 
+  We can simply specify the SCE `colData` here since it contains `sample` and `patient` columns.
   - `vars_use`, a vector of which column names in `meta_data` should actually be used as covariates.
-  Other columns in this data frame are ignored.
+  Other columns in `meta_data` which are not in `vars_use` are ignored.
   
 Let's go!
 
 ```{r run_harmony, live = TRUE}
 harmony_pca <- harmony::HarmonyMatrix(
   # Provide the uncorrected PCA matrix:
-  data_mat  = reducedDim(merged_sce, "merged_PCA"),
+  data_mat = reducedDim(merged_sce, "merged_PCA"),
   # Set do_pca = FALSE since we are providing a PCA matrix directly
   do_pca = FALSE,
   # Provide colData as metadata
   meta_data = colData(merged_sce),
-  # Specify which variables in `meta_data` to use
+  # Specify which covariate variables in to use
   vars_use = c("sample", "patient")
 )
 ```
@@ -767,6 +775,7 @@ The result is a PCA matrix.
 Let's print a subset of this matrix to see it:
 
 ```{r print_harmony_result, live = TRUE}
+# Print the harmony result
 harmony_pca[1:5, 1:5]
 ```
 

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -113,7 +113,7 @@ sqrt(squares[1])
 sqrt(squares[2])
 sqrt(squares[3])
 
-# The `purrr:map()` function always returns a list
+# The `purrr::map()` function always returns a list
 purrr::map(squares, # vector to map over
            sqrt)    # function to apply to each item in `squares`
 ```
@@ -345,7 +345,7 @@ Based on our exploration, here is a schematic of how one of the SCE objects will
 We'll write a _custom function_ (seen in the chunk below) tailored to our wrangling steps that prepares a single SCE object for merging.
 We'll then use our new `purrr::map()` programming skills to run this function over the `sce_list`.
 This will give us a new list of formatted SCEs that we can proceed to merge.
-It's important to remember that the `format_sce()` function written below is not a function for general use - it's been precisely written to match the processing we need to do for _these_ SCEs, and different SCEs in the wild will require different types of processing.
+It's important to remember that the `format_sce()` function written below is not a function for general use – it's been precisely written to match the processing we need to do for _these_ SCEs, and different SCEs in the wild will require different types of processing.
 
 ```{r format_sce function}
 format_sce <- function(sce, sample_name) {
@@ -710,7 +710,7 @@ scater::plotReducedDim(merged_sce,
   theme_bw() 
 ```
 
-What trends do you observe between Tumor and healthy tissues among these integrated samples?
+What trends do you observe between tumor and healthy tissues among these integrated samples?
 
 
 ### Integration with `harmony`

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -79,7 +79,7 @@ integrated_sce_file <- file.path(output_dir, "rms_integrated_subset.rds")
 
 We can use the `dir()` function to list all contents of a given directory, for example to see all the files in our `input_dir`:
 
-```{r input_dir, live = TRUE}
+```{r input dir, live = TRUE}
 dir(input_dir)
 ```
 
@@ -103,7 +103,7 @@ purrr::map(<input vector or list>,
 
 Let's see a very simple example in action by quickly taking the square root of a vector of values:
 
-```{r map_example, live = TRUE}
+```{r map example, live = TRUE}
 
 # Define a vector of squares
 squares <- c(4, 9, 16)
@@ -122,7 +122,7 @@ The output from running `purr::map()` is always a list (but note that there are 
 
 We'll note that, in this case, it's possible to simply run `sqrt()` directly on the `squares` vector itself since this function is already vectorized, but not all functions behave this way.
 
-```{r quick_squares}
+```{r quick squares}
 sqrt(squares)
 ```
 
@@ -158,7 +158,7 @@ We'll first need to define a vector of the file paths to read in.
 We'll start by creating a vector of sample names themselves and then formatting them into the correct paths.
 This way (foreshadowing!) we also have a stand-alone vector of just sample names, which will come in handy!
 
-```{r sce_paths, live = TRUE} 
+```{r sce paths, live = TRUE} 
 # Vector of all the samples to read in:
 sample_names <- c("SCPCL000479",
                   "SCPCL000480",
@@ -171,7 +171,7 @@ sce_paths <- file.path(input_dir,
 )
 ```
 
-```{r print_sce_paths, live = TRUE}
+```{r print sce paths, live = TRUE}
 # Print the sce_paths vector
 sce_paths
 ```
@@ -179,7 +179,7 @@ sce_paths
 We can now read these files in and create a list of four SCE objects.
 Since `readr::read_rds()` can only operate on one input at a time (unlike `sqrt()` which can operate across a vector), we'll need to use `purrr::map()` to run in simultaneously on all input file paths.
 
-```{r read_sce_paths, live = TRUE}
+```{r read sce paths, live = TRUE}
 # Use purrr::map() to read all files into a list at once
 sce_list <- purrr::map(
   sce_paths, 
@@ -189,7 +189,7 @@ sce_list <- purrr::map(
 
 Let's have a look at our list of SCE objects:
 
-```{r print_sce_list, live=TRUE}
+```{r print sce list, live=TRUE}
 # Print sce_list
 sce_list
 ```
@@ -197,12 +197,12 @@ sce_list
 We now have a list of length four, where each item is a processed SCE object!
 However, we'll need to keep track of which sample each item is, so it's helpful to add _names_ to this list representing the relevant sample names.
 
-```{r add_list_names, live = TRUE}
+```{r add list names, live = TRUE}
 # Assign the sample names as the names for sce_list
 names(sce_list) <- sample_names
 ```
 
-```{r print_named_list, live=TRUE}
+```{r print named list, live=TRUE}
 # Print the list to see it with names
 sce_list
 ```
@@ -281,12 +281,10 @@ For example, rather than being called `mean`, this column will be named `SCPCL00
 
 All our SCE objects have the same `rowData` columns (as we can see in the next chunk), so we'll perform this renaming across all SCEs.
 
-```{r compare_rowdata}
+```{r compare rowdata}
 # Use `purrr::map()` to quickly extract rowData column names for all SCEs
 purrr::map(sce_list,
-           # This syntax is a formula where the period is a stand-in for 
-           # each item in sce_list
-           ~colnames(rowData(.)))
+           \(x) colnames(rowData(x)))
 ```
 
 
@@ -297,7 +295,7 @@ Here, those gene IDs are unique Ensembl gene IDs.
 
 We can use some `purrr` magic to quickly find the set of shared genes among our samples:
 
-```{r shared_genes, live = TRUE}
+```{r shared genes, live = TRUE}
 # Define vector of shared genes
 shared_genes <- sce_list |>
   # get rownames (genes) for each SCE in sce_list
@@ -306,7 +304,7 @@ shared_genes <- sce_list |>
   purrr::reduce(intersect)
 ```
 
-```{r print_shared_genes, live = TRUE}
+```{r print shared genes, live = TRUE}
 # Use head to look at the vector of shared genes:
 head(shared_genes)
 ```
@@ -314,7 +312,7 @@ head(shared_genes)
 In this case, we happen to know that all SCE objects we're working with already contained the same genes. 
 We do a quick-and-dirty check for this by looking at the number of rows across SCE objects, and we'll see that they are all the same:
 
-```{r check_shared_genes, live = TRUE}
+```{r check shared genes, live = TRUE}
 # The number of genes in an SCE corresponds to its number of rows:
 sce_list |>
   purrr::map(nrow)
@@ -327,7 +325,7 @@ So, for our data, we will not have to subset to shared genes since they are alre
 Finally, we'll need to have the same column names across all SCE `colData` tables, so let's look at all those column names.
 We can use similar syntax here to what we used to look at all the `rowData` column names.
 
-```{r compare_coldata, live = TRUE}
+```{r compare coldata, live = TRUE}
 purrr::map(sce_list,
            \(x) colnames(colData(x)) )
 ```
@@ -349,7 +347,7 @@ We'll then use our new `purrr::map()` programming skills to run this function ov
 This will give us a new list of formatted SCEs that we can proceed to merge.
 It's important to remember that the `format_sce()` function written below is not a function for general use - it's been precisely written to match the processing we need to do for _these_ SCEs, and different SCEs in the wild will require different types of processing.
 
-```{r format_sce_function, live = TRUE}
+```{r format_sce function, live = TRUE}
 format_sce <- function(sce, sample_name) {
   # Input arguments:
   ## sce: An SCE object to format
@@ -382,7 +380,7 @@ format_sce <- function(sce, sample_name) {
 To run this function, we'll use the `purrr::map2()` function, a relative of `purrr::map()` that allows you to simultaneously loop over _two_ input lists/vectors.
 In our case, we want to run `format_sce()` over paired `sce_list` items and `sce_list` names.
 
-```{r format_sces_for_merge, live = TRUE}
+```{r format sces for merge, live = TRUE}
 # We can use `purrr::map2()` to loop over two list/vector arguments simultaneously
 sce_list_formatted <- purrr::map2(
   # Each "iteration" will march down the first two 
@@ -392,9 +390,7 @@ sce_list_formatted <- purrr::map2(
   # Name of the function to run
   format_sce
 )
-```
 
-```{r print_sce_list_formatted, live = TRUE}
 # Print resulting list
 sce_list_formatted
 ```
@@ -409,13 +405,10 @@ Following that structure, other SCE slots (`colData`, `rowData`, reduced dimensi
 
 Since we need to apply `cbind()` to a _list_ of objects, we need to use some slightly-gnarly syntax: We'll use the function `do.call()`, which allows the `cbind()` input to be a list of objects to combine.
 
-```{r merges_sces, live = TRUE}
+```{r merges sces, live = TRUE}
 # Merge SCE objects 
 merged_sce <- do.call(cbind, sce_list_formatted)
-```
 
-
-```{r print_merged_sce, live = TRUE}
 # Print the merged_sce object
 merged_sce
 ```
@@ -424,7 +417,7 @@ We now have a single SCE object that contains all cells from all samples we'd li
 
 Let's take a peek at some of the innards of this new SCE object:
 
-```{r explore_merged_sce, live = TRUE}
+```{r explore merged_sce, live = TRUE}
 # What are the unique values in the `sample` column?
 unique( colData(merged_sce)$sample )
 
@@ -445,7 +438,7 @@ The integration methods we'll be using here actually perform batch correction on
 
 You'll notice that the merged SCE object object already contains PCA and UMAP reduced dimensions, which were calculated during our pre-processing:
 
-```{r merged_sce_reddim, live = TRUE}
+```{r merged_sce reddim, live = TRUE}
 # Print the reducedDimNames of the merged_sce
 reducedDimNames(merged_sce)
 ```
@@ -458,7 +451,7 @@ When samples are separately centered but plotting together, you will see samples
 In addition, the mathematical relationship between the original expression data and reduced dimension version of that data will differ across samples, meaning we can't interpret them all together.
 To see how this looks, let's look at the UMAP when calculated from individual samples:
 
-```{r individual_UMAPs}
+```{r plot individual UMAPs, live = TRUE}
 # UMAPs scaled separately when calculated from individual samples:
 scater::plotReducedDim(merged_sce,
                        dimred = "UMAP",
@@ -484,7 +477,7 @@ We'll also save these new reduced dimensions with different names, `merged_PCA` 
 First, as usual, we'll determine the high-variance genes to use for PCA from the `merged_sce` object.
 For this, we'll need to provide the argument `block = merged_sce$sample` when modeling gene variance, which tells `scran::modelGeneVar()` to first model variance separately for each batch and then combine those modeling statistics.
 
-```{r calc_merged_hv_genes}
+```{r calc merged hv genes}
 # Specify the number of genes to identify
 num_genes <- 2000
 
@@ -502,7 +495,7 @@ To calculate the PCA matrix itself, we'll use an approach from the `batchelor` p
 The [`batchelor::multiBatchPCA()`](https://rdrr.io/bioc/batchelor/man/multiBatchPCA.html) function calculates a batch-weighted PCA matrix.
 This weighting ensures that all batches, which may have very different numbers of cells, contribute equally to the overall scaling.
 
-```{r merged_pca, live = TRUE}
+```{r make merged_pca, live = TRUE}
 # Use batchelor to calculate PCA for merged_sce
 merged_pca <- batchelor::multiBatchPCA(merged_sce,
                                        # Consider only the high-variance genes
@@ -516,20 +509,20 @@ merged_pca <- batchelor::multiBatchPCA(merged_sce,
 ```
 
 Let's have a look at the output:
-```{r print_merged_pca, live = TRUE}
+```{r print merged_pca, live = TRUE}
 # This output is not very interesting!
 merged_pca
 ```
 
 We can use indexing `[[1]]` to see the PCA matrix calculated, looking at a small subset for convenience:
 
-```{r print_merged_pca_indexed, live = TRUE}
+```{r print merged_pca indexed, live = TRUE}
 merged_pca[[1]][1:5,1:5]
 ```
 
 We can now include this PCA matrix in our `merged_sce` object:
 
-```{r add_merged_pca, live = TRUE}
+```{r add merged_pca, live = TRUE}
 # add PCA results to merged SCE object 
 reducedDim(merged_sce, "merged_PCA") <- merged_pca[[1]]
 ```
@@ -543,7 +536,7 @@ We want to use the batch-weighted PCA, which we named above as `"merged_PCA"`.
 - `name = "merged_UMAP"`, which names the final UMAP that this function calculates.
 This argument will prevent us from overwriting the existing UMAP which is already named "UMAP" and instead create a separate `"merged_UMAP"`.
 
-```{r merged_umap, live = TRUE}
+```{r calculate merged umap, live = TRUE}
 # add merged_UMAP from merged_PCA
 merged_sce <- scater::runUMAP(merged_sce,
                               # Specify which reduced dimension to calculate UMAP from
@@ -553,7 +546,7 @@ merged_sce <- scater::runUMAP(merged_sce,
 
 Now, let's see how this new `merged_UMAP` looks compared to the `UMAP` calculated from individual samples:
 
-```{r uncorrected_merged_UMAP, live = TRUE}
+```{r plot uncorrected merged UMAP}
 # UMAPs scaled together when calculated from the merged SCE
 scater::plotReducedDim(merged_sce,
                        dimred = "merged_UMAP",
@@ -576,7 +569,7 @@ What similarities do you think the integrated UMAP will have to this plot?
 
 ### Integration with `fastMNN`
 
-Finally, we're ready to integrate.
+Finally, we're ready to integrate!
 To start, we'll use the `fastMNN` approach from the Bioconductor [`batchelor` package](http://www.bioconductor.org/packages/3.16/bioc/html/batchelor.html).
 
 `fastMNN` takes as input the `merged_sce` object to integrate, and the first step it performs is actually to run `batchelor::multiBatchPCA()` on that SCE.
@@ -586,7 +579,7 @@ The `batch` argument is used to specify the different groupings within the `merg
 Let's run it and save the result to a variable called `integrated_sce`.
 
 
-```{r run_fastmnn, live = TRUE}
+```{r run fastmnn, live = TRUE}
 # integrate with fastMNN
 integrated_sce <- batchelor::fastMNN(
   # the merged SCE object
@@ -601,7 +594,7 @@ integrated_sce <- batchelor::fastMNN(
 
 Let's have a look at the result:
 
-```{r fastmnn_result, live = TRUE}
+```{r fastmnn result, live = TRUE}
 # Print the integrated_sce object
 integrated_sce
 ```
@@ -615,14 +608,14 @@ If the `subset.row` argument is provided (as it was here), only genes present in
 
 We're mostly interested in the PCA that `fastMNN` calculated, so let's save that information (with an informative and unique name) into our `merged_sce` object:
 
-```{r fastmnn_pcs, live = TRUE}
+```{r fastmnn pcs, live = TRUE}
 # Make a new reducedDim named fastmnn_PCA from the corrected reducedDim in integrated_sce
 reducedDim(merged_sce, "fastmnn_PCA") <- reducedDim(integrated_sce, "corrected")
 ```
 
 Finally, we'll calculate UMAP from these corrected PCA matrix for visualization.
 
-```{r fastmnn_umap, live = TRUE}
+```{r calculate fastmnn umap, live = TRUE}
 # Calculate UMAP
 merged_sce <- scater::runUMAP(
   merged_sce, 
@@ -637,7 +630,7 @@ First, let's plot the integrated UMAP highlighting the different batches.
 A well-integrated dataset will show batch mixing, but a poorly-integrated dataset will show more separation among batches, similar to the uncorrected UMAP.
 Note that this is a more qualitative way to assess the success of integration, but there are formal metrics one can use to assess batch mixing, which you can read more about in [this chapter of _Orchestrating Single Cell Analyses](http://bioconductor.org/books/3.16/OSCA.multisample/correction-diagnostics.html).
 
-```{r fastmnn_umap_batches, live = TRUE}
+```{r plot fastmnn umap batches}
 scater::plotReducedDim(merged_sce,
                        # plot the fastMNN coordinates
                        dimred = "fastmnn_UMAP",
@@ -661,9 +654,9 @@ Importantly, one reason that batches may still appear separated in the corrected
 Recall from earlier that we conveniently have cell type annotations in our SCEs, so we can explore those here!
 Let's take a quick detour to see what kinds of cell types are in this data by making a barplot of the cell types across samples:
 
-```{r explore_celltypes, live = TRUE}
+```{r explore celltypes}
 # Cell types are in the `celltype_broad` and `celltype_fine` columns
-merged_sce_df <-  as.data.frame(colData(merged_sce)) 
+merged_sce_df <- as.data.frame(colData(merged_sce)) 
 
 # Use ggplot2 to make a barplot the cell types across samples 
 ggplot(merged_sce_df, 
@@ -684,7 +677,7 @@ This difference _may_ explain why we observe that `SCPCL000481` is somewhat more
 Let's re-plot this UMAP to highlight cell types:
 
 
-```{r fastmnn_umap_celltypes, live = TRUE}
+```{r plot fastmnn umap celltypes}
 scater::plotReducedDim(merged_sce,
                        dimred = "fastmnn_UMAP",
                        # color by broad celltypes
@@ -701,7 +694,7 @@ Tumor cell types from different samples are all also clustering together, which 
 However, it's a bit challenging to see all the points given the amount of overlap in the plot.
 One way we can see all the points a bit better is to facet the plot by sample, using `facet_wrap()` from the `ggplot2` package (which we can do because `scater::plotReducedDim()` returns a `ggplot2` object):
 
-```{r fastmnn_umap_celltype_faceted, live = TRUE}
+```{r plot fastmnn umap celltypes faceted}
 scater::plotReducedDim(merged_sce,
                        dimred = "fastmnn_UMAP",
                        colour_by = "celltype_broad",
@@ -731,7 +724,7 @@ So, let's perform integration with a method that can use this information - [`ha
 To begin setting up for `harmony` integration, we need to add explicit patient information into our merged SCE.
 We'll create a new column `patient` whose value is either "A" or "B" depending on the given sample name, using the [`dplyr::case_when()`](https://dplyr.tidyverse.org/reference/case_when.html) function.
 
-```{r add_patient_info, live = TRUE}
+```{r add patient info, live = TRUE}
 # Create patient column with values "A" or "B" for the two patients
 merged_sce$patient <- dplyr::case_when(
   # Assign a value of "A" if the sample is one of these
@@ -759,7 +752,8 @@ To do this, we provide two arguments:
   
 Let's go!
 
-```{r run_harmony, live = TRUE}
+```{r run harmony, live = TRUE}
+# integrate with harmony
 harmony_pca <- harmony::HarmonyMatrix(
   # Provide the uncorrected PCA matrix:
   data_mat = reducedDim(merged_sce, "merged_PCA"),
@@ -775,7 +769,7 @@ harmony_pca <- harmony::HarmonyMatrix(
 The result is a PCA matrix.
 Let's print a subset of this matrix to see it:
 
-```{r print_harmony_result, live = TRUE}
+```{r print harmony result, live = TRUE}
 # Print the harmony result
 harmony_pca[1:5, 1:5]
 ```
@@ -783,7 +777,7 @@ harmony_pca[1:5, 1:5]
 As we did with `fastMNN` results, let's store this PCA matrix directly in our `merged_sce` object with an informative name that won't overwrite any of the existing PCA matrices.
 We'll also calculate UMAP from it.
 
-```{r save_harmony, live = TRUE}
+```{r save harmony, live = TRUE}
 # Store PCA as `harmony_PCA`
 reducedDim(merged_sce, "harmony_PCA") <- harmony_pca
 
@@ -796,7 +790,7 @@ merged_sce <- scater::runUMAP(merged_sce,
 
 Let's see how the `harmony` UMAP, colored by sample, looks compared to the `fastMNN` UMAP:
 
-```{r harmony_umap_batches, live = TRUE}
+```{r plot harmony umap batches}
 scater::plotReducedDim(merged_sce,
                        dimred = "harmony_UMAP",
                        colour_by = "sample",
@@ -810,7 +804,7 @@ How do you think this `harmony` UMAP compares to that from `fastMNN` integration
 
 Let's see how this UMAP looks colored by cell type, and faceted for visibility:
 
-```{r harmony_umap_celltypes_broad, live = TRUE}
+```{r plot harmony umap celltypes}
 scater::plotReducedDim(merged_sce,
                        dimred = "harmony_UMAP",
                        colour_by = "celltype_broad",
@@ -834,7 +828,7 @@ Finally, we'll export the final SCE object with both `fastMNN` and `harmony` int
 Since this object is very large (over 1 GB!), we'll export it to a file with some compression, which, in this case, will reduce the final size to a smaller ~360 MB.
 This will take a couple minutes to save while compression is performed.
 
-```{r save_integration, live = TRUE}
+```{r save integration, live = TRUE}
 readr::write_rds(merged_sce, 
                  integrated_sce_file,
                  compress = "gz")

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -113,7 +113,7 @@ sqrt(squares[1])
 sqrt(squares[2])
 sqrt(squares[3])
 
-# The `map()` function always returns a list
+# The `purrr:map()` function always returns a list
 purrr::map(squares, # vector to map over
            sqrt)    # function to apply to each item in `squares`
 ```
@@ -126,7 +126,7 @@ We'll note that, in this case, it's possible to simply run `sqrt()` directly on 
 sqrt(squares)
 ```
 
-More involved scenarios, as we'll see shortly, will necessitate the use of `map()`, in particular when the input is a list itself.
+More involved scenarios, as we'll see shortly, will necessitate the use of `purrr::map()`, in particular when the input is a list itself.
 
 
 One other new coding strategy we'll learn in this notebook is using the [`glue`](https://glue.tidyverse.org/) package to combine strings.
@@ -177,7 +177,7 @@ sce_paths
 ```
 
 We can now read these files in and create a list of four SCE objects.
-Since `readr::read_rds()` can only operate on one input at a time (unlike `sqrt()` which can operate across a vector), we'll need to use `purrr::map()` to run in simultaneously on all input file paths.
+Since `readr::read_rds()` can only operate on one input at a time (unlike `sqrt()` which can operate across a vector), we'll need to use `purrr::map()` to run it on all input file paths in one command.
 
 ```{r read sce paths, live = TRUE}
 # Use purrr::map() to read all files into a list at once
@@ -254,7 +254,7 @@ Second, it would literally cause an error in R, which does not allow duplicate c
 One way to ensure that cell ids remain unique even after merging is to actually modify them by _prepending_ the relevant sample name. 
 For example, consider these barcodes for the `SCPCL000479` sample:
 
-```{r barcodes, live = TRUE}
+```{r barcodes}
 # Look at the column names for the `SCPCL000479` sample, for example
 colnames(sce_list$SCPCL000479) |>
   # Only print out the first 6 for convenience
@@ -267,7 +267,7 @@ These ids will be updated `SCPCL000479-GGGACCTCAAGCGGAT`, `SCPCL000479-CACAGATAG
 
 The `rowData` table in SCE objects will often contain both "general" and "library-specific" information, for example:
 
-```{r rowdata, live = TRUE}
+```{r rowdata}
 rowData(sce_list$SCPCL000479) |>
   head()
 ```
@@ -281,7 +281,7 @@ For example, rather than being called `mean`, this column will be named `SCPCL00
 
 All our SCE objects have the same `rowData` columns (as we can see in the next chunk), so we'll perform this renaming across all SCEs.
 
-```{r compare rowdata}
+```{r compare rowdata, live = TRUE}
 # Use `purrr::map()` to quickly extract rowData column names for all SCEs
 purrr::map(sce_list,
            \(x) colnames(rowData(x)))
@@ -325,7 +325,7 @@ So, for our data, we will not have to subset to shared genes since they are alre
 Finally, we'll need to have the same column names across all SCE `colData` tables, so let's look at all those column names.
 We can use similar syntax here to what we used to look at all the `rowData` column names.
 
-```{r compare coldata, live = TRUE}
+```{r compare coldata}
 purrr::map(sce_list,
            \(x) colnames(colData(x)) )
 ```
@@ -347,7 +347,7 @@ We'll then use our new `purrr::map()` programming skills to run this function ov
 This will give us a new list of formatted SCEs that we can proceed to merge.
 It's important to remember that the `format_sce()` function written below is not a function for general use - it's been precisely written to match the processing we need to do for _these_ SCEs, and different SCEs in the wild will require different types of processing.
 
-```{r format_sce function, live = TRUE}
+```{r format_sce function}
 format_sce <- function(sce, sample_name) {
   # Input arguments:
   ## sce: An SCE object to format
@@ -377,11 +377,11 @@ format_sce <- function(sce, sample_name) {
 }
 ```
 
-To run this function, we'll use the `purrr::map2()` function, a relative of `purrr::map()` that allows you to simultaneously loop over _two_ input lists/vectors.
+To run this function, we'll use the `purrr::map2()` function, a relative of `purrr::map()` that allows you to loop over _two_ input lists/vectors.
 In our case, we want to run `format_sce()` over paired `sce_list` items and `sce_list` names.
 
 ```{r format sces for merge, live = TRUE}
-# We can use `purrr::map2()` to loop over two list/vector arguments simultaneously
+# We can use `purrr::map2()` to loop over two list/vector arguments
 sce_list_formatted <- purrr::map2(
   # Each "iteration" will march down the first two 
   #  arguments `sce_list` and `names(sce_list)` in order

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -28,7 +28,7 @@ The particular libraries we'll integrate come from two rhabdomyosarcoma (RMS) pa
 Each library is from a separate biological sample.
 
 We'll be integrating these samples with two different tools, [`fastMNN`](http://www.bioconductor.org/packages/release/bioc/html/batchelor.html) ([Haghverdi _et al._ (2018)](https://doi.org/10.1038/nbt.4091)) and [`harmony`](https://portals.broadinstitute.org/harmony/) ([Korsunsky _et al._ (2019)](https://doi.org/10.1038/s41592-019-0619-0)). 
-Integration corrects for batch effects that arise from different library preparations, genetic backgrounds, and other sample-specific factors, so that datasets can be jointly analyzed at the cell-level. 
+Integration corrects for batch effects that arise from different library preparations, genetic backgrounds, and other sample-specific factors, so that datasets can be jointly analyzed at the cell level. 
 `fastMNN` corrects for batch effects using a faster variant of the mutual-nearest neighbors algorithm, the technical details of which you can learn more about from this [vignette by Lun (2019)](https://marionilab.github.io/FurtherMNN2018/theory/description.html).
 `harmony`, on the other hand, corrects for batch effects using an iterative clustering approach, and unlike `fastMNN`, it is also able to consider additional covariates beyond just the batch groupings.
 
@@ -103,7 +103,7 @@ purrr::map(<input vector or list>,
 
 Let's see a very simple example in action by quickly taking the square root of a vector of values:
 
-```{r map_example, life = TRUE}
+```{r map_example, live = TRUE}
 
 # Define a vector of squares
 squares <- c(4, 9, 16)
@@ -226,7 +226,7 @@ Overall we'll want to take care of these items:
 
 1. We should be able to trace sample-specific information back to the originating sample, including...
     - Cell-level information: Which sample is each cell from? 
-    - Library-specific feature statistics, e.g. gene-level statistics for a given library found in `rowData`.
+    - Library-specific feature statistics, e.g., gene-level statistics for a given library found in `rowData`.
     Which sample is a given feature statistic from?
 2. SCE objects should contain the same genes: Each SCE object should have the same row names.
 3. SCE cell metadata columns should match: The `colData` for each SCE object should have the same column names.
@@ -329,7 +329,7 @@ We can use similar syntax here to what we used to look at all the `rowData` colu
 
 ```{r compare_coldata, live = TRUE}
 purrr::map(sce_list,
-           ~colnames(colData(.)))
+           \(x) colnames(colData(x)) )
 ```
 
 It looks like the column names are all already matching among SCEs, so there's no specific preparation we'll need to do there.
@@ -493,7 +493,7 @@ gene_variance <- scran::modelGeneVar(merged_sce,
                                      # specify the grouping column:
                                      block = merged_sce$sample)
 
-# Cet the top `num_genes` high-variance genes to use for dimension reduction
+# Get the top `num_genes` high-variance genes to use for dimension reduction
 hv_genes <- scran::getTopHVGs(gene_variance,
                               n = num_genes)
 ```
@@ -587,6 +587,7 @@ Let's run it and save the result to a variable called `integrated_sce`.
 
 
 ```{r run_fastmnn, live = TRUE}
+# integrate with fastMNN
 integrated_sce <- batchelor::fastMNN(
   # the merged SCE object
   merged_sce,

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -60,7 +60,7 @@ These SCE objects, stored as RDS files, are available in the `data/rms/processed
 
 To begin, let's set up our directories and files:
 
-```{r directories}
+```{r directories, live = TRUE}
 # Define directory where processed SCE object to be integrated are stored
 input_dir <- file.path("data", "rms", "processed")
 
@@ -79,11 +79,11 @@ integrated_sce_file <- file.path(output_dir, "rms_integrated_subset.rds")
 
 We can use the `dir()` function to list all contents of a given directory, for example to see all the files in our `input_dir`:
 
-```{r dir input_dir}
+```{r input_dir}
 dir(input_dir)
 ```
 
-We want to read in four of these files, as listed above.
+We want to read in just four of these files, as listed previously.
 To read in these files, we could use `readr::read_rds()` (or the base R `readRDS()`) function four times, once for each of the files. 
 We could also use a `for` loop, which is the approach that many programming languages would lean toward.
 A different and more modular coding approach to reading in these files (and more!) is to leverage the [`purrr`](https://purrr.tidyverse.org/) `tidyverse` package, which provides a convenient set of functions for operating on lists.
@@ -120,7 +120,7 @@ The output from running `purr::map()` is always a list (but note that there are 
 
 We'll note that, in this case, it's possible to simply run `sqrt()` directly on the `squares` vector itself:
 
-```{r quick squares}
+```{r quick_squares}
 sqrt(squares)
 ```
 
@@ -140,7 +140,7 @@ paste("Welcome to the", org_name, "workshop on Advanced scRNA-seq!")
 
 We can use `glue::glue()` to accomplish the same goal with some different syntax:
 
-```{r glue}
+```{r glue, live = TRUE}
 # glue::glue takes a single string argument (only one set of quotes!), and 
 #  variables can easily be included inside {curly braces}
 glue::glue("Welcome to the {org_name} workshop on Advanced scRNA-seq!")
@@ -156,7 +156,7 @@ We'll first need to define a vector of the file paths to read in.
 We'll start by creating a vector of sample names themselves and then formatting them into the correct paths.
 This way (foreshadowing!) we also have a stand-alone vector of just sample names, which will come in handy!
 
-```{r read input} 
+```{r sce_paths, live = TRUE} 
 # Vector of all the samples to read in:
 sample_names <- c("SCPCL000479",
                   "SCPCL000480",
@@ -167,27 +167,39 @@ sample_names <- c("SCPCL000479",
 sce_paths <- file.path(input_dir, 
                        glue::glue("{sample_names}.rds")
 )
+```
+
+```{r print_sce_paths, live = TRUE}
+# Print the sce_paths vector
 sce_paths
 ```
 
 We can now read these files in and create a list of four SCE objects:
 
-```{r}
+```{r read_sce_paths, live = TRUE}
 # Use purrr::map() to read all files into a list at once:
 sce_list <- purrr::map(
   sce_paths, 
   readr::read_rds
 )
+```
+
+Let's have a look at our list of SCE objects:
+```{r print_sce_list, live=TRUE}
+# Print sce_list
 sce_list
 ```
 
 We now have a list of length four, where each item is a processed SCE object!
 However, we'll need to keep track of which sample each item is, so it's helpful to add _names_ to this list representing the relevant sample names.
 
-```{r add list names}
+```{r add_list_names, live = TRUE}
 # Assign the sample names as the names for sce_list
 names(sce_list) <- sample_names
+```
 
+```{r print_named_list, live=TRUE}
+# Print the list to see it with names
 sce_list
 ```
 
@@ -237,7 +249,7 @@ Second, it would literally cause an error in R, which does not allow duplicate c
 One way to ensure that cell ids remain unique even after merging is to actually modify them by _prepending_ the relevant sample name. 
 For example, consider these barcodes for the `SCPCL000479` sample:
 
-```{r barcodes}
+```{r barcodes, live = TRUE}
 # Look at the column names for the `SCPCL000479` sample, for example
 colnames(sce_list$SCPCL000479) |>
   # Only print out the first 6 for convenience
@@ -250,8 +262,9 @@ These IDs will be updated `SCPCL000479-GGGACCTCAAGCGGAT`, `SCPCL000479-CACAGATAG
 
 The `rowData` table in SCE objects will often contain both "general" and "library-specific" information, for example:
 
-```{r rowdata colnames}
-head( rowData(sce_list$SCPCL000479) )
+```{r rowdata, live = TRUE}
+rowData(sce_list$SCPCL000479) |>
+  head()
 ```
 
 Here, the rownames are Ensembl gene IDs, and columns are `gene_symbol`, `mean`, and `detected`. 
@@ -263,7 +276,7 @@ For example, rather than being called `mean`, this column will be named `SCPCL00
 
 All our SCE objects have the same `rowData` columns (as we can see in the next chunk), so we'll perform this renaming across all SCEs.
 
-```{r compare rowdata}
+```{r compare_rowdata}
 # Use `purrr::map()` to quickly extract rowData column names for all SCEs
 purrr::map(sce_list,
            # This syntax is a formula where the period is a stand-in for 
@@ -279,21 +292,24 @@ Here, those gene ids are unique Ensembl gene ids.
 
 We can use some `purrr` magic to quickly find the set of shared genes among our samples:
 
-```{r shared genes}
+```{r shared_genes, live = TRUE}
+# Define vector of shared genes
 shared_genes <- sce_list |>
   # get rownames (genes) for each SCE in sce_list
   purrr::map(rownames) |>
   # reduce to the _intersection_ among lists
   purrr::reduce(intersect)
+```
 
-# We've now created a vector of genes that are present in all SCEs
+```{r print_shared_genes, live = TRUE}
+# Use head to look at the vector of shared genes:
 head(shared_genes)
 ```
 
 In this case, we happen to know that all SCE objects we're working with already contained the same genes. 
 We can quickly confirm that this is true by looking at the number of rows across SCE objects, and we'll see that they are all the same:
 
-```{r check shared genes}
+```{r check_shared_genes, live = TRUE}
 # The number of genes in an SCE corresponds to its number of rows:
 sce_list |>
   purrr::map(nrow)
@@ -303,9 +319,10 @@ So, for our data, we will not have to subset to shared genes since they are alre
  
 #### Ensuring matching columns in `colData`
 
-Finally, we'll need to have the same column names across all SCE `colData` tables, so let's look at all those column names:
+Finally, we'll need to have the same column names across all SCE `colData` tables, so let's look at all those column names.
+We can use similar syntax here to what we used to look at all the `rowData` column names.
 
-```{r compare coldata}
+```{r compare_coldata, live = TRUE}
 purrr::map(sce_list,
            ~colnames(colData(.)))
 ```
@@ -326,7 +343,7 @@ We'll write a _custom function_ (seen in the chunk below) tailored to our wrangl
 We'll then use our new `purrr::map()` programming skills to run this function over the `sce_list` to end up with a formatted version of `sce_list` that we can merge.
 It's important to remember that this is not a function for general use - it's been precisely written to match the processing we need to do for _these_ SCEs, and different SCEs in the wild will require different types of processing.
 
-```{r format function}
+```{r format_, live = TRUEfunction}
 format_sce <- function(sce, sample_name) {
   # Input arguments:
   ## sce: An SCE object to format
@@ -359,7 +376,7 @@ format_sce <- function(sce, sample_name) {
 To run this function, we'll use the `purrr::map2()` function, a relative of `purrr::map()` that allows you to simultaneously loop over _two_ input lists/vectors.
 In our case, we want to run `format_sce()` over paired `sce_list` items and `sce_list` names.
 
-```{r format sces for merge}
+```{r format_sces_for_merge, live = TRUE}
 # We can use `purrr::map2()` to loop over two list/vector arguments simultaneously
 sce_list_formatted <- purrr::map2(
   # Each "iteration" will march down the first two 
@@ -369,7 +386,10 @@ sce_list_formatted <- purrr::map2(
   # Name of the function to run
   format_sce
 )
+```
 
+```{r print_sce_list_formatted, live = TRUE}
+# Print resulting list
 sce_list_formatted
 ```
 
@@ -384,11 +404,14 @@ Following that structure, other SCE slots (`colData`, `rowData`, reduced dimensi
 
 Since we need to apply `cbind()` to a _list_ of objects, we need to use some slightly-gnarly syntax: We'll use the function `do.call()`, which allows the `cbind()` input to be a list of objects to combine.
 
-```{r merge sces}
+```{r merges_sces, live = TRUE}
 # Merge SCE objects 
 merged_sce <- do.call(cbind, sce_list_formatted)
+```
 
-# Let's have a look!
+
+```{r print_merged_sce, live = TRUE}
+# Print the merged_sce
 merged_sce
 ```
 
@@ -396,7 +419,7 @@ We now have a single SCE object that contains all cells from all samples we'd li
 
 Let's take a peek at some of the innards of this new SCE object:
 
-```{r explore merged_sce}
+```{r explore_merged_sce, live = TRUE}
 # What are the unique values in the `sample` column?
 unique( colData(merged_sce)$sample )
 
@@ -418,7 +441,8 @@ The main reason for using reduced dimensions is efficiency.
 
 You'll notice that the merged SCE object object already contains PCA and UMAP reduced dimensions, which were calculated during our pre-processing:
 
-```{r merged sce view pca}
+```{r merged_sce_reddim, live = TRUE}
+# Print the reducedDimNames of the merged_sce
 reducedDimNames(merged_sce)
 ```
 
@@ -430,7 +454,7 @@ When samples are separately centered but plotting together, you will see samples
 In addition, the mathematical relationship between the original expression data and reduced dimension version of that data will differ across samples, meaning we can't interpret them all together.
 To see how this looks, let's look at the UMAP when calculated from individual samples:
 
-```{r individual UMAPs}
+```{r individual_UMAPs}
 # UMAPs scaled separately when calculated from individual samples:
 scater::plotReducedDim(merged_sce,
                        dimred = "UMAP",
@@ -456,15 +480,16 @@ We'll also save these new reduced dimensions with different names, `merged_PCA` 
 First, as usual, we'll determine the high-variance genes to use for PCA from the `merged_sce` object.
 For this, we'll need to provide the argument `block = merged_sce$sample` when modeling gene variance, which tells `scran::modelGeneVar()` to first model variance separately for each batch and then combine those modeling statistics.
 
-```{r calc merged hv_genes}
+```{r calc_merged_hv_genes}
+# Specify the number of genes to identify
 num_genes <- 2000
 
-# calculate variation for each gene
+# Calculate variation for each gene
 gene_variance <- scran::modelGeneVar(merged_sce,
                                      # specify the grouping column:
                                      block = merged_sce$sample)
 
-# get the top high-variance genes to use for dimension reduction
+# Cet the top `num_genes` high-variance genes to use for dimension reduction
 hv_genes <- scran::getTopHVGs(gene_variance,
                               n = num_genes)
 ```
@@ -473,7 +498,7 @@ To calculate the PCA matrix itself, we'll use an approach from the `batchelor` p
 The [`batchelor::multiBatchPCA()`](https://rdrr.io/bioc/batchelor/man/multiBatchPCA.html) function calculates a batch-weighted PCA matrix.
 This weighting ensures that all batches, which may have very different numbers of cells, contribute equally to the overall scaling.
 
-```{r merged_pca}
+```{r merged_pca, live = TRUE}
 # Use batchelor to calculate PCA for merged_sce
 merged_pca <- batchelor::multiBatchPCA(merged_sce,
                                        # Consider only the high-variance genes
@@ -484,20 +509,23 @@ merged_pca <- batchelor::multiBatchPCA(merged_sce,
                                        #  is a single matrix that contains all samples, 
                                        #  instead of a separate matrix for each sample
                                        preserve.single = TRUE)
- 
+```
 
+Let's have a look at the output:
+```{r print_merged_pca, live = TRUE}
 # This output is not very interesting!
 merged_pca
+```
 
+We can use indexing `[[1]]` to see the PCA matrix calculated, looking at a small subset for convenience:
 
-# We can use indexing `[[1]]` to see the PCA matrix calculated, looking at a 
-# small subset for convenience
+```{r print_merged_pca_indexed, live = TRUE}
 merged_pca[[1]][1:5,1:5]
 ```
 
 We can now include this PCA matrix in our `merged_sce` object:
 
-```{r add merged_pca}
+```{r add_merged_pca, live = TRUE}
 # add PCA results to merged SCE object 
 reducedDim(merged_sce, "merged_PCA") <- merged_pca[[1]]
 ```
@@ -511,18 +539,17 @@ We want to use the batch-weighted PCA, which we named above as `"merged_PCA"`.
 - `name = "merged_UMAP"`, which names the final UMAP that this function calculates.
 This argument will prevent us from overwriting the existing UMAP which is already named "UMAP" and instead create a separate `"merged_UMAP"`.
 
-```{r merged_umap}
+```{r merged_umap, live = TRUE}
 # add merged_UMAP from merged_PCA
 merged_sce <- scater::runUMAP(merged_sce,
                               # Specify which reduced dimension to calculate UMAP from
                               dimred = "merged_PCA",
                               name = "merged_UMAP")
-merged_sce
 ```
 
 Now, let's see how this new `merged_UMAP` looks compared to the `UMAP` calculated from individual samples:
 
-```{r uncorrected merged UMAP}
+```{r uncorrected_merged_UMAP, live = TRUE}
 # UMAPs scaled together when calculated from the merged SCE
 scater::plotReducedDim(merged_sce,
                        dimred = "merged_UMAP",
@@ -554,7 +581,7 @@ The `batch` argument is used to specify the different groupings within the `merg
 `fastMNN` will return an SCE object that contains a batch-corrected PCA.
 
 
-```{r run_fastmnn}
+```{r run_fastmnn, live = TRUE}
 integrated_sce <- batchelor::fastMNN(
   # the merged SCE object
   merged_sce,
@@ -564,8 +591,11 @@ integrated_sce <- batchelor::fastMNN(
   #  high variance genes across samples in the merged_sce
   subset.row = hv_genes
 )
+```
 
-# Let's have a look!
+Let's have a look at the result:
+
+```{r fastmnn_result, live = TRUE}
 integrated_sce
 ```
 
@@ -578,16 +608,14 @@ If the `subset.row` argument was provided (as it was here), only genes present i
 
 We're mostly interested in the PCA that `fastMNN` calculated, so let's save that information (with an informative and unique name!) into our `merged_sce` object:
 
-```{r fastmnn pcs}
+```{r fastmnn_pcs, live = TRUE}
 # Make a new reducedDim named fastmnn_PCA from the corrected reducedDim in integrated_sce
 reducedDim(merged_sce, "fastmnn_PCA") <- reducedDim(integrated_sce, "corrected")
-
-merged_sce
 ```
 
 Finally, we'll calculate UMAP from these corrected PCA matrix for visualization.
 
-```{r fastmnn umap}
+```{r fastmnn_umap, live = TRUE}
 # Calculate UMAP
 merged_sce <- scater::runUMAP(
   merged_sce, 
@@ -602,7 +630,7 @@ First, let's plot the integrated UMAP highlighting the different batches.
 A well-integrated dataset will show batch mixing, but a poorly-integrated dataset will show more separation among batches, similar to the uncorrected UMAP.
 Note that this is a more qualitative way to assess the success of integration, but there are formal metrics one can use to assess batch mixing, which you can read more about in [this chapter of _Orchestrating Single Cell Analyses](http://bioconductor.org/books/3.16/OSCA.multisample/correction-diagnostics.html).
 
-```{r fastmnn umap batches}
+```{r fastmnn_umap_batches, live = TRUE}
 scater::plotReducedDim(merged_sce,
                        # plot the fastMNN coordinates
                        dimred = "fastmnn_UMAP",
@@ -626,15 +654,15 @@ Importantly, one reason that batches may still appear separated in the corrected
 Recall from earlier that we conveniently have cell type annotations in our SCEs, so we can explore those here!
 Let's take a quick detour to see what kinds of cell types are in this data by making a barplot of the cell types across samples:
 
-```{r explore celltypes}
+```{r explore_celltypes, live = TRUE}
 # Cell types are stored in the `celltype_broad` and `celltype_fine` columns in the SCE
 merged_sce_df <-  as.data.frame(colData(merged_sce)) 
 
+# Use ggplot2 to make a barplot the cell types across samples 
 ggplot(merged_sce_df, 
        aes(x = sample, 
-           fill = celltype_broad)
-) +
-  # Barplot of celltype counts, arranged horizontally
+           fill = celltype_broad)) +
+  # Barplot of celltype proportions
   geom_bar(position = "fill") + 
   # Use a CVD-friendly color scheme
   scale_fill_brewer(palette = "Dark2", na.value = "grey80") +
@@ -649,7 +677,7 @@ This difference _may_ explain why we observe that `SCPCL000481` is somewhat more
 Let's re-plot this UMAP to highlight cell types:
 
 
-```{r fastmnn umap celltypes}
+```{r fastmnn_umap_celltypes, live = TRUE}
 scater::plotReducedDim(merged_sce,
                        dimred = "fastmnn_UMAP",
                        # color by broad celltypes
@@ -666,7 +694,7 @@ Tumor cell types from different samples are all also clustering together, which 
 However, it's a bit challenging to see all the points given the amount of overlap in the plot.
 One way we can see all the points a bit better is to facet the plot by sample, using `facet_wrap()` from the `ggplot2` package (which we can do because `scater::plotReducedDim()` returns a `ggplot2` object):
 
-```{r fastmnn umap celltype faceted}
+```{r fastmnn_umap_celltype_faceted, live = TRUE}
 scater::plotReducedDim(merged_sce,
                        dimred = "fastmnn_UMAP",
                        colour_by = "celltype_broad",
@@ -695,7 +723,7 @@ So, let's perform integration with a method that can use this information - [`ha
 To begin setting up for `harmony` integration, we need to add explicit patient information into our merged SCE.
 We'll create a new column `patient` whose value is either "A" or "B" depending on the given sample name, using the [`dplyr::case_when()`](https://dplyr.tidyverse.org/reference/case_when.html).
 
-```{r add patient info}
+```{r add_patient_info, live = TRUE}
 # Create patient column with values "A" or "B" for the two patients
 merged_sce$patient <- dplyr::case_when(
   # Assign a value of "A" if the sample is one of these
@@ -722,7 +750,7 @@ To do this, we provide two arguments:
   
 Let's go!
 
-```{r harmony}
+```{r run_harmony, live = TRUE}
 harmony_pca <- harmony::HarmonyMatrix(
   # Provide the uncorrected PCA matrix:
   data_mat  = reducedDim(merged_sce, "merged_PCA"),
@@ -733,19 +761,23 @@ harmony_pca <- harmony::HarmonyMatrix(
   # Specify which variables in `meta_data` to use
   vars_use = c("sample", "patient")
 )
+```
 
-# The result is a PCA matrix:
+The result is a PCA matrix.
+Let's print a subset of this matrix to see it:
+
+```{r print_harmony_result, live = TRUE}
 harmony_pca[1:5, 1:5]
 ```
 
 As we did with `fastMNN` results, let's store this PCA matrix directly in our `merged_sce` object with an informative name that won't overwrite any of the existing PCA matrices.
 We'll also calculate UMAP from it.
 
-```{r save harmony}
+```{r save_harmony, live = TRUE}
 # Store PCA as `harmony_PCA`
 reducedDim(merged_sce, "harmony_PCA") <- harmony_pca
 
-# As before, calculate UMAP on this PCA matrix:
+# As before, calculate UMAP on this PCA matrix with appropriate names
 merged_sce <- scater::runUMAP(merged_sce, 
                               dimred = "harmony_PCA", 
                               name   = "harmony_UMAP")
@@ -754,7 +786,7 @@ merged_sce <- scater::runUMAP(merged_sce,
 
 Let's see how the `harmony` UMAP, colored by sample, looks compared to the `fastMNN` UMAP:
 
-```{r harmony umap batches}
+```{r harmony_umap_batches, live = TRUE}
 scater::plotReducedDim(merged_sce,
                        dimred = "harmony_UMAP",
                        colour_by = "sample",
@@ -768,7 +800,7 @@ How do you think this `harmony` UMAP compares to that from `fastMNN` integration
 
 Let's see how this UMAP looks colored by cell type, and faceted for visibility:
 
-```{r harmony umap celltypes broad}
+```{r harmony_umap_celltypes_broad, live = TRUE}
 scater::plotReducedDim(merged_sce,
                        dimred = "harmony_UMAP",
                        colour_by = "celltype_broad",
@@ -792,7 +824,7 @@ Finally, we'll export the final SCE object with both `fastMNN` and `harmony` int
 Since this object is very large (over 1 GB!), we'll export it to a file with some compression, which, in this case, will reduce the final size to a smaller ~360 MB.
 This will take a couple minutes to save while compression is performed.
 
-```{r save integration}
+```{r save_integration, live = TRUE}
 readr::write_rds(merged_sce, 
                  integrated_sce_file,
                  compress = "gz")

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -39,7 +39,6 @@ This merged SCE can then be used for integration to obtain a formally batch-corr
 
 ```{r setup}
 # Load libraries
-library(magrittr) # access to %>%
 library(ggplot2)  # plotting tools 
 library(SingleCellExperiment) # work with SCE objects
 

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -84,7 +84,7 @@ dir(input_dir)
 ```
 
 We want to read in just four of these files, as listed previously.
-To read in these files, we could use `readr::read_rds()` function (or the base R `readRDS()`) four times, once for each of the files. 
+To read in these files, we could use the `readr::read_rds()` function (or the base R `readRDS()`) four times, once for each of the files. 
 We could also use a `for` loop, which is the approach that many programming languages would lean toward.
 A different and more modular coding approach to reading in these files (and more!) is to leverage the [`purrr`](https://purrr.tidyverse.org/) `tidyverse` package, which provides a convenient set of functions for operating on lists.
 You can read more about these functions and their power and utility in R in [Chapter 21 of _R for Data Science_](https://r4ds.had.co.nz/iteration.html#for-loops-vs.-functionals).
@@ -126,7 +126,7 @@ We'll note that, in this case, it's possible to simply run `sqrt()` directly on 
 sqrt(squares)
 ```
 
-More involved scenarios as we'll see shortly will necessitate the use of `map()`, in particular when the input is a list itself.
+More involved scenarios, as we'll see shortly, will necessitate the use of `map()`, in particular when the input is a list itself.
 
 
 One other new coding strategy we'll learn in this notebook is using the [`glue`](https://glue.tidyverse.org/) package to combine strings.
@@ -291,7 +291,7 @@ purrr::map(sce_list,
 #### Ensuring that only shared genes are used
 
 The next step in ensuring SCE compatibility is to make sure they all contain the same genes, which are stored as the SCE object's row names (these names are also found the `rowData` slot's row names). 
-Here, those gene ids are unique Ensembl gene ids .
+Here, those gene ids are unique Ensembl gene ids.
 
 We can use some `purrr` magic to quickly find the set of shared genes among our samples:
 

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -239,7 +239,7 @@ For example, consider these barcodes for the `SCPCL000479` sample:
 
 ```{r barcodes}
 # Look at the column names for the `SCPCL000479` sample, for example
-colnames(sce_list$SCPCL000479) %>%
+colnames(sce_list$SCPCL000479) |>
   # Only print out the first 6 for convenience
   head()
 ```
@@ -280,9 +280,9 @@ Here, those gene ids are unique Ensembl gene ids.
 We can use some `purrr` magic to quickly find the set of shared genes among our samples:
 
 ```{r shared genes}
-shared_genes <- sce_list %>%
+shared_genes <- sce_list |>
   # get rownames (genes) for each SCE in sce_list
-  purrr::map(rownames) %>%
+  purrr::map(rownames) |>
   # reduce to the _intersection_ among lists
   purrr::reduce(intersect)
 
@@ -295,7 +295,7 @@ We can quickly confirm that this is true by looking at the number of rows across
 
 ```{r check shared genes}
 # The number of genes in an SCE corresponds to its number of rows:
-sce_list %>%
+sce_list |>
   purrr::map(nrow)
 ```
 

--- a/scRNA-seq-advanced/03-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/03-dataset_integration.Rmd
@@ -51,7 +51,7 @@ set.seed(12345)
 
 
 We have already prepared count data for the four samples we'll be integrating (i.e., filtered cells, normalized counts, and calculated PCA & UMAP).
-These SCE objects, stored as RDS files, are available in the `data/rms/processed/` directory and are named according to their `ScPCA` library IDs:
+These SCE objects, stored as RDS files, are available in the `data/rms/processed/` directory and are named according to their `ScPCA` library ids :
 
 - `SCPCL000479.rds` (Patient A)
 - `SCPCL000480.rds` (Patient A)
@@ -84,7 +84,7 @@ dir(input_dir)
 ```
 
 We want to read in just four of these files, as listed previously.
-To read in these files, we could use `readr::read_rds()` (or the base R `readRDS()`) function four times, once for each of the files. 
+To read in these files, we could use `readr::read_rds()` function (or the base R `readRDS()`) four times, once for each of the files. 
 We could also use a `for` loop, which is the approach that many programming languages would lean toward.
 A different and more modular coding approach to reading in these files (and more!) is to leverage the [`purrr`](https://purrr.tidyverse.org/) `tidyverse` package, which provides a convenient set of functions for operating on lists.
 You can read more about these functions and their power and utility in R in [Chapter 21 of _R for Data Science_](https://r4ds.had.co.nz/iteration.html#for-loops-vs.-functionals).
@@ -243,15 +243,15 @@ How will we be able to tell which sample a given cell came from?
 
 The best way to do this is simply to add a `colData` column with the sample information, so that we can know which sample each row came from.
 
-In addition, we want to pay some attention to the SCE object's column names (the cell IDs), which must remain unique after merging since duplicate IDs will cause an R error.
+In addition, we want to pay some attention to the SCE object's column names (the cell ids), which must remain unique after merging since duplicate ids will cause an R error.
 In this case, the SCE column names are barcodes (which is usually but not always the case in SCE objects), which are only guaranteed to be unique _within_ a sample but may be repeated across samples.
 So, after merging, it's technically possible that multiple cells will have the same barcode.
 This would be a problem for two reasons: 
-First, the cell ID would not be able to point us back to cell's originating sample.
+First, the cell id would not be able to point us back to cell's originating sample.
 Second, it would literally cause an error in R, which does not allow duplicate column names.
 
 
-One way to ensure that cell IDs remain unique even after merging is to actually modify them by _prepending_ the relevant sample name. 
+One way to ensure that cell ids remain unique even after merging is to actually modify them by _prepending_ the relevant sample name. 
 For example, consider these barcodes for the `SCPCL000479` sample:
 
 ```{r barcodes, live = TRUE}
@@ -261,7 +261,7 @@ colnames(sce_list$SCPCL000479) |>
   head()
 ```
 
-These IDs will be updated `SCPCL000479-GGGACCTCAAGCGGAT`, `SCPCL000479-CACAGATAGTGAGTGC`, and so on, thereby ensuring fully unique IDs for all cells across all samples.
+These ids will be updated `SCPCL000479-GGGACCTCAAGCGGAT`, `SCPCL000479-CACAGATAGTGAGTGC`, and so on, thereby ensuring fully unique ids for all cells across all samples.
 
 #### Preserving sample information at the gene level
 
@@ -272,10 +272,10 @@ rowData(sce_list$SCPCL000479) |>
   head()
 ```
 
-Here, the rownames are Ensembl gene IDs, and columns are `gene_symbol`, `mean`, and `detected`. 
+Here, the rownames are Ensembl gene ids, and columns are `gene_symbol`, `mean`, and `detected`. 
 The `gene_symbol` column is general information about all genes, not specific to any library or experiment, but `mean` and `detected` are library-specific gene statistics. 
 So, `gene_symbol` does not need to be traced back to its originating sample, but `mean` and `detected` do.
-To this end, we can take a similar approach to what we'll do for cell IDs: 
+To this end, we can take a similar approach to what we'll do for cell ids: 
 We can change the sample-specific `rowData` column names by prepending the sample name.
 For example, rather than being called `mean`, this column will be named `SCPCL000478-mean` for the `SCPCL000478` sample.
 
@@ -291,7 +291,7 @@ purrr::map(sce_list,
 #### Ensuring that only shared genes are used
 
 The next step in ensuring SCE compatibility is to make sure they all contain the same genes, which are stored as the SCE object's row names (these names are also found the `rowData` slot's row names). 
-Here, those gene IDs are unique Ensembl gene IDs.
+Here, those gene ids are unique Ensembl gene ids .
 
 We can use some `purrr` magic to quickly find the set of shared genes among our samples:
 
@@ -360,8 +360,8 @@ format_sce <- function(sce, sample_name) {
   sce$sample <- sample_name
   
   
-  ###### Ensure cell IDs will be unique ######
-  # Update the SCE object column names (cell IDs) by prepending `sample_name`
+  ###### Ensure cell ids will be unique ######
+  # Update the SCE object column names (cell ids) by prepending `sample_name`
  colnames(sce) <- glue::glue("{sample_name}-{colnames(sce)}")
         
   
@@ -421,7 +421,7 @@ Let's take a peek at some of the innards of this new SCE object:
 # What are the unique values in the `sample` column?
 unique( colData(merged_sce)$sample )
 
-# What are the new cell IDs (column names)?
+# What are the new cell ids (column names)?
 head( colnames(merged_sce) )
 
 # What does rowData look like?
@@ -586,7 +586,7 @@ integrated_sce <- batchelor::fastMNN(
   merged_sce,
   # vector indicating the batches
   batch = merged_sce$sample, 
-  # Optionally, we can specify genes to use as the previously-ID'd
+  # Optionally, we can provide the previously-identified
   #  high variance genes across samples in the merged_sce
   subset.row = hv_genes
 )


### PR DESCRIPTION
Related to #570 
This PR aims to mostly wrap up the integration instruction notebook, including...
- making chunks live (feedback welcome!)
  - One thing I'm still on the fence for here is UMAP plotting. For now the first one is not live but the rest are (or at least this was my idea!). 
- removing spaces from chunk names (possibly overkill but doesn't _hurt_)
- switching over to base pipe
- spacing around code chunks
- printing objects separately from the chunks where they are made (did I go too far here?)
- other miscellaneous cleanups and text changes along the way!

Here's the rendered version: [03-dataset_integration.nb.html.zip](https://github.com/AlexsLemonade/training-modules/files/10346368/03-dataset_integration.nb.html.zip)
