### PR TITLE
Update to R 4.4 & Bioconductor 3.19

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
 
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Load 1Password secrets
-        uses: 1password/load-secrets-action@v1
+        uses: 1password/load-secrets-action@v2
         with:
           export-env: true
         env:
@@ -32,18 +32,18 @@ jobs:
 
       # Login to Dockerhub
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USER }}
           password: ${{ env.DOCKER_PASSWORD }}
 
       # set up Docker build
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Build Docker image
       - name: Build Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           context: .
@@ -53,10 +53,10 @@ jobs:
       # If we have a failure, Slack us
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v1.1
+        uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}
           notify_when: 'failure'
+          message_format: 'Training build & push Docker workflow failed'
         env:
           SLACK_WEBHOOK_URL: ${{ env.ACTION_MONITORING_SLACK }}
-          SLACK_MESSAGE: 'Training build Docker & push workflow failed'

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,15 +20,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # set up Docker build
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Build docker image
       - name: Build Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: false
           context: .

--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure git
         run: |
@@ -29,7 +29,7 @@ jobs:
           git config --local user.name "GitHub Actions"
 
       - name: Load 1Password secrets
-        uses: 1password/load-secrets-action@v1
+        uses: 1password/load-secrets-action@v2
         with:
           export-env: true
         env:
@@ -52,7 +52,7 @@ jobs:
 
       # Make changes to pull request here
       - name: Create PR with rendered notebooks
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ env.DOCS_BOT_GITHUB_TOKEN }}
           commit-message: Live and rendered notebooks

--- a/.github/workflows/render-rmds.yml
+++ b/.github/workflows/render-rmds.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Load 1Password secrets
-        uses: 1password/load-secrets-action@v1
+        uses: 1password/load-secrets-action@v2
         with:
           export-env: true
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,10 @@ RUN R -e "install.packages('renv')"
 
 WORKDIR /usr/local/renv
 COPY renv.lock renv.lock
-RUN R -e 'renv::consent(provided = TRUE); renv::restore()' && rm -rf ~/.local/share/renv
+RUN R -e 'renv::restore()' && \
+    rm -rf ~/.cache/R/renv && \
+    rm -rf /tmp/downloaded_packages && \
+    rm -rf /tmp/Rtmp*
 
 
 WORKDIR /home/rstudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:4.3.3
+FROM rocker/tidyverse:4.4.0
 LABEL maintainer="ccdl@alexslemonade.org"
 WORKDIR /rocker-build/
 

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.3",
+    "Version": "4.4.0",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -9,7 +9,7 @@
     ]
   },
   "Bioconductor": {
-    "Version": "3.18"
+    "Version": "3.19"
   },
   "Packages": {
     "ALL": {
@@ -4086,12 +4086,10 @@
     "renv": {
       "Package": "renv",
       "Version": "1.0.7",
-      "Source": "Repository",
+      "OS_type": null,
+      "NeedsCompilation": "no",
       "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
-      "Hash": "397b7b2a265bc5a7a06852524dabae20"
+      "Source": "Repository"
     },
     "reprex": {
       "Package": "reprex",

--- a/renv.lock
+++ b/renv.lock
@@ -3,6 +3,26 @@
     "Version": "4.4.0",
     "Repositories": [
       {
+        "Name": "BioCsoft",
+        "URL": "https://bioconductor.org/packages/3.19/bioc"
+      },
+      {
+        "Name": "BioCann",
+        "URL": "https://bioconductor.org/packages/3.19/data/annotation"
+      },
+      {
+        "Name": "BioCexp",
+        "URL": "https://bioconductor.org/packages/3.19/data/experiment"
+      },
+      {
+        "Name": "BioCworkflows",
+        "URL": "https://bioconductor.org/packages/3.19/workflows"
+      },
+      {
+        "Name": "BioCbooks",
+        "URL": "https://bioconductor.org/packages/3.19/books"
+      },
+      {
         "Name": "CRAN",
         "URL": "https://p3m.dev/cran/latest"
       }
@@ -14,18 +34,19 @@
   "Packages": {
     "ALL": {
       "Package": "ALL",
-      "Version": "1.44.0",
+      "Version": "1.45.0",
       "Source": "Bioconductor",
       "Requirements": [
         "Biobase",
         "R"
       ],
-      "Hash": "a25785a77a761fe3b33839ca4631b14b"
+      "Hash": "60b39dcec22fb935f54516a1bd593871"
     },
     "AnnotationDbi": {
       "Package": "AnnotationDbi",
-      "Version": "1.64.1",
+      "Version": "1.66.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "BiocGenerics",
@@ -39,12 +60,13 @@
         "stats",
         "stats4"
       ],
-      "Hash": "27587689922e22f60ec9ad0182a0a825"
+      "Hash": "b7df9c597fb5533fc8248d73b8c703ac"
     },
     "AnnotationFilter": {
       "Package": "AnnotationFilter",
-      "Version": "1.26.0",
+      "Version": "1.28.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "GenomicRanges",
         "R",
@@ -52,12 +74,13 @@
         "methods",
         "utils"
       ],
-      "Hash": "759acec0b1522c1a85c6ba703d4c0ec5"
+      "Hash": "24e809470aef6d81b25003d775b2fb56"
     },
     "AnnotationHub": {
       "Package": "AnnotationHub",
-      "Version": "3.10.1",
+      "Version": "3.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "BiocFileCache",
@@ -70,13 +93,12 @@
         "dplyr",
         "grDevices",
         "httr",
-        "interactiveDisplayBase",
         "methods",
         "rappdirs",
         "utils",
         "yaml"
       ],
-      "Hash": "07d1966e3ffc8c313410579f76b4718c"
+      "Hash": "346ca347b61989d1da5f655d7bac6a8c"
     },
     "BH": {
       "Package": "BH",
@@ -87,20 +109,22 @@
     },
     "Biobase": {
       "Package": "Biobase",
-      "Version": "2.62.0",
+      "Version": "2.64.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "R",
         "methods",
         "utils"
       ],
-      "Hash": "38252a34e82d3ff6bb46b4e2252d2dce"
+      "Hash": "9bc4cabd3bfda461409172213d932813"
     },
     "BiocFileCache": {
       "Package": "BiocFileCache",
-      "Version": "2.10.2",
+      "Version": "2.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "DBI",
         "R",
@@ -114,12 +138,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "d59a927de08cce606299009cc595b2cb"
+      "Hash": "9c3414bcfae204d56080dd0f0a220136"
     },
     "BiocGenerics": {
       "Package": "BiocGenerics",
-      "Version": "0.48.1",
+      "Version": "0.50.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "graphics",
@@ -127,12 +152,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "e34278c65d7dffcc08f737bf0944ca9a"
+      "Hash": "ef32d07aafdd12f24c5827374ae3590d"
     },
     "BiocIO": {
       "Package": "BiocIO",
-      "Version": "1.12.0",
+      "Version": "1.14.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -140,7 +166,7 @@
         "methods",
         "tools"
       ],
-      "Hash": "aa543468283543c9a8dad23a4897be96"
+      "Hash": "f97a7ef01d364cf20d1946d43a3d526f"
     },
     "BiocManager": {
       "Package": "BiocManager",
@@ -154,9 +180,9 @@
     },
     "BiocNeighbors": {
       "Package": "BiocNeighbors",
-      "Version": "1.20.2",
+      "Version": "1.22.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocParallel",
         "Matrix",
@@ -166,12 +192,13 @@
         "methods",
         "stats"
       ],
