### PR TITLE
Integration exercise setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN tar xzf salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
 ENV RENV_VERSION 0.15.2
 ENV RENV_CONFIG_CACHE_ENABLED FALSE
 RUN R -e "install.packages('remotes')"
-RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
+RUN R -e "remotes::install_version('renv', version = '${RENV_VERSION}')"
 
 WORKDIR /usr/local/renv
 COPY renv.lock renv.lock

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -246,6 +246,7 @@ MSigDB
 mTOR
 MultiQC
 multiforme
+Muraro
 murine
 Muris
 musculus

--- a/renv.lock
+++ b/renv.lock
@@ -3829,6 +3829,28 @@
         "xgboost"
       ]
     },
+    "scRNAseq": {
+      "Package": "scRNAseq",
+      "Version": "2.8.0",
+      "Source": "Bioconductor",
+      "git_url": "https://git.bioconductor.org/packages/scRNAseq",
+      "git_branch": "RELEASE_3_14",
+      "git_last_commit": "1ce543c",
+      "git_last_commit_date": "2021-10-26",
+      "Hash": "b2b9ca4712e3601d48b509c87f4454e1",
+      "Requirements": [
+        "AnnotationDbi",
+        "AnnotationHub",
+        "BiocGenerics",
+        "ExperimentHub",
+        "GenomicFeatures",
+        "GenomicRanges",
+        "S4Vectors",
+        "SingleCellExperiment",
+        "SummarizedExperiment",
+        "ensembldb"
+      ]
+    },
     "scales": {
       "Package": "scales",
       "Version": "1.1.1",

--- a/scRNA-seq-advanced/setup/README.md
+++ b/scRNA-seq-advanced/setup/README.md
@@ -58,4 +58,22 @@ To download the files, change directories to the `setup/PBMC_TotalSeqB` director
 snakemake -j2 
 ```
 
-This will place the downloaded files in `/shared/data/training-modules/scRNA-seq-advanced/data/PBMC_TotalSeqB`
+This will place the downloaded files in `/shared/data/training-modules/scRNA-seq-advanced/data/PBMC-TotalSeqB`
+
+## Rhabdomyosarcoma (RMS)
+
+These data are from [`SCPCP000005`](https://scpca.alexslemonade.org/projects/SCPCP000005)
+
+### Pancreas
+
+This data for these samples comes from the `scRNAseq` RNA package, specifically the [Muraro _et al._ (2016)](https://doi.org/10.1016/j.cels.2016.09.002) paper.
+
+The included script splits the dataset by donor, then performs filtering, normalization and dimension reduction as would usually be performed with a raw dataset.
+
+To produce the files, change directories to the `setup/pancreas` directory and run:
+
+```sh
+snakemake -j2 
+```
+
+This will place the downloaded files in `/shared/data/training-modules/scRNA-seq-advanced/data/pancreas`

--- a/scRNA-seq-advanced/setup/README.md
+++ b/scRNA-seq-advanced/setup/README.md
@@ -66,7 +66,7 @@ These data are from [`SCPCP000005`](https://scpca.alexslemonade.org/projects/SCP
 
 ### Pancreas
 
-This data for these samples comes from the `scRNAseq` RNA package, specifically the [Muraro _et al._ (2016)](https://doi.org/10.1016/j.cels.2016.09.002) paper.
+The data for these samples comes from the `scRNAseq` RNA package, specifically the [Muraro _et al._ (2016)](https://doi.org/10.1016/j.cels.2016.09.002) paper.
 
 The included script splits the dataset by donor, then performs filtering, normalization and dimension reduction as would usually be performed with a raw dataset.
 

--- a/scRNA-seq-advanced/setup/pancreas/Snakefile
+++ b/scRNA-seq-advanced/setup/pancreas/Snakefile
@@ -1,0 +1,19 @@
+configfile: "config.yaml"
+outdir = config["base_dir"]
+
+rule target:
+  input:
+    os.path.join(outdir, "processed")
+
+
+rule prepare_muraro:
+  output:
+    directory(os.path.join(outdir, "processed"))
+  log:
+    "logs/muraro_setup.log"
+  shell:
+    """
+      Rscript muraro_setup.R \
+        --outdir "{output}" \
+        >& {log}
+    """

--- a/scRNA-seq-advanced/setup/pancreas/config.yaml
+++ b/scRNA-seq-advanced/setup/pancreas/config.yaml
@@ -1,0 +1,3 @@
+# The main directory where processed files will be stored
+base_dir: /shared/data/training-modules/scRNA-seq-advanced/data/pancreas
+

--- a/scRNA-seq-advanced/setup/pancreas/muraro_setup.R
+++ b/scRNA-seq-advanced/setup/pancreas/muraro_setup.R
@@ -1,0 +1,114 @@
+#!/usr/bin/env RScript
+
+# Script to prepare sample files for integration exercise
+
+
+# Setup -----------------
+
+suppressPackageStartupMessages({
+  library(optparse)
+  library(SingleCellExperiment)
+})
+
+set.seed(2023)
+
+# Parse command line options
+options <- list(
+  make_option(
+    "--outdir",
+    help = "Path to output directory for split data files."
+  )
+)
+opts <- parse_args(OptionParser(option_list = options))
+
+# Make output directory if it doesn't exist
+if (!(dir.exists(opts$outdir))) {
+  dir.create(opts$outdir)
+}
+
+
+# Download and process pancreas data -----------
+
+# install scRNAseq package if needed
+if(!requireNamespace("scRNAseq", quietly = TRUE)){
+  BiocManager::install("scRNAseq", update = FALSE)
+}
+
+# get muraro data
+muraro_sce <- scRNAseq::MuraroPancreasData(ensembl = TRUE)
+
+# add ensembl column to rowData & remove originalName
+rowData(muraro_sce)$ensembl <- rownames(muraro_sce)
+rowData(muraro_sce)$originalName <- NULL
+
+# filtering based on http://bioconductor.org/books/3.16/OSCA.workflows/muraro-human-pancreas-cel-seq.html
+
+stats <- scuttle::perCellQCMetrics(muraro_sce)
+qc <- scuttle::quickPerCellQC(stats, 
+                              # use ERCC spike-in as QC measure
+                              sub.fields = "altexps_ERCC_percent",
+                              batch = muraro_sce$donor, 
+                              # calculate cutoff stats without outlier sample
+                              subset = muraro_sce$donor!="D28")
+muraro_sce <- muraro_sce[, !qc$discard]
+
+
+# Split merged data by donor ------
+
+# get donor list
+muraro_sce_list <- unique(muraro_sce$donor) |>
+  purrr::set_names() |>
+  # select cells for each donor
+  purrr::map( \(id) muraro_sce[, muraro_sce$donor == id] )
+
+# Remove the donor-specific cell labels
+muraro_sce_list <- muraro_sce_list |>
+  purrr::map( \(sce){
+    colnames(sce) <- stringr::str_sub(colnames(sce), 5)
+    sce
+  })
+
+
+
+# Normalization and dimension reduction ----
+
+muraro_sce_list <- muraro_sce_list |>
+  purrr::map(\(sce){
+    
+    clusters <- scran::quickCluster(sce)
+    sce <- sce |>
+      scran::computeSumFactors(clusters = clusters) |>
+      scuttle::logNormCounts()
+    
+    # use spike-in with plate blocking to model gene variance
+    var_model <- scran::modelGeneVarWithSpikes(sce, "ERCC", block=sce$plate)
+    hvgs <- scran::getTopHVGs(var_model, prop=0.1)
+    
+    # dimensionality reduction
+    sce <- sce |>
+      scater::runPCA(subset_row = hvgs) |>
+      scater::runUMAP(dimred = "PCA")
+    sce
+  })
+
+# Remove donor column and spike-in experiment. 
+
+muraro_sce_list <- muraro_sce_list |>
+  purrr::map(\(sce){
+    sce$donor <- NULL
+    altExp(sce) <- NULL
+    # add QC fields
+    sce <- scuttle::addPerCellQC(sce)
+    sce
+  })
+
+# Write output files ------
+muraro_sce_list |> 
+  purrr::iwalk(\(sce, id){
+    readr::write_rds(sce, 
+                     file.path(opts$outdir, glue::glue("{id}_sce.rds")))
+  })
+
+# log session info
+sessionInfo()
+

--- a/scripts/link-data.sh
+++ b/scripts/link-data.sh
@@ -37,6 +37,7 @@ mkdir -p scRNA-seq-advanced/data/PBMC-TotalSeqB/normalized
 mkdir -p scRNA-seq-advanced/data/glioblastoma
 mkdir -p scRNA-seq-advanced/data/rms/integrated
 mkdir -p scRNA-seq-advanced/data/rms/annotations
+mkdir -p scRNA-seq-advanced/data/pancreas
 
 # Machine learning module directory
 mkdir -p machine-learning/data
@@ -85,6 +86,7 @@ link_locs=(
   scRNA-seq-advanced/data/rms/processed
   scRNA-seq-advanced/data/rms/integrated/rms_all_sce.rds
   scRNA-seq-advanced/data/rms/annotations/rms_sample_metadata.tsv
+  scRNA-seq-advanced/data/pancreas/processed
   machine-learning/data/open-pbta
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma

--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -41,6 +41,7 @@ sync_dirs=(
   scRNA-seq-advanced/data/PBMC-TotalSeqB/normalized
   scRNA-seq-advanced/data/rms/processed
   scRNA-seq-advanced/data/rms/integrated
+  scRNA-seq-advanced/data/pancreas/processed
   machine-learning/data/open-pbta/processed
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma


### PR DESCRIPTION
Related to https://github.com/AlexsLemonade/exercise-notebook-answers/issues/126, this PR adds a setup script for the Muraro pancreas data that splits and processes that data so it can be used in a merging & integration exercise.

I updated the renv.lock as well, as well as the link and sync scripts. 

Finally I updated the setup README file, and in the process noticed that the RMS data isn't described there, so I added a little stub for that, but I am probably not the best person to fill it out!

