### PR TITLE
Sync glioblastoma output to S3 for input to cell type exercises

### DIFF
--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -60,6 +60,7 @@ sync_files=(
   scRNA-seq/data/tabula-muris/mm_mitochondrial_genes.tsv
   scRNA-seq/data/tabula-muris/mm_ensdb95_tx2gene.tsv
   scRNA-seq/analysis/mouse-liver/markers/cluster07_markers.tsv
+  scRNA-seq-advanced/data/glioblastoma/normalized/glioblastoma_normalized_sce.rds
   scRNA-seq-advanced/data/rms/annotations/rms_sample_metadata.tsv
   scRNA-seq-advanced/data/reference/hs_mitochondrial_genes.tsv
 )


### PR DESCRIPTION
This PR adds the output from the 1st notebook, the glioblastoma normalized and filtered data, to the `syncup-s3.sh` script. That way we can use it for input to the cell type exercise notebook. Is there any other syncing that I am missing? 