-      "Hash": "c5c8ade5852fd3b25c66ec28873d00f1"
+      "Hash": "da9f332c88453734623406dcca13ee03"
     },
     "BiocParallel": {
       "Package": "BiocParallel",
-      "Version": "1.36.0",
+      "Version": "1.38.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BH",
         "R",
@@ -184,12 +211,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "6d1689ee8b65614ba6ef4012a67b663a"
+      "Hash": "7b6e79f86e3d1c23f62c5e2052e848d4"
     },
     "BiocSingular": {
       "Package": "BiocSingular",
-      "Version": "1.18.0",
+      "Version": "1.20.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocParallel",
@@ -204,22 +232,23 @@
         "rsvd",
         "utils"
       ],
-      "Hash": "bed2b7ea3b0b0b31387d1d80286abb97"
+      "Hash": "9d2e9fbd803f4eddfeb307b1ee376aad"
     },
     "BiocVersion": {
       "Package": "BiocVersion",
-      "Version": "3.18.1",
+      "Version": "3.19.1",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R"
       ],
-      "Hash": "2ecaed86684f5fae76ed5530f9d29c4a"
+      "Hash": "b892e27fc9659a4c8f8787d34c37b8b2"
     },
     "Biostrings": {
       "Package": "Biostrings",
-      "Version": "2.70.3",
+      "Version": "2.72.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "GenomeInfoDb",
@@ -229,12 +258,11 @@
         "XVector",
         "crayon",
         "grDevices",
-        "graphics",
         "methods",
         "stats",
         "utils"
       ],
-      "Hash": "86ffa781f132f54e9c963a13fd6cf9fc"
+      "Hash": "48618c7c7b90b503837824ebcfee6363"
     },
     "Cairo": {
       "Package": "Cairo",
@@ -250,8 +278,9 @@
     },
     "ComplexHeatmap": {
       "Package": "ComplexHeatmap",
-      "Version": "2.18.0",
+      "Version": "2.20.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "GetoptLong",
         "GlobalOptions",
@@ -273,12 +302,13 @@
         "png",
         "stats"
       ],
-      "Hash": "fd8d03c43e175afce12c1012711a05cc"
+      "Hash": "0308920b8b9315ccfe69bccb66c15485"
     },
     "ConsensusClusterPlus": {
       "Package": "ConsensusClusterPlus",
-      "Version": "1.66.0",
+      "Version": "1.68.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "ALL",
         "Biobase",
@@ -287,7 +317,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "69d3cd404389117e88215a843d332c93"
+      "Hash": "ba88e4eb2ca2df69376294de93bdda2f"
     },
     "DBI": {
       "Package": "DBI",
@@ -302,9 +332,9 @@
     },
     "DESeq2": {
       "Package": "DESeq2",
-      "Version": "1.42.1",
+      "Version": "1.44.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "BiocGenerics",
@@ -322,12 +352,13 @@
         "methods",
         "stats4"
       ],
-      "Hash": "39ce3d1e4fe223602fd27d2ae92c8535"
+      "Hash": "a90e0e67215ba95ccb29e93b169caaa4"
     },
     "DOSE": {
       "Package": "DOSE",
-      "Version": "3.28.2",
+      "Version": "3.30.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "BiocParallel",
@@ -343,7 +374,7 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "f6e782014c01a819603ca4a3a508c301"
+      "Hash": "48770d6c09181b2e1353650830a2b375"
     },
     "DT": {
       "Package": "DT",
@@ -364,8 +395,9 @@
     },
     "DelayedArray": {
       "Package": "DelayedArray",
-      "Version": "0.28.0",
+      "Version": "0.30.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "IRanges",
@@ -379,12 +411,13 @@
         "stats",
         "stats4"
       ],
-      "Hash": "0e5c84e543a3d04ce64c6f60ed46d7eb"
+      "Hash": "9141899d1bb4ce53e036810eb217721f"
     },
     "DelayedMatrixStats": {
       "Package": "DelayedMatrixStats",
-      "Version": "1.24.0",
+      "Version": "1.26.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "DelayedArray",
         "IRanges",
@@ -394,12 +427,13 @@
         "methods",
         "sparseMatrixStats"
       ],
-      "Hash": "71c2d178d33f9d91999f67dc2d53b747"
+      "Hash": "5d9536664ccddb0eaa68a90afe4ee76e"
     },
     "DropletUtils": {
       "Package": "DropletUtils",
-      "Version": "1.22.0",
+      "Version": "1.24.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BH",
         "BiocGenerics",
@@ -425,23 +459,25 @@
         "stats",
         "utils"
       ],
-      "Hash": "be3893d30c97591f1d3ec6f053830c3a"
+      "Hash": "77f762ad74d48a0ef578fc81deded039"
     },
     "EnhancedVolcano": {
       "Package": "EnhancedVolcano",
-      "Version": "1.20.0",
+      "Version": "1.22.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "ggplot2",
         "ggrepel",
         "methods"
       ],
-      "Hash": "dfa97d2c97c00b32f77e192424c65736"
+      "Hash": "5a83fa8aee8e8ef141122053cd398f53"
     },
     "ExperimentHub": {
       "Package": "ExperimentHub",
-      "Version": "2.10.0",
+      "Version": "2.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationHub",
         "BiocFileCache",
@@ -452,7 +488,7 @@
         "rappdirs",
         "utils"
       ],
-      "Hash": "fb43ec028a58aa8a8539d79ea936d39f"
+      "Hash": "988693270e5886a33c536dda6b3c9f98"
     },
     "FNN": {
       "Package": "FNN",
@@ -466,8 +502,9 @@
     },
     "GEOquery": {
       "Package": "GEOquery",
-      "Version": "2.70.0",
+      "Version": "2.72.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "R.utils",
@@ -481,7 +518,7 @@
         "tidyr",
         "xml2"
       ],
-      "Hash": "58fcaef94e52f4d6053eb4f8fd4a479d"
+      "Hash": "b27b8e249f59da9349a482311c603a58"
     },
     "GGally": {
       "Package": "GGally",
@@ -510,19 +547,20 @@
     },
     "GO.db": {
       "Package": "GO.db",
-      "Version": "3.18.0",
+      "Version": "3.19.1",
       "Source": "Bioconductor",
       "Requirements": [
         "AnnotationDbi",
         "R",
         "methods"
       ],
-      "Hash": "1ec786f8b958a01ceb245883701873b1"
+      "Hash": "46bfc38370acea3503c223347915e43b"
     },
     "GOSemSim": {
       "Package": "GOSemSim",
-      "Version": "2.28.1",
+      "Version": "2.30.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "GO.db",
@@ -534,12 +572,13 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "e4f46278e8b0ecdb5060abbd2d459d26"
+      "Hash": "71084bb847242267f84259405c0094b0"
     },
     "GSEABase": {
       "Package": "GSEABase",
-      "Version": "1.64.0",
+      "Version": "1.66.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "Biobase",
@@ -550,12 +589,13 @@
         "graph",
         "methods"
       ],
