### PR TITLE
Add dimensionality reduction slide link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The accompanying slides for each module are linked below and briefly introduce t
 - [Machine learning](https://docs.google.com/presentation/d/1o90uBTlQMx8qu3Jbhqe-ch-ykvLb3_vpi0O-6lBggRg/edit?usp=sharing)
 - Intro to scRNA-seq
   - [Intro to scRNA-seq](https://docs.google.com/presentation/d/1EGijSWUxcfjLpDU9QULYLHxsHMHlI6KPtR1Cs4QWy7A/edit?usp=sharing)
+  - [Dimensionality reduction and Clustering](https://docs.google.com/presentation/d/1W1-rZ1xJROSUC7rOYDJhJ1q-Z9gvdIXS4CzPHluMHnk/edit?usp=sharing)
   - [Cell type annotation](https://docs.google.com/presentation/d/16ivLdwm17jqHZKOnRGVjigIMAZtr9Xpc5kjspn9mIhQ/edit?usp=sharing)
 - Advanced scRNA-seq
   - [scRNA-seq refresher](https://docs.google.com/presentation/d/1qjmx_C0P5feswxXvn6ezCRE5OObtB9iftQvI3ceUAa0/edit?usp=sharing)


### PR DESCRIPTION
Does what it says on the title, but this seems as good a time as any for reviewers to have a look at the updates that I made to both 
- [Dimensionality reduction and clustering slides](https://docs.google.com/presentation/d/1W1-rZ1xJROSUC7rOYDJhJ1q-Z9gvdIXS4CzPHluMHnk/edit?usp=sharing)
- and [Cell typing slides](https://docs.google.com/presentation/d/16ivLdwm17jqHZKOnRGVjigIMAZtr9Xpc5kjspn9mIhQ/edit?usp=sharing)

Completes one more checkbox on https://github.com/AlexsLemonade/training-modules/issues/714