### PR TITLE
Notebook updates: Some md -> Rmd, and colour -> color

### DIFF
--- a/intro-to-R-tidyverse/00a-rstudio_guide.Rmd
+++ b/intro-to-R-tidyverse/00a-rstudio_guide.Rmd
@@ -1,4 +1,12 @@
-# A quick guide to RStudio
+---
+title: "A quick guide to RStudio"
+author: CCDL for ALSF
+date: 2021
+output:
+  html_document:
+    toc: true
+    toc_float: true
+---
 
 Our course material uses [R Markdown Notebooks](https://bookdown.org/yihui/rmarkdown/notebook.html).
 Opening and running R Markdown (`.Rmd`) files requires [RStudio](https://www.rstudio.com/products/RStudio/).

--- a/intro-to-R-tidyverse/00b-debugging_resources.Rmd
+++ b/intro-to-R-tidyverse/00b-debugging_resources.Rmd
@@ -1,4 +1,12 @@
-# An Introductory Guide to Troubleshooting Errors
+---
+title: "An Introductory Guide to Troubleshooting Errors"
+author: CCDL for ALSF
+date: 2021
+output:
+  html_document:
+    toc: true
+    toc_float: true
+---
 
 This guide gives you tips and approaches for fixing errors that will arise. We 
 also go through some of the most common errors that you will encounter and what 

--- a/intro-to-R-tidyverse/00c-good-scientific-coding-practices.Rmd
+++ b/intro-to-R-tidyverse/00c-good-scientific-coding-practices.Rmd
@@ -1,6 +1,14 @@
-## Tips for good scientific coding practices
+---
+title: "Tips for good scientific coding practices"
+author: CCDL for ALSF
+date: 2021
+output:
+  html_document:
+    toc: true
+    toc_float: true
+---
 
-### Style guides help people read your code
+## Style guides help people read your code
 
 Just how incorrect punctuation and grammar can distract a reader from the message in your writing, code that doesn't follow a style can be difficult for others to understand and use.
 Your code is not as useful if it isn't easily readable, which is why naming conventions, code style, and consistency are important.
@@ -9,7 +17,7 @@ We suggest following a style guide like one of these:
 - [Hadley Wickham's R Style Guide](http://adv-r.had.co.nz/Style.html)  
 - [Google's R Style Guide](https://google.github.io/styleguide/Rguide.xml).   
 
-### `set.seed()` helps people reproduce your results
+## `set.seed()` helps people reproduce your results
 
 Setting the seed is needed when performing any kind of analyses that use random sampling or something that may vary each time you re-run it.
 
@@ -75,13 +83,13 @@ The preview shows you a rendered HTML copy of the contents of the editor.
 Consequently, unlike *Knit*, *Preview* does not run any R code chunks.
 Instead, the output of the chunk when it was last run in the editor is displayed.
 
-### `sessionInfo` tells people what packages you used
+## `sessionInfo()` tells people what packages you used
 
-The `sessionInfo` function prints out what packages and versions you used in your analysis.
+The `sessionInfo()` function prints out what packages and versions you used in your analysis.
 This way, when others try to reproduce your research, they know what packages you have loaded and how things were set for the code you ran.
 
-#### More reading on good scientific code:
+## More reading on good scientific code:
 
-- ['Ten simple rules' for reproducible computational research- PLoS](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003285)
-- ['Ten simple rules' for documenting scientific software](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006561)
+- ['Ten simple rules' for reproducible computational research  (PLOS)](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003285)
+- ['Ten simple rules' for documenting scientific software (PLOS)](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006561)
 - [Guide to reproducible code](https://github.com/crazyhottommy/getting-started-with-genomics-tools-and-resources/blob/master/guide-to-reproducible-code.pdf)

--- a/scRNA-seq/04-dimension_reduction_scRNA.Rmd
+++ b/scRNA-seq/04-dimension_reduction_scRNA.Rmd
@@ -376,11 +376,11 @@ normalized_sce <- runUMAP(normalized_sce,
 ```
 
 Now we can plot with the same `plotReducedDim()` function, specifying we want to plot the UMAP results this time.
-We will also add some color (colour) this time with the `colour_by` argument, using the number of genes detected in each cell to assign a hue.
+We will also add some color this time with the `color_by` argument, using the number of genes detected in each cell to assign a hue.
 
 ```{r plot_umap, live = TRUE}
 # make a UMAP plot with `plotReducedDim()`
-plotReducedDim(normalized_sce, "UMAP", colour_by = "detected")
+plotReducedDim(normalized_sce, "UMAP", color_by = "detected")
 ```
 
 There is clearly a lot of structure in there, but is it meaningful?
@@ -408,9 +408,9 @@ UMAP_plot_wrapper <- function(sce = normalized_sce, nn_param = 15) {
 
   # Run UMAP with a specified n_neighbors parameter
   sce_umap <- scater::runUMAP(sce, dimred = "PCA", n_neighbors = nn_param)
-  scater::plotReducedDim(sce_umap, "UMAP", colour_by = "detected") +
+  scater::plotReducedDim(sce_umap, "UMAP", color_by = "detected") +
     # make the legend label more informative (this is ggplot2 code!)
-    guides(color = guide_colourbar(title="genes\nexpressed"))
+    guides(color = guide_colorbar(title="genes\nexpressed"))
 }
 ```
 
@@ -474,7 +474,7 @@ Note that this analysis also uses PCA before moving on to the fancy machine lear
 normalized_sce <- runTSNE(normalized_sce, dimred = "PCA")
 
 # plot with scater function
-plotReducedDim(normalized_sce, "TSNE", colour_by = "detected")
+plotReducedDim(normalized_sce, "TSNE", color_by = "detected")
 ```
 
 Different! (Slower!) Is it better or worse? Hard to say!

--- a/scRNA-seq/05-clustering_markers_scRNA.Rmd
+++ b/scRNA-seq/05-clustering_markers_scRNA.Rmd
@@ -124,7 +124,7 @@ Note that this does require that the cluster identities were stored in the `Sing
 
 ```{r plot_k, live = TRUE}
 # plot clustering results
-plotReducedDim(hodgkins_sce, "UMAP", colour_by = "kcluster")
+plotReducedDim(hodgkins_sce, "UMAP", color_by = "kcluster")
 ```
 
 - Do those clusters line up with what you might have expected if you were doing this by eye?
@@ -175,7 +175,7 @@ This time we will also use the `text_by` argument to include the cluster ids dir
 ```{r plot_nnclust, live = TRUE}
 plotReducedDim(hodgkins_sce,
                "UMAP",
-               colour_by = "nncluster",
+               color_by = "nncluster",
                text_by = "nncluster")
 ```
 
@@ -310,7 +310,7 @@ marker_df_list <- purrr::imap(
 
 One thing we can do with this list of marker genes is to see how they look across the cells and clusters.
 The `scater::plotReducedDim()` function makes this easy!
-We have earlier colored points by some cell statistic, like the number of expressed genes, but it is just as easy to color by the expression of a single gene by using the gene identifier as the `colour_by` argument.
+We have earlier colored points by some cell statistic, like the number of expressed genes, but it is just as easy to color by the expression of a single gene by using the gene identifier as the `color_by` argument.
 
 The first step is to get the gene information for the genes we might be interested in.
 
@@ -335,9 +335,9 @@ symbol <- gene_info$Symbol[rank]
 
 # Plot UMAP results colored by expression
 plotReducedDim(hodgkins_sce, "UMAP",
-               colour_by = gene_id) +
+               color_by = gene_id) +
   # label the guide with the gene symbol
-  guides(color = guide_colourbar(title = symbol))
+  guides(color = guide_colorbar(title = symbol))
 ```
 
 

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -159,9 +159,9 @@ This is a shortcut for `scater::plotReducedDim(dimred = "UMAP", ...)`, which can
 
 ```{r plot clusters}
 # plot clusters
-scater::plotUMAP(sce, colour_by = "nn_cluster") + 
+scater::plotUMAP(sce, color_by = "nn_cluster") + 
   # rename the legend
-  guides(colour = guide_legend(title = "Cluster"))
+  guides(color = guide_legend(title = "Cluster"))
 ```
 But what are these clusters, really? 
 Do they correspond to particular cell types that we are interested in?
@@ -180,11 +180,11 @@ The first marker we will look at is `CD3`, which is a protein complex that is fo
 We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels. 
 
 Note that this function can plot data from the `colData` table (as we used it above when plotting clusters), in the main gene expression matrix (as we used it in the previous notebook), *AND* in `altExp` tables and matrices!
-So to color by the ADT levels (as normalized in the `logcounts` matrix) we only need to provide the tag name that we want to plot in the `colour_by` argument.
+So to color by the ADT levels (as normalized in the `logcounts` matrix) we only need to provide the tag name that we want to plot in the `color_by` argument.
 
 ```{r plot CD3, live=TRUE}
 # plot CD3 expression
-scater::plotUMAP(sce, colour_by = "CD3")
+scater::plotUMAP(sce, color_by = "CD3")
 ```
 
 It appears that we have a number of potential T cells down in the lower left!
@@ -200,13 +200,13 @@ Let's plot the ADT results for those two markers as well below:
 ```{r plot CD4, live=TRUE}
 # plot CD4 marker
 scater::plotUMAP(sce, 
-                 colour_by = "CD4")
+                 color_by = "CD4")
 ```
 
 ```{r plot CD8, live=TRUE}
 # plot CD8 marker
 scater::plotUMAP(sce, 
-                 colour_by = "CD8")
+                 color_by = "CD8")
 ```
 
 
@@ -308,7 +308,7 @@ Creating and assigning values to this column can be done with the `$` shortcut, 
 ```{r plot thresholds}
 sce$threshold_celltype <- adt_df$celltype
 scater::plotUMAP(sce, 
-                 colour_by = "threshold_celltype") + 
+                 color_by = "threshold_celltype") + 
   guides(color = guide_legend(title = "Cell type"))
 ```
 
@@ -458,9 +458,19 @@ sce$celltype_main <- singler_result$pruned.labels
 Now we can plot the cell type assignments onto our UMAP to see how they compare to the patterns we saw there before.
 
 ```{r plot celltype umap, live=TRUE}
-scater::plotUMAP(sce, colour_by = "celltype_main") 
+scater::plotUMAP(sce, color_by = "celltype_main") 
 ```
-Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices, but this plot isn't a bad start!
+Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices.
+Luckily, since `plotUMAP()` returns a ggplot object, we can modify the color palette using ggplot2 functions.
+Still annoyingly, however, when we change the palette, the legend title defaults to the uninformative name `"colour_by"`, so we'll also specify a matching legend title with our new color palette.
+
+```{r plot celltype umap palette}
+scater::plotUMAP(sce, color_by = "celltype_main") +
+  scale_color_brewer(name = "celltype_main", # legend title
+                     palette = "Dark2",      # color palette
+                     na.value = "gray80")    # use light gray for NA values
+```
+
 We seem to have a pretty good set of cell type assignments, with most falling into groupings consistent with what we see in the UMAP plot.
 
 We can thank the fact that this is a PBMC sample and that we have a good reference dataset for these cell types for the cleanliness of this plot.
@@ -537,7 +547,7 @@ table(singler_result_fine$pruned.labels, useNA = "ifany")
 # add fine labels to SCE
 sce$celltype_fine <- singler_result_fine$pruned.labels
 # plot UMAP with fine labels
-scater::plotUMAP(sce, colour_by = "celltype_fine")
+scater::plotUMAP(sce, color_by = "celltype_fine")
 ```
 
 That's a pretty messy plot.
@@ -603,7 +613,7 @@ Now that we have that set up, we can plot using our collapsed and ordered cell t
 ```{r plot collapsed, live=TRUE}
 sce$celltype_collapsed <- collapsed_labels
 scater::plotUMAP(sce, 
-                 colour_by = "celltype_collapsed")
+                 color_by = "celltype_collapsed")
 ```
 
 
@@ -704,7 +714,7 @@ sce$celltype_cluster <- singler_cluster[sce$nn_cluster, "pruned.labels"]
 Now we can plot these cluster-based cell type assignments using the now familiar `plotUMAP()` function.
 
 ```{r plot cluster celltypes, live=TRUE}
-scater::plotUMAP(sce, colour_by = "celltype_cluster")
+scater::plotUMAP(sce, color_by = "celltype_cluster")
 ```
 
 This sure looks nice and clean, but what have we really done here? 
@@ -753,7 +763,7 @@ sce$celltype_metacell <- metacell_singler[kclusters, "pruned.labels"]
 Now we can plot the results as we have done before.
 
 ```{r metacell umap}
-scater::plotUMAP(sce, colour_by = "celltype_metacell")
+scater::plotUMAP(sce, color_by = "celltype_metacell")
 ```
 
 What do you think of this plot? 


### PR DESCRIPTION
_**Stacked on #732**_

- Closes #728 
  - Intro "on your own" markdown documents are converted to Rmd so the embedded screenshots can appear in-line. A few small formatting changes along the way (a couple headers and PLoS -> PLOS)

- Closes #730 
  - Use `color_by()` argument for reduced dim plots in scIntro module. I also added a chunk in the celltyping notebook to show the addition of `scale_color_brewer()`, wherein I noticed other annoying behavior but still the plot looks better. Currently this chunk is _not_ live - any thoughts there?
    - Other plots where we could add palettes don't seem to need it - colors are either sufficiently distinguishable, or there were too many colors for _any_ discrete palette. 