-      "Hash": "96e2adf800dc97758f8c5a36b98d8fef"
+      "Hash": "b55026a2047cdc8fbadac8670eb6fd8b"
     },
     "GSVA": {
       "Package": "GSVA",
-      "Version": "1.50.2",
+      "Version": "1.52.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "BiocParallel",
@@ -569,6 +609,7 @@
         "R",
         "S4Vectors",
         "SingleCellExperiment",
+        "SpatialExperiment",
         "SummarizedExperiment",
         "graphics",
         "methods",
@@ -577,40 +618,41 @@
         "stats",
         "utils"
       ],
-      "Hash": "787e1f2eb10588e83be85b0abe78c5d1"
+      "Hash": "c6d010cbdc01797f5e9249843b7ebff4"
     },
     "GenomeInfoDb": {
       "Package": "GenomeInfoDb",
-      "Version": "1.38.8",
+      "Version": "1.40.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "GenomeInfoDbData",
         "IRanges",
         "R",
-        "RCurl",
         "S4Vectors",
+        "UCSC.utils",
         "methods",
         "stats",
         "stats4",
         "utils"
       ],
-      "Hash": "155053909d2831bfac154a1118151d6b"
+      "Hash": "614124bc9fb80d222cfa0d2e3e76c339"
     },
     "GenomeInfoDbData": {
       "Package": "GenomeInfoDbData",
-      "Version": "1.2.11",
+      "Version": "1.2.12",
       "Source": "Bioconductor",
       "Requirements": [
         "R"
       ],
-      "Hash": "10f32956181d1d46bd8402c93ac193e8"
+      "Hash": "c3c792a7b7f2677be56e8632c5b7543d"
     },
     "GenomicAlignments": {
       "Package": "GenomicAlignments",
-      "Version": "1.38.2",
+      "Version": "1.40.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocParallel",
@@ -626,41 +668,36 @@
         "stats",
         "utils"
       ],
-      "Hash": "3447de036330c8c2ae54f064c8f4e299"
+      "Hash": "e539709764587c581b31e446dc84d7b8"
     },
     "GenomicFeatures": {
       "Package": "GenomicFeatures",
-      "Version": "1.54.4",
+      "Version": "1.56.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
-        "Biobase",
         "BiocGenerics",
-        "BiocIO",
         "Biostrings",
         "DBI",
         "GenomeInfoDb",
         "GenomicRanges",
         "IRanges",
         "R",
-        "RSQLite",
         "S4Vectors",
         "XVector",
-        "biomaRt",
-        "httr",
         "methods",
-        "rjson",
         "rtracklayer",
         "stats",
-        "tools",
         "utils"
       ],
-      "Hash": "28667ac05b72cf841adf792154f387de"
+      "Hash": "0d19619d13b06b9dea85993ce7f09c52"
     },
     "GenomicRanges": {
       "Package": "GenomicRanges",
-      "Version": "1.54.1",
+      "Version": "1.56.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "GenomeInfoDb",
@@ -673,7 +710,7 @@
         "stats4",
         "utils"
       ],
-      "Hash": "7e0c1399af35369312d9c399454374e8"
+      "Hash": "0fab423e3f49e207681eb404d9182a1e"
     },
     "GetoptLong": {
       "Package": "GetoptLong",
@@ -703,8 +740,9 @@
     },
     "HDF5Array": {
       "Package": "HDF5Array",
-      "Version": "1.30.1",
+      "Version": "1.32.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "DelayedArray",
@@ -721,7 +759,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "9b8deb4fd34fa439c16c829457d1968f"
+      "Hash": "b10ddb24baf506cf7b4bc868ae65b984"
     },
     "HDO.db": {
       "Package": "HDO.db",
@@ -737,8 +775,9 @@
     },
     "IRanges": {
       "Package": "IRanges",
-      "Version": "2.36.0",
+      "Version": "2.38.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -748,12 +787,13 @@
         "stats4",
         "utils"
       ],
-      "Hash": "f98500eeb93e8a66ad65be955a848595"
+      "Hash": "836770692f7c8401090519228b93af32"
     },
     "KEGGREST": {
       "Package": "KEGGREST",
-      "Version": "1.42.0",
+      "Version": "1.44.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biostrings",
         "R",
@@ -761,7 +801,7 @@
         "methods",
         "png"
       ],
-      "Hash": "8d6e9f4dce69aec9c588c27ae79be08e"
+      "Hash": "05ef9fd9aa613310e060ddd93a0c8571"
     },
     "KernSmooth": {
       "Package": "KernSmooth",
@@ -776,8 +816,9 @@
     },
     "LoomExperiment": {
       "Package": "LoomExperiment",
-      "Version": "1.20.0",
+      "Version": "1.22.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocIO",
         "DelayedArray",
@@ -794,11 +835,11 @@
         "stringr",
         "utils"
       ],
-      "Hash": "9880e64157cb641d2e6e19c81efe0c95"
+      "Hash": "69afb3fc64fcd99784133bc69dfe4f5d"
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-60.0.1",
+      "Version": "7.3-60.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -809,11 +850,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "b765b28387acc8ec9e9c1530713cb19c"
+      "Hash": "2f342c46163b0b54d7b64d1f798e2c78"
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.6-5",
+      "Version": "1.7-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -826,17 +867,18 @@
         "stats",
         "utils"
       ],
-      "Hash": "8c7115cd3a0e048bda2a7cd110549f7a"
+      "Hash": "1920b2f11133b12350024297d8a4ff4a"
     },
     "MatrixGenerics": {
       "Package": "MatrixGenerics",
-      "Version": "1.14.0",
+      "Version": "1.16.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "matrixStats",
         "methods"
       ],
-      "Hash": "088cd2077b5619fcb7b373b1a45174e7"
+      "Hash": "152dbbcde6a9a7c7f3beef79b68cd76a"
     },
     "PLIER": {
       "Package": "PLIER",
@@ -844,8 +886,8 @@
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteRepo": "PLIER",
       "RemoteUsername": "wgmao",
+      "RemoteRepo": "PLIER",
       "RemoteRef": "v0.1.6",
       "RemoteSha": "08ed6b54e4efe5249107cb335cd8e169657cbc44",
       "Requirements": [
@@ -861,12 +903,13 @@
     },
     "ProtGenerics": {
       "Package": "ProtGenerics",
-      "Version": "1.34.0",
+      "Version": "1.36.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "methods"
       ],
-      "Hash": "f9cf8f8dac1d3e1bd9a5e3215286b700"
+      "Hash": "a3737c10efc865abfa9d204ca8735b74"
     },
     "R.methodsS3": {
       "Package": "R.methodsS3",
@@ -996,7 +1039,7 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "0.12.8.2.0",
+      "Version": "0.12.8.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1006,7 +1049,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "85c0c4491c06db4814ed7e39b960973c"
+      "Hash": "d5448fb24fb114c4da1275a37a571f37"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -1077,24 +1120,26 @@
     },
     "ResidualMatrix": {
       "Package": "ResidualMatrix",
-      "Version": "1.12.0",
+      "Version": "1.14.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "DelayedArray",
         "Matrix",
         "S4Vectors",
         "methods"
       ],
