### PR TITLE
Adding terms to training-modules dictionary

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -82,7 +82,6 @@ DataFrames
 dataset
 deconvolution
 deconvolved
-deidentified
 dendritic
 DESeq
 DESeq2

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -82,6 +82,7 @@ DataFrames
 dataset
 deconvolution
 deconvolved
+deidentified
 dendritic
 DESeq
 DESeq2
@@ -298,6 +299,7 @@ octothorps
 OkabeIto
 oligodendrocyte
 oligoprogenitors
+onboarding
 oncogenesis
 Oncol
 oncoproteins
@@ -322,6 +324,7 @@ ped
 phenotypes
 Phred
 Picelli
+PII
 plasmacytoid
 PLIER
 PLoS


### PR DESCRIPTION
This PR adds the terms `deidentified`, `onboarding`, and `PII` to the dictionary to resolve spell check errors.