### PR TITLE
recalculate stats and another filtering step

### DIFF
--- a/scRNA-seq/04-dimension_reduction_scRNA.Rmd
+++ b/scRNA-seq/04-dimension_reduction_scRNA.Rmd
@@ -212,13 +212,53 @@ dim(filtered_sce)
 Now we will perform the same normalization steps we did in a previous dataset, using `scran::computeSumFactors()` and `scater::logNormCounts()`.
 You might recall that there is a bit of randomness in some of these calculations, so we should be sure to have used `set.seed()` earlier in the notebook for reproducibility.
 
-```{r normalize}
+```{r sumfactors}
 # Cluster similar cells
 qclust <- scran::quickCluster(filtered_sce)
 
 # Compute sum factors for each cell cluster grouping.
-filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust)
+filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust, positive = FALSE)
+```
 
+It turns out in this case we end up with some negative size factors.
+This is usually an indication that our filtering was not stringent enough, and there remain a number of cells or genes with nearly zero counts.
+This probably happened when some cells had many UMIs from the genes we removed in the last filtering.
+
+To account for this, we will recalculate the per-cell stats and filter out low counts.
+Unfortunately, to do this, we need to first remove the previously calculated statistics, which we will do by setting them to `NULL`
+
+```{r reQC}
+# remove previous calculations
+filtered_sce$sum <- NULL
+filtered_sce$detected <- NULL
+filtered_sce$total <- NULL
+filtered_sce$subsets_mito_sum <- NULL
+filtered_sce$subsets_mito_detected <- NULL
+filtered_sce$subsets_mito_sum <- NULL
+
+# recalculate cell stats
+filtered_sce <- scater::addPerCellQC(filtered_sce, subsets = list(mito = mito_genes))
+
+# print the number of cells with fewer than 500 UMIs
+sum(filtered_sce$sum < 500)
+```
+
+Now we can filter again.
+In this case, we will keep cells with at least 500 UMIs after removing the lowly expressed genes.
+Then we will redo the size factor calculation, hopefully with no more warnings.
+
+
+```{r refilter}
+filtered_sce <- filtered_sce[, filtered_sce$sum >= 500]
+
+qclust <- scran::quickCluster(filtered_sce)
+
+filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust, positive = FALSE)
+```
+
+Looks good! Now we'll do the normalization.
+
+```{r normalize}
 # Normalize and log transform.
 normalized_sce <- scater::logNormCounts(filtered_sce)
 ```

--- a/scRNA-seq/04-dimension_reduction_scRNA.Rmd
+++ b/scRNA-seq/04-dimension_reduction_scRNA.Rmd
@@ -222,7 +222,7 @@ filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust, positi
 
 It turns out in this case we end up with some negative size factors.
 This is usually an indication that our filtering was not stringent enough, and there remain a number of cells or genes with nearly zero counts.
-This probably happened when some cells had many UMIs from the genes we removed in the last filtering.
+This probably happened when we removed the infrequently-expressed genes; cells which had high counts from those particular genes (and few others) could have had their total counts dramatically reduced.
 
 To account for this, we will recalculate the per-cell stats and filter out low counts.
 Unfortunately, to do this, we need to first remove the previously calculated statistics, which we will do by setting them to `NULL`.

--- a/scRNA-seq/04-dimension_reduction_scRNA.Rmd
+++ b/scRNA-seq/04-dimension_reduction_scRNA.Rmd
@@ -225,7 +225,7 @@ This is usually an indication that our filtering was not stringent enough, and t
 This probably happened when some cells had many UMIs from the genes we removed in the last filtering.
 
 To account for this, we will recalculate the per-cell stats and filter out low counts.
-Unfortunately, to do this, we need to first remove the previously calculated statistics, which we will do by setting them to `NULL`
+Unfortunately, to do this, we need to first remove the previously calculated statistics, which we will do by setting them to `NULL`.
 
 ```{r reQC}
 # remove previous calculations

--- a/scRNA-seq/04-dimension_reduction_scRNA.Rmd
+++ b/scRNA-seq/04-dimension_reduction_scRNA.Rmd
@@ -253,7 +253,7 @@ filtered_sce <- filtered_sce[, filtered_sce$sum >= 500]
 
 qclust <- scran::quickCluster(filtered_sce)
 
-filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust, positive = FALSE)
+filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust)
 ```
 
 Looks good! Now we'll do the normalization.


### PR DESCRIPTION
Closes #768 

To avoid the negative size factors after filtering (which it turns out had been there for a while), I added a step where we recalculate the per-cell stats and re-filter. It turns out that removing some of the lowly expressed genes created cells with very low total UMI counts remaining, which affected the results. The total number of cells affected was only about 5, but I think it is a nice illustration of some of the unexpected effects of filtering!