-      "Hash": "d267a37fc29376e448e4adead5718584"
+      "Hash": "26b5d104b2d27d7aa3725c4e3aa1b3b9"
     },
     "Rhdf5lib": {
       "Package": "Rhdf5lib",
-      "Version": "1.24.2",
+      "Version": "1.26.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R"
       ],
-      "Hash": "3cf103db29d75af0221d71946509a30c"
+      "Hash": "c92ba8b9a2c5c9ff600a1062a3b7b727"
     },
     "RhpcBLASctl": {
       "Package": "RhpcBLASctl",
@@ -1105,17 +1150,20 @@
     },
     "Rhtslib": {
       "Package": "Rhtslib",
-      "Version": "2.4.1",
+      "Version": "3.0.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
+        "tools",
         "zlibbioc"
       ],
-      "Hash": "ee7abc23ddeada73fedfee74c633bffe"
+      "Hash": "5d6514cd44a0106581e3310f3972a82e"
     },
     "Rsamtools": {
       "Package": "Rsamtools",
-      "Version": "2.18.0",
+      "Version": "2.20.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocParallel",
@@ -1133,7 +1181,7 @@
         "utils",
         "zlibbioc"
       ],
-      "Hash": "242517db56d7fe7214120ecc77a5890d"
+      "Hash": "9762f24dcbdbd1626173c516bb64792c"
     },
     "Rtsne": {
       "Package": "Rtsne",
@@ -1148,9 +1196,9 @@
     },
     "S4Arrays": {
       "Package": "S4Arrays",
-      "Version": "1.2.1",
+      "Version": "1.4.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "IRanges",
@@ -1162,13 +1210,13 @@
         "methods",
         "stats"
       ],
-      "Hash": "3213a9826adb8f48e51af1e7b30fa568"
+      "Hash": "665d1f150ce8a6e7614375eafdbad645"
     },
     "S4Vectors": {
       "Package": "S4Vectors",
-      "Version": "0.40.2",
+      "Version": "0.42.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -1177,7 +1225,7 @@
         "stats4",
         "utils"
       ],
-      "Hash": "1716e201f81ced0f456dd5ec85fe20f8"
+      "Hash": "245ac721ca6088200392ea5251db9e3c"
     },
     "SQUAREM": {
       "Package": "SQUAREM",
@@ -1191,20 +1239,22 @@
     },
     "ScaledMatrix": {
       "Package": "ScaledMatrix",
-      "Version": "1.10.0",
+      "Version": "1.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "DelayedArray",
         "Matrix",
         "S4Vectors",
         "methods"
       ],
-      "Hash": "ecab4b44d12fc7642a7161f71f3397b5"
+      "Hash": "bac1c808a92d9c3f45d05e7a8c1b74f0"
     },
     "SingleCellExperiment": {
       "Package": "SingleCellExperiment",
-      "Version": "1.24.0",
+      "Version": "1.26.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "DelayedArray",
@@ -1215,12 +1265,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "e21b3571ce76eb4dfe6bf7900960aa6a"
+      "Hash": "4476ad434a5e7887884521417cab3764"
     },
     "SingleR": {
       "Package": "SingleR",
-      "Version": "2.4.1",
+      "Version": "2.6.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocNeighbors",
         "BiocParallel",
@@ -1237,13 +1288,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "c92ff71608dda35b5fecbf7024a069f8"
+      "Hash": "754516444a16b2616e35e9c8767d1110"
     },
     "SparseArray": {
       "Package": "SparseArray",
-      "Version": "1.2.4",
+      "Version": "1.4.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "IRanges",
@@ -1257,12 +1308,32 @@
         "methods",
         "stats"
       ],
-      "Hash": "391092e7b81373ab624bd6471cebccd4"
+      "Hash": "84697af365cd2a6367fa5d2c1086298c"
+    },
+    "SpatialExperiment": {
+      "Package": "SpatialExperiment",
+      "Version": "1.14.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocFileCache",
+        "BiocGenerics",
+        "S4Vectors",
+        "SingleCellExperiment",
+        "SummarizedExperiment",
+        "grDevices",
+        "magick",
+        "methods",
+        "rjson",
+        "utils"
+      ],
+      "Hash": "f27e097dbca623953cff5694733e2c39"
     },
     "SummarizedExperiment": {
       "Package": "SummarizedExperiment",
-      "Version": "1.32.0",
+      "Version": "1.34.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "BiocGenerics",
@@ -1280,7 +1351,34 @@
         "tools",
         "utils"
       ],
-      "Hash": "caee529bf9710ff6fe1776612fcaa266"
+      "Hash": "2f6c8cc972ed6aee07c96e3dff729d15"
+    },
+    "UCSC.utils": {
+      "Package": "UCSC.utils",
+      "Version": "1.0.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "S4Vectors",
+        "httr",
+        "jsonlite",
+        "methods",
+        "stats"
+      ],
+      "Hash": "83d45b690bffd09d1980c224ef329f5b"
+    },
+    "V8": {
+      "Package": "V8",
+      "Version": "4.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp",
+        "curl",
+        "jsonlite",
+        "utils"
+      ],
+      "Hash": "ca98390ad1cef2a5a609597b49d3d042"
     },
     "XML": {
       "Package": "XML",
@@ -1296,8 +1394,9 @@
     },
     "XVector": {
       "Package": "XVector",
-      "Version": "0.42.0",
+      "Version": "0.44.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "IRanges",
@@ -1308,7 +1407,7 @@
         "utils",
         "zlibbioc"
       ],
-      "Hash": "65c0b6bca03f88758f86ef0aa18c4873"
+      "Hash": "4245b9938ac74c0dbddbebbec6036ab4"
     },
     "abind": {
       "Package": "abind",
@@ -1324,8 +1423,9 @@
     },
     "affy": {
       "Package": "affy",
-      "Version": "1.80.0",
+      "Version": "1.82.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "BiocGenerics",
@@ -1340,23 +1440,120 @@
         "utils",
         "zlibbioc"
       ],
-      "Hash": "52b4ed87e1d923dc184b2200f037411d"
+      "Hash": "de30a31c7d837db23467d5cbfcf88de0"
     },
     "affyio": {
       "Package": "affyio",
-      "Version": "1.72.0",
+      "Version": "1.74.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "methods",
         "zlibbioc"
       ],
