### PR TITLE
Use 1password secrets management for GHA

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - jashapiro/op_secrets
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Load 1Password secrets
-        if: github.event.inputs.rendering == 'TRUE'
         uses: 1password/load-secrets-action@v1
         with:
           export-env: true

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - jashapiro/op_secrets
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -16,15 +16,27 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Load 1Password secrets
+        if: github.event.inputs.rendering == 'TRUE'
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TRAINING_OP_SERVICE_ACCOUNT_TOKEN }}
+          DOCKER_USER: ${{ secrets.OP_DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.OP_DOCKER_PASSWORD }}
+          ACTION_MONITORING_SLACK: ${{ secrets.OP_ACTION_MONITORING_SLACK }}
 
       # Login to Dockerhub
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_ID }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
       # set up Docker build
       - name: Set up Docker Buildx
@@ -47,5 +59,5 @@ jobs:
           status: ${{ job.status }}
           notify_when: 'failure'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_URL: ${{ env.ACTION_MONITORING_SLACK }}
           SLACK_MESSAGE: 'Training build Docker & push workflow failed'

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -3,6 +3,9 @@ name: Make Live Notebooks
 
 # This workflow only runs when it is manually dispatched
 on:
+  push:
+    branches:
+      - jashapiro/op_secrets
   workflow_dispatch:
     inputs:
       rendering:

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -3,9 +3,6 @@ name: Make Live Notebooks
 
 # This workflow only runs when it is manually dispatched
 on:
-  push:
-    branches:
-      - jashapiro/op_secrets
   workflow_dispatch:
     inputs:
       rendering:

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -28,13 +28,15 @@ jobs:
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
 
-      - name: Set up AWS credentials
+      - name: Load 1Password secrets
         if: github.event.inputs.rendering == 'TRUE'
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: 1password/load-secrets-action@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TRAINING_OP_SERVICE_ACCOUNT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OP_TRAINING_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OP_TRAINING_SECRET_ACCESS_KEY }}
 
       - name: Download data from S3
         if: github.event.inputs.rendering == 'TRUE'

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -55,7 +55,7 @@ jobs:
 
       # Make changes to pull request here
       - name: Create PR with rendered notebooks
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ env.DOCS_BOT_GITHUB_TOKEN }}
           commit-message: Live and rendered notebooks

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -29,7 +29,6 @@ jobs:
           git config --local user.name "GitHub Actions"
 
       - name: Load 1Password secrets
-        if: github.event.inputs.rendering == 'TRUE'
         uses: 1password/load-secrets-action@v1
         with:
           export-env: true
@@ -37,6 +36,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TRAINING_OP_SERVICE_ACCOUNT_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.OP_TRAINING_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OP_TRAINING_SECRET_ACCESS_KEY }}
+          DOCS_BOT_GITHUB_TOKEN: ${{ secrets.OP_DOCS_BOT_GITHUB_TOKEN }}
 
       - name: Download data from S3
         if: github.event.inputs.rendering == 'TRUE'
@@ -54,7 +54,7 @@ jobs:
       - name: Create PR with rendered notebooks
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
+          token: ${{ env.DOCS_BOT_GITHUB_TOKEN }}
           commit-message: Live and rendered notebooks
           signoff: false
           branch: auto_render_live

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -42,7 +42,7 @@ jobs:
           DOCS_BOT_GITHUB_TOKEN: ${{ secrets.OP_DOCS_BOT_GITHUB_TOKEN }}
 
       - name: Download data from S3
-        if: github.event.inputs.rendering == 'TRUE'
+        # if: github.event.inputs.rendering == 'TRUE'
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -42,7 +42,7 @@ jobs:
           DOCS_BOT_GITHUB_TOKEN: ${{ secrets.OP_DOCS_BOT_GITHUB_TOKEN }}
 
       - name: Download data from S3
-        # if: github.event.inputs.rendering == 'TRUE'
+        if: github.event.inputs.rendering == 'TRUE'
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -3,6 +3,9 @@ name: Make Live Notebooks
 
 # This workflow only runs when it is manually dispatched
 on:
+  push:
+    branches:
+      - jashapiro/op_secrets
   workflow_dispatch:
     inputs:
       rendering:
@@ -39,7 +42,7 @@ jobs:
           DOCS_BOT_GITHUB_TOKEN: ${{ secrets.OP_DOCS_BOT_GITHUB_TOKEN }}
 
       - name: Download data from S3
-        if: github.event.inputs.rendering == 'TRUE'
+        # if: github.event.inputs.rendering == 'TRUE'
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -3,9 +3,6 @@ name: Make Live Notebooks
 
 # This workflow only runs when it is manually dispatched
 on:
-  push:
-    branches:
-      - jashapiro/op_secrets
   workflow_dispatch:
     inputs:
       rendering:
@@ -42,7 +39,7 @@ jobs:
           DOCS_BOT_GITHUB_TOKEN: ${{ secrets.OP_DOCS_BOT_GITHUB_TOKEN }}
 
       - name: Download data from S3
-        # if: github.event.inputs.rendering == 'TRUE'
+        if: github.event.inputs.rendering == 'TRUE'
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Download data from S3
         if: github.event.inputs.rendering == 'TRUE'
+        env:
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           aws s3 sync s3://ccdl-training-data/training-modules/ .
 

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -33,6 +33,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OP_TRAINING_SECRET_ACCESS_KEY }}
 
       - name: Download data from S3
+        env:
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           aws s3 sync s3://ccdl-training-data/training-modules/ .
 

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -23,12 +23,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+      - name: Load 1Password secrets
+        uses: 1password/load-secrets-action@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TRAINING_OP_SERVICE_ACCOUNT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OP_TRAINING_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OP_TRAINING_SECRET_ACCESS_KEY }}
 
       - name: Download data from S3
         run: |


### PR DESCRIPTION
Should do what it says, using the service account to get all of the secrets using "op://" links that are also stored as github secrets. Includes docs bot, docker, and AWS access.