### PR TITLE
Trying temporary r version downgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:4.2.3
+FROM rocker/tidyverse:4.2.2
 LABEL maintainer="ccdl@alexslemonade.org"
 WORKDIR /rocker-build/
 
@@ -42,7 +42,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install
 
 # FastQC
-RUN apt update && apt install -y fastqc
+RUN apt-get update && apt-get install -y fastqc
 
 # fastp
 ENV FASTP_VERSION 0.20.1
@@ -69,10 +69,8 @@ RUN tar xzf salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
     ln -s /usr/local/src/salmon-latest_linux_x86_64/bin/salmon /usr/local/bin/salmon
 
 # Use renv for R packages
-ENV RENV_VERSION 0.17.2
 ENV RENV_CONFIG_CACHE_ENABLED FALSE
-RUN R -e "install.packages('remotes')"
-RUN R -e "remotes::install_version('renv', version = '${RENV_VERSION}')"
+RUN R -e "install.packages(c('renv', 'yaml', 'BiocManager'))"
 
 WORKDIR /usr/local/renv
 COPY renv.lock renv.lock


### PR DESCRIPTION
The docker image mysteriously stopped building between yesterday and today, which I can only think is some hidden dependency/something that broke in a daily build of rocker 4.2.3. So here I am downgrading to R 4.2.2, which is not _exactly_ what we have on the server, but should be fine. I will monitor R 4.2.3 to see if we can make it match as time goes on. 