-      "Hash": "63280d6f5ba6b3a6665a3d00f0a738dc"
+      "Hash": "88e77a7f8571a173db7d4f6d9bf46a64"
+    },
+    "alabaster.base": {
+      "Package": "alabaster.base",
+      "Version": "1.4.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "Rcpp",
+        "Rhdf5lib",
+        "S4Vectors",
+        "alabaster.schemas",
+        "jsonlite",
+        "jsonvalidate",
+        "methods",
+        "rhdf5",
+        "utils"
+      ],
+      "Hash": "dff0dcd23d2ca7ce1d90e513cb6a6c63"
+    },
+    "alabaster.matrix": {
+      "Package": "alabaster.matrix",
+      "Version": "1.4.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocGenerics",
+        "DelayedArray",
+        "HDF5Array",
+        "Matrix",
+        "Rcpp",
+        "S4Arrays",
+        "S4Vectors",
+        "SparseArray",
+        "alabaster.base",
+        "methods",
+        "rhdf5"
+      ],
+      "Hash": "22b09ff731438f649f7a6bfe25dccde1"
+    },
+    "alabaster.ranges": {
+      "Package": "alabaster.ranges",
+      "Version": "1.4.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocGenerics",
+        "GenomeInfoDb",
+        "GenomicRanges",
+        "IRanges",
+        "S4Vectors",
+        "alabaster.base",
+        "methods",
+        "rhdf5"
+      ],
+      "Hash": "74b3fe9e2e18d0f10e25af0278f5452a"
+    },
+    "alabaster.sce": {
+      "Package": "alabaster.sce",
+      "Version": "1.4.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "SingleCellExperiment",
+        "alabaster.base",
+        "alabaster.se",
+        "jsonlite",
+        "methods"
+      ],
+      "Hash": "fa41c555dd420c8f19cfddeb74da75b3"
+    },
+    "alabaster.schemas": {
+      "Package": "alabaster.schemas",
+      "Version": "1.4.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Hash": "e58b4124478c9f912c7c4a21d9adca6c"
+    },
+    "alabaster.se": {
+      "Package": "alabaster.se",
+      "Version": "1.4.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocGenerics",
+        "GenomicRanges",
+        "IRanges",
+        "S4Vectors",
+        "SummarizedExperiment",
+        "alabaster.base",
+        "alabaster.matrix",
+        "alabaster.ranges",
+        "jsonlite",
+        "methods"
+      ],
+      "Hash": "507cafb86c69a5f04a5ad0eb7f05fcf1"
     },
     "alevinQC": {
       "Package": "alevinQC",
-      "Version": "1.18.1",
+      "Version": "1.20.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "DT",
         "GGally",
@@ -1376,12 +1573,13 @@
         "tximport",
         "utils"
       ],
-      "Hash": "194c333b10b4aacc960c487864e403d4"
+      "Hash": "6eeae7ae41bf79ffb8137fdd0360b9cf"
     },
     "annotate": {
       "Package": "annotate",
-      "Version": "1.80.0",
+      "Version": "1.82.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "Biobase",
@@ -1396,7 +1594,7 @@
         "utils",
         "xtable"
       ],
-      "Hash": "08359e5ce909c14a936ec1f9712ca830"
+      "Hash": "659c0a3bfad51dc798e4b4eb0f2cdedc"
     },
     "ape": {
       "Package": "ape",
@@ -1419,8 +1617,9 @@
     },
     "apeglm": {
       "Package": "apeglm",
-      "Version": "1.24.0",
+      "Version": "1.26.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "GenomicRanges",
         "Rcpp",
@@ -1432,7 +1631,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "48b2b0378047fa5eae8441806d611d02"
+      "Hash": "db0445903cb0274f9b99abc410768df1"
     },
     "aplot": {
       "Package": "aplot",
@@ -1515,8 +1714,9 @@
     },
     "batchelor": {
       "Package": "batchelor",
-      "Version": "1.18.1",
+      "Version": "1.20.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocNeighbors",
@@ -1538,7 +1738,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "e4b9d99c9e53be1b5b232634ebdb22c9"
+      "Hash": "ec5dcf85cdf644b078d02deaf27a3bfd"
     },
     "bbmle": {
       "Package": "bbmle",
@@ -1572,8 +1772,9 @@
     },
     "beachmat": {
       "Package": "beachmat",
-      "Version": "2.18.1",
+      "Version": "2.20.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "DelayedArray",
@@ -1582,7 +1783,7 @@
         "SparseArray",
         "methods"
       ],
-      "Hash": "c1c423ca7149d9e7f55d1e609342c2bd"
+      "Hash": "10e94b1bce9070632a40c6b873f8b2d4"
     },
     "beeswarm": {
       "Package": "beeswarm",
@@ -1599,14 +1800,14 @@
     },
     "biomaRt": {
       "Package": "biomaRt",
-      "Version": "2.58.2",
+      "Version": "2.60.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "BiocFileCache",
-        "XML",
         "digest",
-        "httr",
+        "httr2",
         "methods",
         "progress",
         "rappdirs",
@@ -1614,7 +1815,7 @@
         "utils",
         "xml2"
       ],
-      "Hash": "d6e043a6bfb4e2e256d00b8eee9c4266"
+      "Hash": "8bce67ed479b1d54e1627598edd9db30"
     },
     "bit": {
       "Package": "bit",
@@ -1661,8 +1862,9 @@
     },
     "bluster": {
       "Package": "bluster",
-      "Version": "1.12.0",
+      "Version": "1.14.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocNeighbors",
         "BiocParallel",
@@ -1675,7 +1877,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "fca0d5ffad6380f13cad4d7855107aef"
+      "Hash": "ed9597168d850071aa9abbbef7be7204"
     },
     "broom": {
       "Package": "broom",
@@ -1778,19 +1980,29 @@
     },
     "celldex": {
       "Package": "celldex",
-      "Version": "1.12.0",
+      "Version": "1.13.3",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "AnnotationHub",
+        "DBI",
         "DelayedArray",
         "DelayedMatrixStats",
         "ExperimentHub",
+        "Matrix",
+        "RSQLite",
         "S4Vectors",
         "SummarizedExperiment",
+        "alabaster.base",
+        "alabaster.matrix",
+        "alabaster.se",
+        "gypsum",
+        "jsonlite",
+        "methods",
         "utils"
       ],
-      "Hash": "1aef6a9efa6b33e3bd0a924a34c6c461"
+      "Hash": "b5cb1466016b2b454cf9cd5e95a48e05"
     },
     "cellranger": {
       "Package": "cellranger",
@@ -1874,8 +2086,9 @@
     },
     "clusterProfiler": {
       "Package": "clusterProfiler",
-      "Version": "4.10.1",
+      "Version": "4.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "DOSE",
@@ -1898,7 +2111,7 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "296ab91fa793d661ad730c3685d89483"
+      "Hash": "4dcafdc7266ccabdde011cbab04b1730"
     },
     "coda": {
       "Package": "coda",
@@ -2149,8 +2362,9 @@
     },
     "edgeR": {
       "Package": "edgeR",
-      "Version": "4.0.16",
+      "Version": "4.2.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "Rcpp",
@@ -2161,7 +2375,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "a0405c7890708dcb53809d46758800f4"
+      "Hash": "20783ecb7e7cea3f351e8b21153e3eb8"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -2207,8 +2421,9 @@
     },
     "enrichplot": {
       "Package": "enrichplot",
-      "Version": "1.22.0",
+      "Version": "1.24.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "DOSE",
         "GOSemSim",
@@ -2235,12 +2450,13 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "92d736b111bdefed6b7a073f0978e7b7"
+      "Hash": "19039e8a7075c61615d6f1459fb13ec6"
     },
     "ensembldb": {
       "Package": "ensembldb",
-      "Version": "2.26.0",
+      "Version": "2.28.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "AnnotationFilter",
@@ -2261,7 +2477,7 @@
         "methods",
         "rtracklayer"
       ],
