### PR TITLE
Add instructions for copying notebook file to magic file location

### DIFF
--- a/RNA-seq/setup/magic-files.md
+++ b/RNA-seq/setup/magic-files.md
@@ -12,6 +12,7 @@ Files are listed below by the notebook that produces them:
   - `data/gastric-cancer/txi/gastric-cancer_tximeta.rds`
 - `setup/ref_notebooks/04-nb_cell_line_tximeta.Rmd` (participants create their own notebook for this step)
   - `data/NB-cell/txi/NB-cell_tximeta.rds`
+  - For convenience, we should also copy `setup/ref_notebooks/04-nb_cell_line_tximeta.Rmd` to `/shared/data/training-data/<date>/RNA-seq/nb_cell_tximeta.Rmd`, to match the activity instructions for notebook name.
 - `05-nb_cell_line_DESeq2.Rmd`
   - `results/NB-cell/NB-cell_DESeq_amplified_v_nonamplified.rds`
   - `results/NB-cell/NB-cell_DESeq_amplified_v_nonamplified_results.tsv`


### PR DESCRIPTION
Since we probably want to have the full notebook for NB tximeta activity easily available just in case, let's copy it to the same magic files location.

Note that I have have also done this, moving the file that @sjspielman had initially placed in a subdirectory.