### PR TITLE
Reformatting scAdvanced notebooks 1 & 2 

### DIFF
--- a/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
+++ b/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
@@ -36,9 +36,12 @@ To start, we will load some of the libraries we will need later, and set a rando
 
 ```{r setup}
 # Load libraries
-library(ggplot2) # plotting functions
-library(SingleCellExperiment) # our main class for storing Single Cell data
 
+# Plotting functions
+library(ggplot2) 
+
+# The main class we will use for Single Cell data
+library(SingleCellExperiment) 
 
 # Setting the seed for reproducibility
 set.seed(12345)
@@ -92,7 +95,8 @@ if (!dir.exists(normalized_dir)) {
 }
 
 # output RDS file for normalized data
-output_sce_file <- file.path(normalized_dir, "glioblastoma_normalized_sce.rds")
+output_sce_file <- file.path(normalized_dir,
+                             "glioblastoma_normalized_sce.rds")
 ```
 
 
@@ -124,7 +128,7 @@ One of our first steps will be to filter out barcodes that were never seen, or t
 In addition to the main `counts` matrix, listed as an `assay` in the SCE summary above, the SCE object can contain a number of other tables and matrices, each stored in a "slot" with a particular format. 
 The overall structure of the object can be seen in the figure below, which comes from an [OSCA Introduction chapter](http://bioconductor.org/books/3.16/OSCA.intro/the-singlecellexperiment-class.html).
 
-![structure of a SingleCellExperiment object](diagrams/SingleCellExperiment.png)
+![Structure of a SingleCellExperiment object](diagrams/SingleCellExperiment.png)
 
 We have just mentioned the main `assay` slot, which contains full matrices of data (such as transcript counts) with each row a feature and each column a cell. 
 There are also a couple of tables for metadata, and a slot to store reduced-dimension representations (e.g., PCA and/or UMAP) of the expression data.
@@ -323,7 +327,8 @@ We stick with that default, but for clarity, we will also include it in our code
 
 ```{r miQC plotFiltering}
 # look at miQC filtering
-miQC::plotFiltering(filtered_sce, miqc_model, posterior_cutoff = 0.75) + 
+miQC::plotFiltering(filtered_sce, miqc_model, 
+                    posterior_cutoff = 0.75) + 
   theme_bw()
 ```
 
@@ -333,7 +338,8 @@ The cutoff point can vary for different numbers of unique genes within a sample,
 At this point, we can perform the actual filtering using the `filterCells()` function, giving us a further filtered SCE object.
 
 ```{r miQC filtercells, live=TRUE}
-qcfiltered_sce <- miQC::filterCells(filtered_sce, model = miqc_model)
+qcfiltered_sce <- miQC::filterCells(filtered_sce, 
+                                    model = miqc_model)
 ```
 
 ### One more filter: unique gene count
@@ -365,7 +371,8 @@ Finally, we apply the scaling factor to the expression values for each cell and 
 qclust <- scran::quickCluster(qcfiltered_sce)
 
 # use clusters to compute scaling factors and add to SCE object
-qcfiltered_sce <- scran::computeSumFactors(qcfiltered_sce, clusters = qclust)
+qcfiltered_sce <- scran::computeSumFactors(qcfiltered_sce, 
+                                           clusters = qclust)
 
 # perform normalization using scaling factors
 # and save as a new SCE object

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -511,10 +511,8 @@ Now we can perform the classification step, using our SCE object and the `Single
 ```{r classify fine, live=TRUE}
 # classify with fine model
 singler_result_fine <- SingleR::classifySingleR(
-  # our SCE object
-  sce,
-  # the trained model object
-  singler_finemodel,
+  sce, # our SCE object
+  singler_finemodel, # the trained model object
   # perform fine tuning (default)
   fine.tune = TRUE,
   # parallel processing

--- a/scRNA-seq-advanced/02-celltype_assignment.Rmd
+++ b/scRNA-seq-advanced/02-celltype_assignment.Rmd
@@ -41,7 +41,7 @@ To start, we will load some of the libraries we will need later, and set a rando
 ```{r setup}
 # Load libraries
 library(ggplot2) # plotting functions
-library(SingleCellExperiment) # our main class for storing Single Cell data
+library(SingleCellExperiment) # Bioconductor single-cell data class
 
 
 # Setting the seed for reproducibility
@@ -59,13 +59,17 @@ We aren't planning any significant modifications of the underlying data, so we w
 
 ```{r filepaths, live=TRUE}
 # directory for the input data
-data_dir <- file.path("data", "PBMC-TotalSeqB", "normalized")
+data_dir <- file.path("data", 
+                      "PBMC-TotalSeqB", 
+                      "normalized")
 
 # the input file itself
-sce_file <- file.path(data_dir, "PBMC_TotalSeqB_normalized_sce.rds")
+sce_file <- file.path(data_dir, 
+                      "PBMC_TotalSeqB_normalized_sce.rds")
 
 # A directory to store outputs
-analysis_dir <- file.path("analysis", "PBMC-TotalSeqB")
+analysis_dir <- file.path("analysis", 
+                          "PBMC-TotalSeqB")
 
 # check whether the output directory exists 
 if (!dir.exists(analysis_dir)){
@@ -73,7 +77,8 @@ if (!dir.exists(analysis_dir)){
 }
 
 # output table path
-cellinfo_file <- file.path(analysis_dir, "PBMC_TotalSeqB_cellinfo.tsv")
+cellinfo_file <- file.path(analysis_dir, 
+                           "PBMC_TotalSeqB_cellinfo.tsv")
 ```
 
 
@@ -178,7 +183,7 @@ We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels.
 Note that this function can plot data from the `colData` table (as we used it above when plotting clusters), in the main gene expression matrix (as we used it in the previous notebook), *AND* in `altExp` tables and matrices!
 So to color by the ADT levels (as normalized in the `logcounts` matrix) we only need to provide the tag name that we want to plot in the `colour_by` argument.
 
-```{r plot CD3, live = TRUE}
+```{r plot CD3, live=TRUE}
 # plot CD3 expression
 scater::plotUMAP(sce, colour_by = "CD3")
 ```
@@ -349,16 +354,17 @@ The `celldex` functions also have a convenient option to convert gene symbols to
 
 ```{r get monaco}
 # Bioconductor "Hub" packages provide the option to cache
-# downloads, but the interactive prompt can be annoying
-# when working with notebooks.
+#   downloads, but the interactive prompt can be annoying
+#   when working with notebooks.
 # These options disable the prompt by giving permission 
-# to create the cache automatically
+#   to create the cache automatically
 ExperimentHub::setExperimentHubOption("ASK", FALSE)
 AnnotationHub::setAnnotationHubOption("ASK", FALSE)
 
 # Get Monaco 2019 data from celldex with Ensembl ids.
 monaco_ref <- celldex::MonacoImmuneData(ensembl = TRUE)
 ```
+
 What is this `monaco_ref` object?
 
 ```{r explore ref, live = TRUE}


### PR DESCRIPTION
Here I am adding a few small edits to the first two teaching notebooks for narrower rendering. 

Unlike @allyhawkins, I didn't elect to reformat `DataFrames` as `data.frames`, but I think it is fine to not be perfectly consistent here.