-      "Hash": "6be48b1a96556976a4e9ee6836f88b97"
+      "Hash": "f9a5e52468ec832a839c012e15c41c15"
     },
     "estimability": {
       "Package": "estimability",
@@ -2298,9 +2514,9 @@
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteRepo": "exrcise",
       "RemoteUsername": "AlexsLemonade",
-      "RemoteRef": "HEAD",
+      "RemoteRepo": "exrcise",
+      "RemoteRef": "main",
       "RemoteSha": "a496662f8a8a2294366cae4d2f3547c50ac341f1",
       "Requirements": [
         "knitr",
@@ -2309,7 +2525,7 @@
         "readr",
         "stringr"
       ],
-      "Hash": "a5a91e3a3f03206b58ae5dbc6ee66f64"
+      "Hash": "ba726351afff6ca2957a801ee977f295"
     },
     "fansi": {
       "Package": "fansi",
@@ -2384,8 +2600,9 @@
     },
     "fgsea": {
       "Package": "fgsea",
-      "Version": "1.28.0",
+      "Version": "1.30.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BH",
         "BiocParallel",
@@ -2401,7 +2618,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "b2de43d04c504b819feec692e2b94523"
+      "Hash": "ead409e5a973cd285681c3bb0ade49a7"
     },
     "filelock": {
       "Package": "filelock",
@@ -2415,8 +2632,9 @@
     },
     "fishpond": {
       "Package": "fishpond",
-      "Version": "2.8.0",
+      "Version": "2.10.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "GenomicRanges",
         "IRanges",
@@ -2435,7 +2653,7 @@
         "svMisc",
         "utils"
       ],
-      "Hash": "60ebe3366ccb6c1a11a99682f56f2a2f"
+      "Hash": "9091a296b5cdb86da7c4c35f958c67f6"
     },
     "flexmix": {
       "Package": "flexmix",
@@ -2510,14 +2728,14 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.3",
+      "Version": "1.6.4",
       "Source": "Repository",
-      "Repository": "PPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "47b5f30c720c23999b913a1a635cf0bb"
+      "Hash": "15aeb8c27f5ea5161f9f6a641fafd93a"
     },
     "futile.logger": {
       "Package": "futile.logger",
@@ -2656,7 +2874,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.5.0",
+      "Version": "3.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2677,7 +2895,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "52ef83f93f74833007f193b2d4c159a2"
+      "Hash": "44c6a2f8202d5b7e878ea274b1092426"
     },
     "ggplotify": {
       "Package": "ggplotify",
@@ -2792,8 +3010,9 @@
     },
     "ggtree": {
       "Package": "ggtree",
-      "Version": "3.10.1",
+      "Version": "3.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "ape",
@@ -2815,7 +3034,7 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "6b825b70c84bd46133ac63b6dccedef0"
+      "Hash": "6c4748308cbe296a022cba26e118075a"
     },
     "ggupset": {
       "Package": "ggupset",
@@ -2932,8 +3151,9 @@
     },
     "graph": {
       "Package": "graph",
-      "Version": "1.80.0",
+      "Version": "1.82.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -2942,7 +3162,7 @@
         "stats4",
         "utils"
       ],
-      "Hash": "af02a936ce577656083213cdd8f5584d"
+      "Hash": "096137dd6d37588451a82658aa94ecbd"
     },
     "graphlayouts": {
       "Package": "graphlayouts",
@@ -3000,7 +3220,7 @@
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.4",
+      "Version": "0.3.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3011,7 +3231,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "b29cf3031f49b04ab9c852c912547eef"
+      "Hash": "e18861963cbc65a27736e02b3cd3c4a0"
     },
     "gtools": {
       "Package": "gtools",
@@ -3024,6 +3244,22 @@
         "utils"
       ],
       "Hash": "588d091c35389f1f4a9d533c8d709b35"
+    },
+    "gypsum": {
+      "Package": "gypsum",
+      "Version": "1.0.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "filelock",
+        "httr2",
+        "jsonlite",
+        "parallel",
+        "paws.storage",
+        "tools",
+        "utils"
+      ],
+      "Hash": "380fad913349a0834d73a49c312155b9"
     },
     "harmony": {
       "Package": "harmony",
@@ -3180,6 +3416,27 @@
       ],
       "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
     },
+    "httr2": {
+      "Package": "httr2",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "curl",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "openssl",
+        "rappdirs",
+        "rlang",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "03d741c92fda96d98c3a3f22494e3b4a"
+    },
     "hunspell": {
       "Package": "hunspell",
       "Version": "3.0.3",
@@ -3225,19 +3482,6 @@
         "vctrs"
       ],
       "Hash": "c3b7d801d722e26e4cd888e042bf9af5"
-    },
-    "interactiveDisplayBase": {
-      "Package": "interactiveDisplayBase",
-      "Version": "1.40.0",
-      "Source": "Bioconductor",
-      "Requirements": [
-        "BiocGenerics",
-        "DT",
-        "R",
-        "methods",
-        "shiny"
-      ],
-      "Hash": "776b86cd30211a590997dc15d02c8eff"
     },
     "invgamma": {
       "Package": "invgamma",
@@ -3301,6 +3545,16 @@
       ],
       "Hash": "e1b9c55281c5adc4dd113652d9e26768"
     },
+    "jsonvalidate": {
+      "Package": "jsonvalidate",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "V8"
+      ],
+      "Hash": "cdc2843ef7f44f157198bb99aea7552d"
+    },
     "knitr": {
       "Package": "knitr",
       "Version": "1.46",
@@ -3330,7 +3584,7 @@
     },
     "labelled": {
       "Package": "labelled",
-      "Version": "2.12.0",
+      "Version": "2.13.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3341,9 +3595,10 @@
         "rlang",
         "stringr",
         "tidyr",
+        "tidyselect",
         "vctrs"
       ],
-      "Hash": "1ec27c624ece6c20431e9249bd232797"
+      "Hash": "ad4b6d757624221aec6220b8c78defeb"
     },
     "lambda.r": {
       "Package": "lambda.r",
@@ -3407,8 +3662,9 @@
     },
     "limma": {
       "Package": "limma",
-      "Version": "3.58.1",
+      "Version": "3.60.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "grDevices",
@@ -3418,7 +3674,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "74c3b64358e0be7edc3ecd130816dd3f"
+      "Hash": "eb9369d11da98acc7f7ca4cdab0ee3d8"
     },
     "locfit": {
       "Package": "locfit",
@@ -3502,12 +3758,13 @@
     },
     "metapod": {
       "Package": "metapod",
-      "Version": "1.10.1",
+      "Version": "1.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Rcpp"
       ],
-      "Hash": "64e76c256313f40ff540e371e58b5503"
+      "Hash": "026552a86c3aa0d92d4d8b12d80010cc"
     },
     "mgcv": {
       "Package": "mgcv",
@@ -3528,8 +3785,9 @@
     },
     "miQC": {
       "Package": "miQC",
-      "Version": "1.10.0",
+      "Version": "1.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "SingleCellExperiment",
@@ -3537,7 +3795,7 @@
         "ggplot2",
         "splines"
       ],
-      "Hash": "5d3660451d88509307ce0b0e48748109"
+      "Hash": "86a3469aee260ac4094af5302291d57a"
     },
     "mime": {
       "Package": "mime",
@@ -3670,17 +3928,17 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.1.1",
+      "Version": "2.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "2a0dc8c6adfb6f032e4d4af82d258ab5"
+      "Hash": "ea2475b073243d9d338aa8f086ce973e"
     },
     "optparse": {
       "Package": "optparse",
-      "Version": "1.7.4",
+      "Version": "1.7.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3688,51 +3946,51 @@
         "getopt",
         "methods"
       ],
