### PR TITLE
Remove specifying local fit type

### DIFF
--- a/scRNA-seq-advanced/04-differential_expression.Rmd
+++ b/scRNA-seq-advanced/04-differential_expression.Rmd
@@ -272,7 +272,7 @@ ggplot(tumor_cells_df, aes(x = sample, fill = celltype_broad)) +
     geom_bar(position = "fill", color = "black", size = 0.2) +
     labs(
       x = "Sample",
-      y = "Number of cells", 
+      y = "Proportion of cells", 
       fill = "Cell type"
     ) +
   theme_bw() +
@@ -676,7 +676,7 @@ This can help us validate the `DESeq2` results so that we can visualize gene exp
 # filter to just myoblast cells and remove any NA's before plotting
 myoblast_combined_sce <- rms_sce[, which(rms_sce$celltype_broad == "Tumor_Myoblast")]
 
-# plot PTPRT expression in ARMS vs. ERMS
+# plot PTPRT (ENSG00000196090) expression in ARMS vs. ERMS
 scater::plotReducedDim(myoblast_combined_sce,
                        dimred = "fastmnn_UMAP",
                        colour_by = "ENSG00000196090", #PTPRT

--- a/scRNA-seq-advanced/04-differential_expression.Rmd
+++ b/scRNA-seq-advanced/04-differential_expression.Rmd
@@ -534,8 +534,7 @@ deseq_object <- DESeq2::estimateSizeFactors(deseq_object)
 
 # normalize and log transform to use for visualization
 normalized_object <- DESeq2::rlog(deseq_object, 
-                                  blind = TRUE, 
-                                  fitType = 'local')
+                                  blind = TRUE)
 normalized_object
 ```
 
@@ -554,8 +553,7 @@ This function calculates normalization factors, estimates gene-wise dispersions,
 
 ```{r deseq, live=TRUE}
 # run DESeq
-# use the same fit type as with rlog 
-deseq_object <- DESeq2::DESeq(deseq_object, fitType = "local")
+deseq_object <- DESeq2::DESeq(deseq_object)
 ```
 
 We can evaluate how well the model fit our data by looking at the dispersion estimates.


### PR DESCRIPTION
Closes #638 
Closes #643 

Here I made some minor edits to the differential expression notebook based on some things we learned at the first training. I removed the `fitType=local` from setting up and running `DESeq` and tested that things still ran successfully. I also changed the few comments/ labels that were mentioned in #643 while I was making edits. 