### PR TITLE
Sync myoblast DE tsv to s3

### DIFF
--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -42,6 +42,7 @@ sync_dirs=(
   scRNA-seq-advanced/data/rms/processed
   scRNA-seq-advanced/data/rms/integrated
   scRNA-seq-advanced/data/pancreas/processed
+  scRNA-seq-advanced/analysis/rms/deseq
   machine-learning/data/open-pbta/processed
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma
@@ -67,6 +68,7 @@ sync_files=(
 output_files=(
   scRNA-seq-advanced/data/glioblastoma/normalized/glioblastoma_normalized_sce.rds
   scRNA-seq-advanced/data/rms/integrated/rms_subset_sce.rds
+  scRNA-seq-advanced/analysis/rms/deseq/rms_myoblast_deseq_results.tsv
 )
 
 # combine into one list of files

--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -42,7 +42,6 @@ sync_dirs=(
   scRNA-seq-advanced/data/rms/processed
   scRNA-seq-advanced/data/rms/integrated
   scRNA-seq-advanced/data/pancreas/processed
-  scRNA-seq-advanced/analysis/rms/deseq
   machine-learning/data/open-pbta/processed
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma


### PR DESCRIPTION
From this comment: https://github.com/AlexsLemonade/exercise-notebook-answers/pull/134#issuecomment-1380572498

This PR includes the myoblast DE results file in S3, since it is read in by the DE exercise so it's needed for rendering.
I did not link the data though, so participants will need to generate it on their ends.