-      "Hash": "523cc4a72afdf6748b7aaf2cad607435"
+      "Hash": "ce5f8381cd2c38d1fc14c83d8b21efd0"
     },
     "org.Cf.eg.db": {
       "Package": "org.Cf.eg.db",
-      "Version": "3.18.0",
+      "Version": "3.19.1",
       "Source": "Bioconductor",
       "Requirements": [
         "AnnotationDbi",
         "R",
         "methods"
       ],
-      "Hash": "7d191ea699290fc76da6324ec07bb87b"
+      "Hash": "683c948128f3c35766e9f71e35b52606"
     },
     "org.Dr.eg.db": {
       "Package": "org.Dr.eg.db",
-      "Version": "3.18.0",
+      "Version": "3.19.1",
       "Source": "Bioconductor",
       "Requirements": [
         "AnnotationDbi",
         "R",
         "methods"
       ],
-      "Hash": "9840353417607700f26746ad1c729af1"
+      "Hash": "1e6893b6ea27551fa2fd8d13644486e7"
     },
     "org.Hs.eg.db": {
       "Package": "org.Hs.eg.db",
-      "Version": "3.18.0",
+      "Version": "3.19.1",
       "Source": "Bioconductor",
       "Requirements": [
         "AnnotationDbi",
         "R",
         "methods"
       ],
-      "Hash": "120d734b7c6eaed99d8f5f61e6c125ed"
+      "Hash": "1ac8a004ad2e4f6489dadf3a2ffeb638"
     },
     "org.Mm.eg.db": {
       "Package": "org.Mm.eg.db",
-      "Version": "3.18.0",
+      "Version": "3.19.1",
       "Source": "Bioconductor",
       "Requirements": [
         "AnnotationDbi",
         "R",
         "methods"
       ],
-      "Hash": "abded9efdefa42108f268872e15aa8bf"
+      "Hash": "3798992dbae16046c472adb1b5fcd04b"
     },
     "palmerpenguins": {
       "Package": "palmerpenguins",
@@ -3761,6 +4019,35 @@
         "utils"
       ],
       "Hash": "9c8ab14c00ac07e9e04d1664c0b74486"
+    },
+    "paws.common": {
+      "Package": "paws.common",
+      "Version": "0.7.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp",
+        "base64enc",
+        "curl",
+        "digest",
+        "httr",
+        "jsonlite",
+        "methods",
+        "stats",
+        "utils",
+        "xml2"
+      ],
+      "Hash": "c66dfa46eb607d3171f89596d7529446"
+    },
+    "paws.storage": {
+      "Package": "paws.storage",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "paws.common"
+      ],
+      "Hash": "e4a5655c4172112449f7f501c60ed671"
     },
     "pheatmap": {
       "Package": "pheatmap",
@@ -3878,12 +4165,13 @@
     },
     "preprocessCore": {
       "Package": "preprocessCore",
-      "Version": "1.64.0",
+      "Version": "1.66.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "stats"
       ],
-      "Hash": "0a2241c04babfab4e0a1f43cfca33fbf"
+      "Hash": "d188d81b219bbf395f3281d3edb6328c"
     },
     "prettyunits": {
       "Package": "prettyunits",
@@ -3966,8 +4254,9 @@
     },
     "qusage": {
       "Package": "qusage",
-      "Version": "2.36.0",
+      "Version": "2.38.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "R",
@@ -3978,12 +4267,13 @@
         "nlme",
         "utils"
       ],
-      "Hash": "53526dace4b4bed80423952ccf71c5aa"
+      "Hash": "f62c4ffeadb75c4b129350116258ac1f"
     },
     "qvalue": {
       "Package": "qvalue",
-      "Version": "2.34.0",
+      "Version": "2.36.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "ggplot2",
@@ -3991,7 +4281,7 @@
         "reshape2",
         "splines"
       ],
-      "Hash": "76fc42834c44b69e4021f6ade524d299"
+      "Hash": "16f095487215acf101cdc3ed3da237cf"
     },
     "ragg": {
       "Package": "ragg",
@@ -4086,10 +4376,12 @@
     "renv": {
       "Package": "renv",
       "Version": "1.0.7",
-      "OS_type": null,
-      "NeedsCompilation": "no",
-      "Repository": "CRAN",
-      "Source": "Repository"
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "397b7b2a265bc5a7a06852524dabae20"
     },
     "reprex": {
       "Package": "reprex",
@@ -4144,7 +4436,7 @@
     },
     "reticulate": {
       "Package": "reticulate",
-      "Version": "1.35.0",
+      "Version": "1.36.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -4162,29 +4454,30 @@
         "utils",
         "withr"
       ],
-      "Hash": "90be16b53b955990db4aa355c03d85eb"
+      "Hash": "e037fb5dc364efdaf616eb6bc05aaca2"
     },
     "rhdf5": {
       "Package": "rhdf5",
-      "Version": "2.46.1",
+      "Version": "2.48.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "Rhdf5lib",
-        "S4Vectors",
         "methods",
         "rhdf5filters"
       ],
-      "Hash": "b0a244022c3427cd8213c33804c6b5de"
+      "Hash": "74d8c5aeb96d090ce8efc9ffd16afa2b"
     },
     "rhdf5filters": {
       "Package": "rhdf5filters",
-      "Version": "1.14.1",
+      "Version": "1.16.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Rhdf5lib"
       ],
-      "Hash": "d27a2f6a89def6388fad5b0aae026220"
+      "Hash": "99e15369f8fb17dc188377234de13fc6"
     },
     "rjson": {
       "Package": "rjson",
@@ -4260,8 +4553,9 @@
     },
     "rtracklayer": {
       "Package": "rtracklayer",
-      "Version": "1.62.0",
+      "Version": "1.64.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocIO",
@@ -4271,17 +4565,18 @@
         "GenomicRanges",
         "IRanges",
         "R",
-        "RCurl",
         "Rsamtools",
         "S4Vectors",
         "XML",
         "XVector",
+        "curl",
+        "httr",
         "methods",
         "restfulr",
         "tools",
         "zlibbioc"
       ],
-      "Hash": "e940c622725a16a0069505876051b077"
+      "Hash": "3d6f004fce582bd7d68e2e18d44abbc1"
     },
     "rvest": {
       "Package": "rvest",
@@ -4318,8 +4613,9 @@
     },
     "scDblFinder": {
       "Package": "scDblFinder",
-      "Version": "1.16.0",
+      "Version": "1.18.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocNeighbors",
@@ -4347,27 +4643,38 @@
         "utils",
         "xgboost"
       ],
-      "Hash": "3dc5166545e7caa130d362f5b809677b"
+      "Hash": "3a998cfc42e06628628c320c904ffdaf"
     },
     "scRNAseq": {
       "Package": "scRNAseq",
-      "Version": "2.16.0",
+      "Version": "2.17.9",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "AnnotationHub",
         "BiocGenerics",
+        "DBI",
+        "DelayedArray",
         "ExperimentHub",
         "GenomicFeatures",
         "GenomicRanges",
+        "Matrix",
+        "RSQLite",
         "S4Vectors",
         "SingleCellExperiment",
+        "SparseArray",
         "SummarizedExperiment",
+        "alabaster.base",
+        "alabaster.matrix",
+        "alabaster.sce",
         "ensembldb",
+        "gypsum",
+        "jsonlite",
         "methods",
         "utils"
       ],
