### PR TITLE
775 Add user-facing gitignore.user

### DIFF
--- a/gitignore.user
+++ b/gitignore.user
@@ -1,0 +1,48 @@
+# Gitignore file for users of training modules repository
+# portions derived from https://github.com/github/gitignore
+
+# R environment and files
+.RData
+.RDataTmp
+.Rhistory
+.Renviron
+.Ruserdata
+.Rproj.user/
+
+# knitr and R markdown default cache directories and temporary files
+*_cache/
+/cache/
+*.utf8.md
+*.knit.md
+
+# Security files
+id_rsa.pub
+id_rsa
+id_ed*
+id_ed*.pub
+*.pem
+*.key
+secring.*
+
+# Mac system files
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows system files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+*.lnk
+*.stackdump
+[Dd]esktop.ini
+
+# Snakemake files
+.snakemake
+
+# mdspell files
+.spelling
+
+# File with errors if you are running locally
+spell_check_errors.tsv


### PR DESCRIPTION
Closes #775

Here I am adding a user-facing gitignore file with a bit of extra security added to the one that is currently part of this repository. Most of this will probably be irrelevant in practice (ssh files should not end up in this directory unless somebody does something very odd), but part of the goal here is to show some of the scope of files you never want to include. 

I decided to name this file `gitignore.user` because that sounded better to me than `gitignore.skel`, but tell me if I am wrong!