### PR TITLE
Swap out fishpond for eds

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image and Push to Dockerhub
+name: Build Docker Image
 
 # Every time something is merged to master or a tag is pushed, we build and push
 # the Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,12 @@ RUN pip install -r requirements.txt
 # Use renv for R packages
 WORKDIR /usr/local/renv
 ENV RENV_CONFIG_CACHE_ENABLED=FALSE
-COPY renv.lock renv.lock
 RUN R -e "install.packages('renv')"
+
+# Temporary fix for broken(?) RSamtools package
+RUN R -e "install.packages('BiocManager'); BiocManager::install('RSamtools')"
+
+COPY renv.lock renv.lock
 RUN R -e "renv::restore()" \
     rm -rf ~/.cache/R/renv && \
     rm -rf /tmp/downloaded_packages && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,13 +73,13 @@ RUN pip install -r requirements.txt
 # Use renv for R packages
 WORKDIR /usr/local/renv
 ENV RENV_CONFIG_CACHE_ENABLED=FALSE
-RUN R -e "install.packages('renv')"
+RUN Rscript -e "install.packages('renv')"
 
 # Temporary fix for broken(?) RSamtools package
-RUN R -e "install.packages('BiocManager'); BiocManager::install('Rsamtools')"
+RUN Rscript -e "install.packages('BiocManager'); BiocManager::install('Rsamtools')"
 
 COPY renv.lock renv.lock
-RUN R -e "renv::restore()" \
+RUN Rscript -e "renv::restore()" \
     rm -rf ~/.cache/R/renv && \
     rm -rf /tmp/downloaded_packages && \
     rm -rf /tmp/Rtmp*

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
+
+
 # Use renv for R packages
 WORKDIR /usr/local/renv
 ENV RENV_CONFIG_CACHE_ENABLED=FALSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV RENV_CONFIG_CACHE_ENABLED=FALSE
 RUN R -e "install.packages('renv')"
 
 # Temporary fix for broken(?) RSamtools package
-RUN R -e "install.packages('BiocManager'); BiocManager::install('RSamtools')"
+RUN R -e "install.packages('BiocManager'); BiocManager::install('Rsamtools')"
 
 COPY renv.lock renv.lock
 RUN R -e "renv::restore()" \

--- a/components/dependencies.R
+++ b/components/dependencies.R
@@ -7,7 +7,7 @@ library(markdown)
 library(magick)
 
 # Recommended by tximport
-library(fishpond)
+library(eds)
 
 # Required for DESeq2::lfcShrink()
 library(apeglm)

--- a/renv.lock
+++ b/renv.lock
@@ -2378,6 +2378,17 @@
       ],
       "Hash": "20783ecb7e7cea3f351e8b21153e3eb8"
     },
+    "eds": {
+      "Package": "eds",
+      "Version": "1.6.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "Matrix",
+        "Rcpp"
+      ],
+      "Hash": "ab19d02b3418e44d6f32ffb8060427d2"
+    },
     "ellipsis": {
       "Package": "ellipsis",
       "Version": "0.3.2",
@@ -2630,31 +2641,6 @@
         "R"
       ],
       "Hash": "192053c276525c8495ccfd523aa8f2d1"
-    },
-    "fishpond": {
-      "Package": "fishpond",
-      "Version": "2.10.0",
-      "Source": "Bioconductor",
-      "Repository": "Bioconductor 3.19",
-      "Requirements": [
-        "GenomicRanges",
-        "IRanges",
-        "Matrix",
-        "S4Vectors",
-        "SingleCellExperiment",
-        "SummarizedExperiment",
-        "abind",
-        "graphics",
-        "gtools",
-        "jsonlite",
-        "matrixStats",
-        "methods",
-        "qvalue",
-        "stats",
-        "svMisc",
-        "utils"
-      ],
-      "Hash": "9091a296b5cdb86da7c4c35f958c67f6"
     },
     "flexmix": {
       "Package": "flexmix",
@@ -5007,20 +4993,6 @@
         "utils"
       ],
       "Hash": "184d7799bca4ba8c3be72ea396f4b9a3"
-    },
-    "svMisc": {
-      "Package": "svMisc",
-      "Version": "1.2.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods",
-        "stats",
-        "tools",
-        "utils"
-      ],
-      "Hash": "b13f5680860f67c32ccb006ad38f24f4"
     },
     "sys": {
       "Package": "sys",


### PR DESCRIPTION
While I was wrong about https://github.com/AlexsLemonade/scpcaTools/issues/277, I had originally noticed the change when remaking output files for this repo, so here I am swapping out `fishpond` for `eds` in the `renv` for this repository. This is because the function that `tximport` uses to speed up reading alevin files has moved to `eds`. By installing `eds` we can quiet the new warning, and get faster imports.

For June 2024, I have already installed `eds` on the server, but that is not reflected here or in the docker image. I don't necessarily think we need to update the docker image, but we could if we wanted to by retagging the release (or adding a point update release). 