-      "Hash": "c2d9488400414a385f838d89b17a23bf"
+      "Hash": "007c6a8b4d4685ead6aba97ead5670db"
     },
     "scales": {
       "Package": "scales",
@@ -4391,8 +4698,9 @@
     },
     "scater": {
       "Package": "scater",
-      "Version": "1.30.1",
+      "Version": "1.32.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocNeighbors",
@@ -4421,7 +4729,7 @@
         "uwot",
         "viridis"
       ],
-      "Hash": "d92b4aa892e1f28148ce3ecad8e63cfb"
+      "Hash": "4a6eb8ab8a2b926fe67cf83aa731a3df"
     },
     "scatterpie": {
       "Package": "scatterpie",
@@ -4443,8 +4751,9 @@
     },
     "scran": {
       "Package": "scran",
-      "Version": "1.30.2",
+      "Version": "1.32.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BH",
         "BiocGenerics",
@@ -4470,12 +4779,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "147b3753ca3cb0a1a24a7f2a35f05222"
+      "Hash": "5b11173a6b49f06dda0db31e80caa561"
     },
     "scuttle": {
       "Package": "scuttle",
-      "Version": "1.12.0",
+      "Version": "1.14.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "BiocParallel",
@@ -4492,7 +4802,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "1412c4b6dfd8de528e1101e493e66a02"
+      "Hash": "6d94b72071aefd6e8b041c34ee83ebd0"
     },
     "selectr": {
       "Package": "selectr",
@@ -4614,8 +4924,9 @@
     },
     "sparseMatrixStats": {
       "Package": "sparseMatrixStats",
-      "Version": "1.14.0",
+      "Version": "1.16.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Matrix",
         "MatrixGenerics",
@@ -4623,7 +4934,7 @@
         "matrixStats",
         "methods"
       ],
-      "Hash": "49383d0f6c6152ff7cb594f254c23cc8"
+      "Hash": "7e500a5a527460ca0406473bdcade286"
     },
     "spelling": {
       "Package": "spelling",
@@ -4906,8 +5217,9 @@
     },
     "treeio": {
       "Package": "treeio",
-      "Version": "1.26.0",
+      "Version": "1.28.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "R",
         "ape",
@@ -4919,9 +5231,10 @@
         "stats",
         "tibble",
         "tidytree",
-        "utils"
+        "utils",
+        "yulab.utils"
       ],
-      "Hash": "a09203806aa0bc49965563ca7016620e"
+      "Hash": "9e0a0b700763836cd36cb3a49be5a15d"
     },
     "truncnorm": {
       "Package": "truncnorm",
@@ -4948,10 +5261,40 @@
       ],
       "Hash": "82fac2b73e6a1f3874fc000aaf96d8bc"
     },
+    "txdbmaker": {
+      "Package": "txdbmaker",
+      "Version": "1.0.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "AnnotationDbi",
+        "Biobase",
+        "BiocGenerics",
+        "BiocIO",
+        "DBI",
+        "GenomeInfoDb",
+        "GenomicFeatures",
+        "GenomicRanges",
+        "IRanges",
+        "RSQLite",
+        "S4Vectors",
+        "UCSC.utils",
+        "biomaRt",
+        "httr",
+        "methods",
+        "rjson",
+        "rtracklayer",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "6daec4674f5198f4d3b7db2c8a3a9508"
+    },
     "tximeta": {
       "Package": "tximeta",
-      "Version": "1.20.3",
+      "Version": "1.22.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "AnnotationHub",
@@ -4969,21 +5312,23 @@
         "methods",
         "tibble",
         "tools",
+        "txdbmaker",
         "tximport",
         "utils"
       ],
-      "Hash": "abe6f74dc6bdbed790f0d8eb9a3d3521"
+      "Hash": "8871a89e79fd3e419b5a5869efb68158"
     },
     "tximport": {
       "Package": "tximport",
-      "Version": "1.30.0",
+      "Version": "1.32.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "methods",
         "stats",
         "utils"
       ],
-      "Hash": "6e9621b0f1bf9398255f32c7000a7e16"
+      "Hash": "de83dfc887cf6205591b70500c987e43"
     },
     "tzdb": {
       "Package": "tzdb",
@@ -5035,12 +5380,13 @@
     },
     "uwot": {
       "Package": "uwot",
-      "Version": "0.1.16",
+      "Version": "0.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "FNN",
         "Matrix",
+        "RSpectra",
         "Rcpp",
         "RcppAnnoy",
         "RcppProgress",
@@ -5048,7 +5394,7 @@
         "irlba",
         "methods"
       ],
-      "Hash": "252deaa1c1d6d3da6946694243781ea3"
+      "Hash": "f693a0ca6d34b02eb432326388021805"
     },
     "vctrs": {
       "Package": "vctrs",
@@ -5127,8 +5473,9 @@
     },
     "vsn": {
       "Package": "vsn",
-      "Version": "3.70.0",
+      "Version": "3.72.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "R",
@@ -5138,7 +5485,7 @@
         "limma",
         "methods"
       ],
-      "Hash": "cd77c1e57dedbaa1aaa0fb35f1a72ff0"
+      "Hash": "72603bed69ebcf4fe1e81de3587e9624"
     },
     "withr": {
       "Package": "withr",
@@ -5229,10 +5576,10 @@
     },
     "zlibbioc": {
       "Package": "zlibbioc",
-      "Version": "1.48.2",
+      "Version": "1.50.0",
       "Source": "Bioconductor",
-      "Repository": "Bioconductor",
-      "Hash": "2344be62c2da4d9e9942b5d8db346e59"
+      "Repository": "Bioconductor 3.19",
+      "Hash": "3db02e3c460e1c852365df117a2b441b"
     }
   }
 }

--- a/renv/settings.json
+++ b/renv/settings.json
@@ -11,7 +11,7 @@
   "ppm.ignored.urls": [],
   "r.version": "4.4.0",
   "snapshot.type": "implicit",
-  "use.cache": false,
+  "use.cache": true,
   "vcs.ignore.cellar": true,
   "vcs.ignore.library": true,
   "vcs.ignore.local": true,

--- a/renv/settings.json
+++ b/renv/settings.json
@@ -1,5 +1,5 @@
 {
-  "bioconductor.version": "3.18",
+  "bioconductor.version": "3.19",
   "external.libraries": [],
   "ignored.packages": [],
   "package.dependency.fields": [
@@ -9,7 +9,7 @@
   ],
   "ppm.enabled": true,
   "ppm.ignored.urls": [],
-  "r.version": "4.3.3",
+  "r.version": "4.4.0",
   "snapshot.type": "implicit",
   "use.cache": false,
   "vcs.ignore.cellar": true,


### PR DESCRIPTION
This PR updates all packages in `renv.lock` with the most notable overall change being the upgrade to R 4.4 and Bioconductor 3.19.

These changes have not been tested across all notebooks, so we still need #759 

closes #761 