### PR TITLE
Restore legend titles in scAdvanced integration notebook

### DIFF
--- a/scRNA-seq-advanced/02-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/02-dataset_integration.Rmd
@@ -702,7 +702,7 @@ scater::plotReducedDim(merged_sce,
                        point_alpha = 0.2,
                        # Allow for faceting by a variable using `other_fields`:
                        other_fields = "sample") +
-  scale_color_brewer(palette = "Dark2", name = "celltype_broad", na.value = "grey80") +
+  scale_color_brewer(palette = "Dark2", name = "Broad celltype", na.value = "grey80") +
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP after integration with fastMNN") +
   # Facet by sample
@@ -811,7 +811,7 @@ scater::plotReducedDim(merged_sce,
                        point_alpha = 0.2,
                        # Specify variable for faceting
                        other_fields = "sample") +
-  scale_color_brewer(palette = "Dark2", name = "celltype_broad", na.value = "grey80") +
+  scale_color_brewer(palette = "Dark2", name = "Broad celltype", na.value = "grey80") +
   guides(color = guide_legend(override.aes = list(size = 3))) +
   ggtitle("UMAP after integration with harmony") +
   facet_wrap(vars(sample))

--- a/scRNA-seq-advanced/02-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/02-dataset_integration.Rmd
@@ -683,7 +683,7 @@ scater::plotReducedDim(merged_sce,
                        point_size = 0.5,
                        point_alpha = 0.2) +
   # include argument to specify color of NA values
-  scale_color_brewer(palette = "Dark2", name = "celltype_broad", na.value = "grey80") +
+  scale_color_brewer(palette = "Dark2", name = "Broad celltype", na.value = "grey80") +
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP after integration with fastMNN")
 ```

--- a/scRNA-seq-advanced/02-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/02-dataset_integration.Rmd
@@ -467,12 +467,12 @@ scater::plotReducedDim(merged_sce,
                        color_by = "sample",
                        point_size = 0.5,
                        point_alpha = 0.2) +
-  # Use a CVD-friendly color scheme
-  scale_color_brewer(palette = "Dark2") +  
+  # Use a CVD-friendly color scheme and specify legend name
+  scale_color_brewer(palette = "Dark2", name = "sample") +
   # Modify the legend key so its points are larger and easier to see
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP calculated on each sample separately")
-  
+
 ```
 
 
@@ -560,7 +560,7 @@ scater::plotReducedDim(merged_sce,
                        # Some styling to help us see the points:
                        point_size = 0.5,
                        point_alpha = 0.2) +
-  scale_color_brewer(palette = "Dark2") +  
+  scale_color_brewer(palette = "Dark2", name = "sample") +
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP calculated on merged_sce")
 ```
@@ -638,7 +638,7 @@ scater::plotReducedDim(merged_sce,
                        # Some styling to help us see the points:
                        point_size = 0.5,
                        point_alpha = 0.2) +
-  scale_color_brewer(palette = "Dark2") +  
+  scale_color_brewer(palette = "Dark2", name = "sample") +
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP after integration with fastMNN")
 ```
@@ -682,7 +682,8 @@ scater::plotReducedDim(merged_sce,
                        color_by = "celltype_broad",
                        point_size = 0.5,
                        point_alpha = 0.2) +
-  scale_color_brewer(palette = "Dark2") +  
+  # include argument to specify color of NA values
+  scale_color_brewer(palette = "Dark2", name = "celltype_broad", na.value = "grey80") +
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP after integration with fastMNN")
 ```
@@ -701,7 +702,7 @@ scater::plotReducedDim(merged_sce,
                        point_alpha = 0.2,
                        # Allow for faceting by a variable using `other_fields`:
                        other_fields = "sample") +
-  scale_color_brewer(palette = "Dark2") +  
+  scale_color_brewer(palette = "Dark2", name = "celltype_broad", na.value = "grey80") +
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP after integration with fastMNN") +
   # Facet by sample
@@ -793,7 +794,7 @@ scater::plotReducedDim(merged_sce,
                        color_by = "sample",
                        point_size = 0.5,
                        point_alpha = 0.2) +
-  scale_color_brewer(palette = "Dark2") +
+  scale_color_brewer(palette = "Dark2", name = "sample") +
   guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +
   ggtitle("UMAP after integration with harmony")
 ```
@@ -810,7 +811,7 @@ scater::plotReducedDim(merged_sce,
                        point_alpha = 0.2,
                        # Specify variable for faceting
                        other_fields = "sample") +
-  scale_color_brewer(palette = "Dark2", na.value = "grey80") +
+  scale_color_brewer(palette = "Dark2", name = "celltype_broad", na.value = "grey80") +
   guides(color = guide_legend(override.aes = list(size = 3))) +
   ggtitle("UMAP after integration with harmony") +
   facet_wrap(vars(sample))


### PR DESCRIPTION
This PR fixes a woopsie introduced in #800, which I caught when reviewing scAdvanced materials.
I had known this at one point but forgotten - when overriding the color scale for `plotReducedDim` and friends, you need to also specify the legend title or it will default back to `colour_by`. 

This PR adds the `name` to all such spots! I also missed a few `na.value` arguments, so I added those in too. Only the integration notebook needed these changes, since we don't override the color scale itself elsewhere. 