### PR TITLE
Enliven and clean up DE notebook with added RMS readme

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -357,6 +357,7 @@ SingleCellExperiment
 SingleCellExperiments
 SingleR
 Sirota
+Snakefile
 snakemake
 SNE
 Soneson

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -346,6 +346,7 @@ Satija
 Sca
 scater
 SCE
+ScPCA
 scran
 scRNA
 Sebire

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -346,7 +346,6 @@ Satija
 Sca
 scater
 SCE
-ScPCA
 scran
 scRNA
 Sebire

--- a/scRNA-seq-advanced/04-differential_expression.Rmd
+++ b/scRNA-seq-advanced/04-differential_expression.Rmd
@@ -115,11 +115,11 @@ For this exercise we will not be using the `fastmnn_corrected` data (more on why
 
 
 ```{r print reducedDim names, live=TRUE}
-# look at the names of the dimension reduction present in the SCE object
+# look at the names of the dimension reductions present in the SCE object
 reducedDimNames(integrated_sce)
 ```
 
-In the `reducedDim` slots you should see `PCA` and `UMAP` which both correspond to the pre-integrated dimension reduction results.
+In the `reducedDim` slots you should see `PCA` and `UMAP`, which were both calculated from the combined data _before_ integration.
 You should also see `fastmnn_PCA` and `fastmnn_UMAP` reduced dimensions, which correspond to the integrated results.
 
 Just like in the integration notebook, this dataset also contains the cell type annotations found in the `celltype_fine` and `celltype_broad` columns of the `colData`.
@@ -158,7 +158,7 @@ coldata_df <- colData(integrated_sce) |>
   # merge with sample metadata 
   dplyr::left_join(sample_metadata, by = c("sample" = "library_id")) |>
   # create new columns
-  # cell_id is combination of barcode and sample
+  # cell_id is a combination of barcode and sample
   dplyr::mutate(cell_id = glue::glue("{sample}-{barcode}"),
                 # simplify subdiagnosis for easier plotting and DE later
                 diagnosis_group = forcats::fct_recode(
@@ -193,7 +193,7 @@ scater::plotReducedDim(integrated_sce,
                        point_alpha = 0.2) 
 ```
 
-Interestingly, it looks like samples from the ARMS and ERMS subtypes tend to "cluster" with samples of the same subtype rather than "cluster" all together. 
+Interestingly, it looks like samples from the ARMS and ERMS subtypes tend to group with samples of the same subtype rather than all together. 
 
 In the integration notebook we also looked at the distribution of cell types after integration.
 In that notebook we discussed that cells of the same cell type are expected to integrate with other cells of the same type.
@@ -329,7 +329,7 @@ Pseudo-bulking creates a new counts matrix that contains the sum of the counts f
 If we were to keep each cell's counts separate, they would be treated as replicates, leading to inflated statistics. 
 By pseudo-bulking first, we will now have one count for each gene for each sample and we can take advantage of well-established methods for differential expression with bulk RNA-seq.
 
-Pseudo-bulking is implemented prior to differential expression analysis on single-cell data for the following reasons: 
+Pseudo-bulking is implemented prior to differential expression analysis on single-cell data because it: 
 
 - Produces larger and less sparse counts, which allows us to use standard normalization and differential expression methods used by bulk RNA-seq. 
 - Collapses gene expression counts by sample, so that samples, rather than cells, represent replicates.
@@ -421,7 +421,7 @@ We can set a threshold for the number of cells required to continue with our ana
 Here we will use 10, but the threshold you use for your dataset can vary depending on the composition of cell types.
 
 ```{r filter pseudobulk, live=TRUE}
-# remove any groups with less than 10 cells
+# remove any groups with fewer than 10 cells
 filter_pb_sce <- pb_sce[, pb_sce$ncells >= 10]
 ```
 
@@ -601,7 +601,7 @@ readr::write_tsv(deseq_results, deseq_output_file)
 The last thing that we will do is take a look at how many genes are significant.
 Here we will want to use the adjusted p-value, found in the `padj` column of the results, as this accounts for multiple test correction.
 
-```{r significant results}
+```{r significant results, live=TRUE}
 # first look at the significant results 
 deseq_results_sig <- deseq_results |>
   # filter based on adjusted pvalue

--- a/scRNA-seq-advanced/04-differential_expression.Rmd
+++ b/scRNA-seq-advanced/04-differential_expression.Rmd
@@ -294,8 +294,9 @@ rms_sce <- integrated_sce[,samples_to_keep]
 rms_sce
 ```
 
+Before we move on, we'll remove the original integrated object from our environment to save some memory. 
+
 ```{r remove sce}
-# remove original integrated object to save some memory
 rm(integrated_sce)
 ```
 
@@ -360,7 +361,7 @@ groups <- c("A", "A", "B", "B")
 
 # sum counts across cells (columns) by group label
 pb_counts <- DelayedArray::colsum(counts_mtx, 
-                                            groups)
+                                  groups)
 pb_counts  
 ```
 

--- a/scRNA-seq-advanced/04-differential_expression.Rmd
+++ b/scRNA-seq-advanced/04-differential_expression.Rmd
@@ -81,7 +81,7 @@ deseq_output_file <- file.path(deseq_dir, "rms_myoblast_deseq_results.tsv")
 
 We can go ahead and read in the SCE object and the metadata file.
 
-```{r read files}
+```{r read files, live=TRUE}
 # read in the SCE object that has already been integrated
 integrated_sce <- readr::read_rds(integrated_sce_file)
 
@@ -97,21 +97,15 @@ We'll start by looking at what's inside the object.
 Here we should have both the original (uncorrected) data and the integrated (corrected) data for both the gene expression and the reduced dimensionality results.
 How are those stored in our object?
 
-```{r print sce}
+```{r print sce, live=TRUE}
 # print out entire object
 integrated_sce
 ```
 
 
-```{r print assay names}
+```{r print assay names, live=TRUE}
 # look at the assay names in our object
 assayNames(integrated_sce)
-```
-
-
-```{r print reducedDim names}
-# look at the names of the dimensionality reduction present in the SCE object
-reducedDimNames(integrated_sce)
 ```
 
 When we look at the assay names we should see that there are 3 matrices, `counts`, `logcounts`, and `fastmnn_corrected`. 
@@ -119,7 +113,13 @@ The `counts` and `logcounts` assays correspond to the uncorrected gene expressio
 The `fastmnn_corrected` data contains the corrected gene expression data obtained from integration. 
 For this exercise we will not be using the `fastmnn_corrected` data (more on why not once we get to setting up the differential expression), but we need to be aware that it is present and be able to distinguish it from our uncorrected data. 
 
-In the `reducedDim` slots you should see `PCA` and `UMAP` which both correspond to the pre-integrated dimensionality reduction results.
+
+```{r print reducedDim names, live=TRUE}
+# look at the names of the dimension reduction present in the SCE object
+reducedDimNames(integrated_sce)
+```
+
+In the `reducedDim` slots you should see `PCA` and `UMAP` which both correspond to the pre-integrated dimension reduction results.
 You should also see `fastmnn_PCA` and `fastmnn_UMAP` reduced dimensions, which correspond to the integrated results.
 
 Just like in the integration notebook, this dataset also contains the cell type annotations found in the `celltype_fine` and `celltype_broad` columns of the `colData`.
@@ -131,7 +131,7 @@ Because we are going to be doing DE analysis between ARMS and ERMS samples, let'
 To do this we will need to be sure that the subtype is present in the `colData` of the integrated SCE object.
 If it's not there, we need to add it in.
 
-```{r coldata head}
+```{r coldata head, live=TRUE}
 # look at the head of the coldata
 head(colData(integrated_sce))
 ```
@@ -139,8 +139,7 @@ head(colData(integrated_sce))
 Uh oh, it looks like the RMS subtype is not found in the SCE object.
 Fortunately we also have the sample metadata table that we read in earlier, which contains information about each of the samples present in the dataset.
 
-
-```{r sample metadata}
+```{r sample metadata, live=TRUE}
 # print out sample metadata
 head(sample_metadata)
 ```
@@ -158,8 +157,8 @@ coldata_df <- colData(integrated_sce) |>
   as.data.frame() |>
   # merge with sample metadata 
   dplyr::left_join(sample_metadata, by = c("sample" = "library_id")) |>
-  # create a new columns
-  # combination of barcode and sample
+  # create new columns
+  # cell_id is combination of barcode and sample
   dplyr::mutate(cell_id = glue::glue("{sample}-{barcode}"),
                 # simplify subdiagnosis for easier plotting and DE later
                 diagnosis_group = forcats::fct_recode(
@@ -171,18 +170,21 @@ coldata_df <- colData(integrated_sce) |>
 # add modified data frame back to SCE as DataFrame
 colData(integrated_sce) <- DataFrame(coldata_df, 
                                      row.names = coldata_df$cell_id)
+```
 
+Now when we look at the `colData` of the SCE object we should see new columns, including the `diagnosis_group` column which indicates if each cell comes from an ERMS or ARMS sample.
+
+```{r print new coldata, live=TRUE}
 # take a look at the new modified colData
 head(colData(integrated_sce))
 ```
 
-Now when we look at the `colData` of the SCE object we should see new columns, including the `diagnosis_group` column which indicates if each cell comes from an ERMS or ARMS sample.
 We can now use that column to label any UMAP plots (or other plot types) that we make.
 In the chunk below we will start by taking a look at our integration results and color our cells by RMS subtype.
 
 **Reminder: You should always use the batch-corrected dimensionality reduction results for visualizing datasets containing multiple libraries or samples.**
 
-```{r diagnosis group UMAP}
+```{r diagnosis group UMAP, live=TRUE}
 # UMAP of all samples, separating by diagnosis group
 scater::plotReducedDim(integrated_sce,
                        dimred = "fastmnn_UMAP",
@@ -191,7 +193,7 @@ scater::plotReducedDim(integrated_sce,
                        point_alpha = 0.2) 
 ```
 
-Interestingly, it looks like samples from the ARMS and ERMS subtypes tend to cluster with samples of the same subtype rather than cluster all together. 
+Interestingly, it looks like samples from the ARMS and ERMS subtypes tend to "cluster" with samples of the same subtype rather than "cluster" all together. 
 
 In the integration notebook we also looked at the distribution of cell types after integration.
 In that notebook we discussed that cells of the same cell type are expected to integrate with other cells of the same type.
@@ -223,7 +225,7 @@ To explore whether cells are grouping together both by cell type and by RMS subt
 We will take advantage of the `facet_grid()` function from `ggplot2` to look at two variables in the `colData` at once - the cell type and the subdiagnosis.
 In the below plot we will color our cells by cell type while also using `facet_grid()` so that cells from different subdiagnoses will be in their own plot panel.
 
-```{r celltype subdiagnosis UMAP}
+```{r celltype subdiagnosis UMAP, live=TRUE}
 # UMAP of all samples, separating by diagnosis group and labeling cell type
 scater::plotReducedDim(integrated_sce,
                        dimred = "fastmnn_UMAP",
@@ -242,7 +244,7 @@ As expected, we see that cell types are separated, most likely due to different 
 We can also use a stacked barplot to look at the distribution of cell types across each sample, which will require a bit of wrangling first.
 
 ```{r celltype barplot}
-# filter coldata data frame to only include tumor cells
+# filter coldata to only include tumor cells
 tumor_cells_df <- coldata_df |>
   # find rows where the cell type name contains the string "Tumor"
   dplyr::filter(stringr::str_detect(celltype_broad, "Tumor"))
@@ -284,7 +286,7 @@ library_ids <- c(
   "SCPCL000491"
 )
 
-# subset sce to only contain samples with IDs of interest 
+# subset sce to only contain samples of interest 
 samples_to_keep <- integrated_sce$sample %in% library_ids
 rms_sce <- integrated_sce[,samples_to_keep]
 
@@ -313,7 +315,7 @@ Now we are ready to start preparing for our DE analysis, where we will compare t
 
 Throughout the notebook we have been working with an integrated dataset that contains corrected gene expression data (`fastmnn_corrected` assay) and a corrected UMAP.
 As a reminder, the uncorrected gene expression data, found in the `counts` and `logcounts` assays, correspond to data that has been merged (the first step we walked through prior to integration) into the same SCE but not yet integrated.
-However, we do not want to use corrected gene expression values for differential expression; `DESeq2` expects the original raw counts as input so we will be using data found in the `counts` assay of the `SingleCellExperiment` object. 
+We do not want to use corrected gene expression values for differential expression; `DESeq2` expects the original raw counts as input so we will be using data found in the `counts` assay of the `SingleCellExperiment` object. 
 
 It is advised to only use the corrected values for any analyses being performed at the cell level, e.g., dimensionality reduction.
 In contrast, it is not advised to use corrected values for any analyses that are gene-based, such as differential expression or marker gene detection, because within-batch and between-batch gene expression differences are no longer preserved.
@@ -325,7 +327,7 @@ See the [OSCA chapter on Using the corrected values](https://bioconductor.org/bo
 Before we can compare the gene expression profiles of myoblasts in ARMS vs. ERMS samples, we will need to "pseudo-bulk" the gene counts. 
 Pseudo-bulking creates a new counts matrix that contains the sum of the counts from all cells with a given label (e.g., cell type) for each sample ([Tung _et al._, 2017](https://doi.org/10.1038/srep39921)). 
 If we were to keep each cell's counts separate, they would be treated as replicates, leading to inflated statistics. 
-By pseudo-bulking first, will now have one count for each gene for each sample and we can take advantage of well-established methods for differential expression with bulk RNA-seq.
+By pseudo-bulking first, we will now have one count for each gene for each sample and we can take advantage of well-established methods for differential expression with bulk RNA-seq.
 
 Pseudo-bulking is implemented prior to differential expression analysis on single-cell data for the following reasons: 
 
@@ -352,7 +354,7 @@ counts_mtx
 Next we will create a pseudo-bulked version of this matrix with only 2 columns: 1 for group `A` and 1 for group `B`.
 To do this we will use the `DelayedArray::colsum()` function, which allows us to sum the counts for each row across groups of columns.
 
-```{r pseudobulk matrix}
+```{r pseudobulk matrix, live=TRUE}
 # define the group that each column belongs to
 groups <- c("A", "A", "B", "B")
 
@@ -398,7 +400,7 @@ How many columns does it have?
 
 Let's take a look at what the `colData` looks like in the pseudo-bulked SCE object. 
 
-```{r pseudobulk colData}
+```{r pseudobulk colData, live=TRUE}
 # note the new column with number of cells per group 
 head(colData(pb_sce))
 ```
@@ -418,14 +420,14 @@ This is equivalent to filtering out any libraries in bulk RNA-seq analysis that 
 We can set a threshold for the number of cells required to continue with our analysis and remove any groups that do not meet the minimum threshold.
 Here we will use 10, but the threshold you use for your dataset can vary depending on the composition of cell types.
 
-```{r filter pseudobulk}
+```{r filter pseudobulk, live=TRUE}
 # remove any groups with less than 10 cells
 filter_pb_sce <- pb_sce[, pb_sce$ncells >= 10]
 ```
 
 We can then take a look and see how many cell type-sample columns we removed, if any.
 
-```{r print dim}
+```{r print dim, live=TRUE}
 # print out dimensions of unfiltered pseudobulk sce
 dim(pb_sce)
 
@@ -436,14 +438,13 @@ dim(filter_pb_sce)
 It looks like we only got rid of one group.
 We can do a quick check to see which group was removed by finding which column is no longer present in the filtered object.
 
-```{r removed columns}
+```{r removed columns, live=TRUE}
 # find removed columns
 removed_cols <- !(colnames(pb_sce) %in% colnames(filter_pb_sce))
 
 # print out missing columns
 colnames(pb_sce)[removed_cols]
 ```
-
 
 The last step we want to do to prepare our dataset for DE is to subset the pseudo-bulked SCE object to contain only the cell type that we are interested in comparing across the two RMS subtypes.
 As mentioned previously, we are specifically interested in the `Tumor_Myoblast` cell type.
@@ -464,22 +465,22 @@ Now we will use the `DESeq2` package to perform differential expression (DE) ana
 From this point, we can proceed in the same way we would if we had a bulk RNA-seq dataset with 6 samples.
 We will start with the unnormalized raw counts in the `counts` assay of the pseudo-bulked SCE and do the following with `DESeq2`:
 
-- Create a `DESeq` object
+- Create a `DESeqDataSet` object
 - Normalize and log transform the counts data
 - Estimate dispersions and shrink estimates
 - Fit a negative binomial model and perform hypothesis testing using Wald statistics
 
 You can also refer to our [materials from our previous workshops covering bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/tree/master/RNA-seq#readme) for more information on using `DESeq`.
 
-#### Create the `DESeq2` object
+#### Create the `DESeqDataSet` object
 
-To create the `DESeq2` object we will need the unnormalized counts matrix, the metadata associated with the samples, and a design formula.
-The first two items are already stored in our SCE object, so we can create a DESeq2 object directly from that object using the `DESeqDataSet()` function.
+To create the `DESeqDataSet` object we will need the unnormalized counts matrix, the metadata associated with the samples, and a design formula.
+The first two items are already stored in our SCE object, so we can create a `DESeqDataSet` object directly from that object using the `DESeqDataSet()` function.
 The design formula is used to indicate which columns of the metadata need to be considered in the DE comparison.
 For our experiment we are comparing gene expression between different RMS subtypes.
 The subtype information is stored in the `diagnosis_group` column of the `colData` in the pseudo-bulked SCE.
 
-```{r deseq object}
+```{r deseq object, live=TRUE}
 # set up the deseq object 
 deseq_object <- DESeq2::DESeqDataSet(tumor_myoblast_sce,
                                      # formula for grouping samples 
@@ -510,16 +511,18 @@ normalized_object
 
 We now have a normalized and transformed object that can be directly input to the `DESeq2::plotPCA()` function, which will both calculate and plot the PC results.
 
-```{r plotPCA}
+```{r plotPCA, live=TRUE}
 DESeq2::plotPCA(normalized_object, intgroup = "diagnosis_group")
 ```
 
 As expected we see that samples group together based on RMS subtype and are separated along the PC1 axis, the PC contributing the highest amount of variation.
 
+#### Run DESeq
+
 We'll now use the convenience function `DESeq()` to perform our differential expression analysis.
 This function calculates normalization factors, estimates gene-wise dispersions, fits a negative binomial model and performs hypothesis testing using Wald statistics.
 
-```{r deseq}
+```{r deseq, live=TRUE}
 # run DESeq
 # use the same fit type as with rlog 
 deseq_object <- DESeq2::DESeq(deseq_object, fitType = "local")
@@ -528,13 +531,13 @@ deseq_object <- DESeq2::DESeq(deseq_object, fitType = "local")
 We can evaluate how well the model fit our data by looking at the dispersion estimates.
 We expect to see the dispersion estimates decrease as means are increasing and follow the line of best fit. 
 
-```{r plot dispersion}
+```{r plot dispersion, live=TRUE}
 plotDispEsts(deseq_object)
 ```
 
 Now we can extract the results from the object, specifying the p-value threshold that we would like to use.
 
-```{r results}
+```{r results, live=TRUE}
 # extract the results as a DataFrame
 deseq_results <- DESeq2::results(deseq_object, alpha = 0.05)
 ```
@@ -548,7 +551,7 @@ We can correct this by applying a "shrinkage" procedure, which will adjust large
 
 To do this, we will use the `lfcShrink()` function, but first we need to know the name and/or position of the "coefficient" that was calculated by `DESeq()`, which we can do with the `resultsNames()` function.
 
-```{r coefficient}
+```{r coefficient, live=TRUE}
 # identify position of coefficient
 DESeq2::resultsNames(deseq_object)
 ```
@@ -571,7 +574,8 @@ Before we save the results as a file, we will grab the gene symbols from the `ro
 
 ```{r add gene symbol}
 deseq_results <- shrink_results |>
-  # directly add Ensembl id as a column, converting results into a data frame
+  # directly add Ensembl id as a column
+  # converting results into a data frame
   tibble::as_tibble(rownames = "ensembl_id")
 
 # convert rowdata to data frame 
@@ -589,7 +593,7 @@ head(deseq_results)
 
 We can save the new data frame that we have created with the Ensembl identifiers, gene symbols, and the `DESeq2` results as a tab separated (`tsv`) file.
 
-```{r save deseq}
+```{r save deseq, live=TRUE}
 # save our results as tsv
 readr::write_tsv(deseq_results, deseq_output_file)
 ```
@@ -597,7 +601,7 @@ readr::write_tsv(deseq_results, deseq_output_file)
 The last thing that we will do is take a look at how many genes are significant.
 Here we will want to use the adjusted p-value, found in the `padj` column of the results, as this accounts for multiple test correction.
 
-```{r significant reults}
+```{r significant results}
 # first look at the significant results 
 deseq_results_sig <- deseq_results |>
   # filter based on adjusted pvalue
@@ -640,7 +644,7 @@ We can create UMAP plots as we did previously, but instead of labeling each cell
 We will also use some of the `ggplot2` skills we picked up earlier, like `facet_grid()` to plot cells from different RMS subtypes separately.
 This can help us validate the `DESeq2` results so that we can visualize gene expression changes across our cell type of interest on a single-cell level. 
 
-```{r expression umap}
+```{r expression umap, live=TRUE}
 # filter to just myoblast cells and remove any NA's before plotting
 myoblast_combined_sce <- rms_sce[, which(rms_sce$celltype_broad == "Tumor_Myoblast")]
 
@@ -665,7 +669,7 @@ celltypes <- c("Tumor_Myoblast",
                "Tumor_Myocyte", 
                "Vascular Endothelium")
 
-# subset to just tumor celltypes that we are interested in
+# subset to just celltypes that we are interested in
 tumor_sce <- rms_sce[, which(rms_sce$celltype_broad %in% celltypes)]
 ```
 

--- a/scRNA-seq-advanced/setup/README.md
+++ b/scRNA-seq-advanced/setup/README.md
@@ -63,7 +63,7 @@ This will place the downloaded files in `/shared/data/training-modules/scRNA-seq
 ## Rhabdomyosarcoma (RMS)
 
 These data are from [`SCPCP000005`](https://scpca.alexslemonade.org/projects/SCPCP000005).
-Files were downloaded directly from the ScPCA portal, and the `_filtered.rds` files were used as input to the Snakefile in the `rms` directory.
+Files were downloaded directly from the `ScPCA` portal, and the `_filtered.rds` files were used as input to the Snakefile in the `rms` directory.
 These files can be found in `/shared/data/training-modules/scRNA-seq-advanced/data/rms/raw`.
 
 The included scripts apply uniform filtering, normalization, and dimension reduction to each input SCE object, followed by integration of all objects using `fastMNN`.

--- a/scRNA-seq-advanced/setup/README.md
+++ b/scRNA-seq-advanced/setup/README.md
@@ -66,9 +66,9 @@ These data are from [`SCPCP000005`](https://scpca.alexslemonade.org/projects/SCP
 Files were downloaded directly from the ScPCA portal, and the `_filtered.rds` files were used as input to the Snakefile in the `rms` directory.
 These files can be found in `/shared/data/training-modules/scRNA-seq-advanced/data/rms/raw`.
 
-The included Snakefile applies uniform filtering, normalization, and dimension reduction to each input SCE object, followed by integration of all objects using `fastMNN`.
+The included scripts apply uniform filtering, normalization, and dimension reduction to each input SCE object, followed by integration of all objects using `fastMNN`.
 The list of libraries included can be found in the `setup/rms/config.yaml`.
-All libraries listed were included in pre-processing prior to integration, and all libraries except `SCPCL000482` are included in the integrated dataset that is output from the Snakefile.
+All libraries listed were included in pre-processing prior to integration, and all libraries except `SCPCL000482` are included in the integrated dataset.
 
 To produce the files, change directories to the `setup/rms` directory and run:
 

--- a/scRNA-seq-advanced/setup/README.md
+++ b/scRNA-seq-advanced/setup/README.md
@@ -62,7 +62,22 @@ This will place the downloaded files in `/shared/data/training-modules/scRNA-seq
 
 ## Rhabdomyosarcoma (RMS)
 
-These data are from [`SCPCP000005`](https://scpca.alexslemonade.org/projects/SCPCP000005)
+These data are from [`SCPCP000005`](https://scpca.alexslemonade.org/projects/SCPCP000005).
+Files were downloaded directly from the ScPCA portal, and the `_filtered.rds` files were used as input to the Snakefile in the `rms` directory.
+These files can be found in `/shared/data/training-modules/scRNA-seq-advanced/data/rms/raw`.
+
+The included Snakefile applies uniform filtering, normalization, and dimension reduction to each input SCE object, followed by integration of all objects using `fastMNN`.
+The list of libraries included can be found in the `setup/rms/config.yaml`.
+All libraries listed were included in pre-processing prior to integration, and all libraries except `SCPCL000482` are included in the integrated dataset that is output from the Snakefile.
+
+To produce the files, change directories to the `setup/rms` directory and run:
+
+```sh
+snakemake -c4
+```
+
+All individual SCE objects that have been processed can be found in `/shared/data/training-modules/scRNA-seq-advanced/data/rms/processed`.
+The integrated SCE object will be saved to `/shared/data/training-modules/scRNA-seq-advanced/data/rms/integrated/rms_all_sce.rds`.
 
 ### Pancreas
 

--- a/scRNA-seq-advanced/setup/rms/integrate_rms.R
+++ b/scRNA-seq-advanced/setup/rms/integrate_rms.R
@@ -52,7 +52,7 @@ sce_list <- purrr::map(
 names(sce_list) <- sample_ids
 
 # remove SCPCL000482
-sce_list <- sce_list[which(names(sce_list) != "SCPCL000479")]
+sce_list <- sce_list[which(names(sce_list) != "SCPCL000482")]
 
 
 # Make output directory if it doesn't exist

--- a/scRNA-seq-advanced/setup/rms/integrate_rms.R
+++ b/scRNA-seq-advanced/setup/rms/integrate_rms.R
@@ -51,6 +51,9 @@ sce_list <- purrr::map(
 # name list with sample ids 
 names(sce_list) <- sample_ids
 
+# remove SCPCL000482
+sce_list <- sce_list[which(names(sce_list) != "SCPCL000479")]
+
 
 # Make output directory if it doesn't exist
 output_dir <- dirname(opt$integrated_sce_file)


### PR DESCRIPTION
Closes #573 and #610

This PR adds live chunks to the DE notebook. I also did a little bit of cleaning up on my read through with the occasional breaking up of chunks or moving text, but not too much. 

When I was doing this I also noticed that in the setup script we are using 11 libraries because we added that 1 library for integration after we did setup. However we only talk about 10 libraries in the DE notebook and it's easy to pick out the 6 libraries that we use because they share the same cell type annotations. If we included the 11th library then we would have 7 that share the same annotations. It seemed like a lot of effort to either explain why we were only using 6 of the 7 libraries that looked good or re-do the analysis with all 7 so I added a line into the integration setup script to specifically remove that library prior to integration. 

The last small change made here was the addition of the readme description for setup of the RMS data to address #610. 