### PR TITLE
Update/fix notebook links

### DIFF
--- a/intro-to-R-tidyverse/03-intro_to_tidyverse.Rmd
+++ b/intro-to-R-tidyverse/03-intro_to_tidyverse.Rmd
@@ -28,7 +28,9 @@ It is a pre-processed [astrocytoma microarray dataset](https://www.refine.bio/ex
 **More tidyverse resources:**
 
 - [R for Data Science](https://r4ds.had.co.nz/)
-- [tidyverse documentation](https://dplyr.tidyverse.org/)
+- [tidyverse documentation](https://tidyverse.org/)
+  - [`dplyr` documentation](https://dplyr.tidyverse.org/)
+  - [`readr` documentation](https://readr.tidyverse.org/)
 - [Cheatsheet of tidyverse data transformation](https://github.com/rstudio/cheatsheets/raw/main/data-transformation.pdf)
 - [Online tidyverse book chapter](https://privefl.github.io/advr38book/tidyverse.html)
 

--- a/scRNA-seq/01-scRNA_quant_qc.Rmd
+++ b/scRNA-seq/01-scRNA_quant_qc.Rmd
@@ -163,7 +163,7 @@ Many of the options for the `salmon alevin` command are the same as those you wo
 #### `-l`
 The `-l` option is for designating the library format. 
 For most single-cell quantification, you will want to use the `ISR` library type.
-See [Salmon's documentation](https://salmon.readthedocs.io/en/latest/library_type.html) for more information on fragment library types (and all of the other options available).
+See [Salmon's documentation](https://salmon.readthedocs.io/en/latest/library_type.html#fraglibtype) for more information on fragment library types (and all of the other options available).
 Note that this option must come *before* the read files.
 
 #### `--chromium`

--- a/scRNA-seq/01-scRNA_quant_qc.Rmd
+++ b/scRNA-seq/01-scRNA_quant_qc.Rmd
@@ -163,7 +163,7 @@ Many of the options for the `salmon alevin` command are the same as those you wo
 #### `-l`
 The `-l` option is for designating the library format. 
 For most single-cell quantification, you will want to use the `ISR` library type.
-See [Salmon's documentation](https://salmon.readthedocs.io/en/latest/library_type.html#fraglibtype) for more information on fragment library types (and all of the other options available).
+See [Salmon's documentation](https://salmon.readthedocs.io/en/latest/library_type.html) for more information on fragment library types (and all of the other options available).
 Note that this option must come *before* the read files.
 
 #### `--chromium`
@@ -183,7 +183,7 @@ The file is a TSV (tab-separated values) file with 2 columns: one of transcripts
 This option will print out information that we will use for quality checks later on, including files with information on the UMIs and cell barcodes.
 
 See the [Alevin documentation](https://salmon.readthedocs.io/en/latest/alevin.html) for a complete list of the Alevin options.
-There are also a number of example analyses at the [Alevin tutorial](https://combine-lab.github.io/alevin-tutorial/#blog) website.
+There are also a number of example analyses at the [Alevin tutorial](https://combine-lab.github.io/alevin-tutorial/) website.
 
 
 ### Note: Running the FULL sample.

--- a/scRNA-seq/02-filtering_scRNA.Rmd
+++ b/scRNA-seq/02-filtering_scRNA.Rmd
@@ -114,7 +114,7 @@ rowData(bladder_sce)
 We could leave the object as it is, but we can unlock some extra functionality by converting this from a `SummarizedExperiment` object to a `SingleCellExperiment`, so we will go ahead and do that next.
 `SingleCellExperiment` objects are a subtype of `SummarizedExperiment` objects that a lot of single-cell analysis R packages use, so we will try to get acquainted with them.
 
-For more information on `SingleCellExperiment` objects, as well as many other topics related to this course, we highly recommend the e-book [_Orchestrating Single-Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/3.16/OSCA/) and/or [Amezquita *et al.* (2020)](https://www.nature.com/articles/s41592-019-0654-x)
+For more information on `SingleCellExperiment` objects, as well as many other topics related to this course, we highly recommend the e-book [_Orchestrating Single-Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/3.16/OSCA/) and/or [Amezquita *et al.* (2020)](https://www.nature.com/articles/s41592-019-0654-x).
 
 Below is a figure from OSCA that shows the general structure of `SingleCellExperiment` objects.
 

--- a/scRNA-seq/03-normalizing_scRNA.Rmd
+++ b/scRNA-seq/03-normalizing_scRNA.Rmd
@@ -22,7 +22,7 @@ In this notebook, we'll continue to process the same dataset that we have been w
 For this tutorial, we will be using a pair of single-cell analysis specific
 R packages: `scater` and `scran` to work with our data.
 This tutorial is in part based on the [scran
-tutorial](https://bioconductor.org/packages/devel/bioc/vignettes/scran/inst/doc/scran.html).
+tutorial](https://bioconductor.org/packages/release/bioc/vignettes/scran/inst/doc/scran.html).
 
 ![Roadmap: QC and filtering](diagrams/roadmap_single_qc_norm_alevin.png)
 

--- a/scRNA-seq/04-dimension_reduction_scRNA.Rmd
+++ b/scRNA-seq/04-dimension_reduction_scRNA.Rmd
@@ -495,7 +495,7 @@ readr::write_rds(normalized_sce, file = output_sce_file)
 - [Becht *et al.* (2018)](https://www.nature.com/articles/nbt.4314) discusses using [UMAP](https://github.com/lmcinnes/umap) for single-cell data.
 - [Wattenberg *et al.* (2016)](https://distill.pub/2016/misread-tsne/) discuss how to use t-SNE properly with great visuals.
 (The lessons apply to UMAP as well, with a broad substitution of the `n_neighbors` parameter for `perplexity`.)
-- [Nguyen & Holmes (2019)](https://journals.plos.org/ploscompbiol/article/file?id=10.1371/journal.pcbi.1006907&type=printable) lay out guidelines on choosing dimensions reduction methods.
+- [Nguyen & Holmes (2019)](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006907) lay out guidelines on choosing dimensions reduction methods.
 - [Freitag (2019)](https://rpubs.com/Saskia/520216) is a nice explanation and comparison of many different dimensionality reduction techniques that you may encounter.
 
 

--- a/scRNA-seq/05-clustering_markers_scRNA.Rmd
+++ b/scRNA-seq/05-clustering_markers_scRNA.Rmd
@@ -80,7 +80,7 @@ You might wonder: How many clusters should we use?
 That is a hard question!
 There are some heuristics we can use for deciding the "correct" number of clusters, but we will not be exploring those right now.
 
-For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/3.14/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
+For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section "Vector quantization with -_k_-means" in the Clustering chapter](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html) is a good reference.
 
 We are going to use the function `clusterRows()` from the  Bioconductor `bluster` package for our clustering.
 This function takes a matrix where each sample (cell in our case) is a row and each column is a feature.
@@ -187,7 +187,7 @@ Again, you will have time to explore these more in the exercise notebook, and of
 Sadly, there are not always good answers to which set of inferred clusters is best!
 Which method and parameters you use may depend on the kind of question you are trying to answer.
 
-For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.14/OSCA.basic/clustering.html#clustering-graph).
+For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html).
 A recent review by [Kislev *et al.* (2019)](https://doi.org/10.1038/s41576-018-0088-9) also goes into some depth about the differences among algorithms and the general challenges associated with clustering single cell data.
 
 ## Identifying marker genes

--- a/scRNA-seq/05-clustering_markers_scRNA.Rmd
+++ b/scRNA-seq/05-clustering_markers_scRNA.Rmd
@@ -80,7 +80,7 @@ You might wonder: How many clusters should we use?
 That is a hard question!
 There are some heuristics we can use for deciding the "correct" number of clusters, but we will not be exploring those right now.
 
-For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section "Vector quantization with -_k_-means" in the Clustering chapter](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html) is a good reference.
+For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section "Vector quantization with _k_-means" in the "Clustering" chapter](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html) is a good reference.
 
 We are going to use the function `clusterRows()` from the  Bioconductor `bluster` package for our clustering.
 This function takes a matrix where each sample (cell in our case) is a row and each column is a feature.

--- a/scRNA-seq/05-clustering_markers_scRNA.Rmd
+++ b/scRNA-seq/05-clustering_markers_scRNA.Rmd
@@ -80,7 +80,7 @@ You might wonder: How many clusters should we use?
 That is a hard question!
 There are some heuristics we can use for deciding the "correct" number of clusters, but we will not be exploring those right now.
 
-For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section "Vector quantization with _k_-means" in the "Clustering" chapter](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html) is a good reference.
+For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
 
 We are going to use the function `clusterRows()` from the  Bioconductor `bluster` package for our clustering.
 This function takes a matrix where each sample (cell in our case) is a row and each column is a feature.
@@ -187,7 +187,7 @@ Again, you will have time to explore these more in the exercise notebook, and of
 Sadly, there are not always good answers to which set of inferred clusters is best!
 Which method and parameters you use may depend on the kind of question you are trying to answer.
 
-For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html).
+For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph).
 A recent review by [Kislev *et al.* (2019)](https://doi.org/10.1038/s41576-018-0088-9) also goes into some depth about the differences among algorithms and the general challenges associated with clustering single cell data.
 
 ## Identifying marker genes

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -324,7 +324,7 @@ While this technique might be good for some simple experiments, and can be usefu
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/3.16/bioc/html/AUCell.html).
-For more on that method, the OSCA section [Assigning cell labels from gene sets in the "Cell Type Annotation" chapter](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html)  is a very good reference.
+For more on that method, the OSCA section ["Assigning cell labels from gene sets" in the "Cell Type Annotation" chapter](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html)  is a very good reference.
 
 
 ## Cell type annotation with `SingleR`

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -326,6 +326,7 @@ We also looked at each marker separately, which might not be the most efficient 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/3.16/bioc/html/AUCell.html).
 For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
 
+
 ## Cell type annotation with `SingleR`
 
 An alternative approach to using known marker genes for classification is to instead classify cells by comparing them to a reference expression dataset.

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -32,7 +32,7 @@ The antibodies used here are the [The TotalSeq™-B Human TBNK Cocktail](https:/
 
 The data here have already been filtered, normalized, and had dimension reductions calculated for the single-cell RNA-seq data.
 The ADT data has also been separately filtered and normalized.
-For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html) of OSCA.
+For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
 
 The processed gene expression and ADT data were saved into a combined `SingleCellExperiment` (SCE) object, and we will start with that object for our exploration here.
 
@@ -324,8 +324,7 @@ While this technique might be good for some simple experiments, and can be usefu
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/3.16/bioc/html/AUCell.html).
-For more on that method, the OSCA section ["Assigning cell labels from gene sets" in the "Cell Type Annotation" chapter](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html)  is a very good reference.
-
+For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
 
 ## Cell type annotation with `SingleR`
 

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -32,7 +32,7 @@ The antibodies used here are the [The TotalSeq™-B Human TBNK Cocktail](https:/
 
 The data here have already been filtered, normalized, and had dimension reductions calculated for the single-cell RNA-seq data.
 The ADT data has also been separately filtered and normalized.
-For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
+For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html) of OSCA.
 
 The processed gene expression and ADT data were saved into a combined `SingleCellExperiment` (SCE) object, and we will start with that object for our exploration here.
 
@@ -324,7 +324,7 @@ While this technique might be good for some simple experiments, and can be usefu
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/3.16/bioc/html/AUCell.html).
-For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
+For more on that method, the OSCA section [Assigning cell labels from gene sets in the "Cell Type Annotation" chapter](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html)  is a very good reference.
 
 
 ## Cell type annotation with `SingleR`


### PR DESCRIPTION
This PR fixes links as indicated in this comment: https://github.com/AlexsLemonade/training-modules/pull/723#issuecomment-1538634461

For links containing a `#`, I couldn't find a way to make `htmlpreview` play nicely with them, so they are now just gone! I tried to update the link text so that enough context was provided for which section in the linked website is of interest.
