### PR TITLE
Keep column names when reading in 10x data

### DIFF
--- a/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
+++ b/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
@@ -113,7 +113,11 @@ Some of these functions for other common data formats are discussed in [Chapter 
 
 ```{r read SCE, live=TRUE}
 # read SCE from matrix directory
-raw_sce <- DropletUtils::read10xCounts(raw_matrix_dir)
+raw_sce <- DropletUtils::read10xCounts(
+  raw_matrix_dir, 
+  # ensure barcodes are set as column names in the SCE object
+  col.names = TRUE
+)
 ```
 
 Let's look at the contents of the object after reading it in:

--- a/scRNA-seq/04-dimension_reduction_scRNA.Rmd
+++ b/scRNA-seq/04-dimension_reduction_scRNA.Rmd
@@ -86,7 +86,11 @@ Cell Ranger also outputs both filtered and raw matrices; today we will start wit
 ![Roadmap: Preprocessing and Import](diagrams/roadmap_single_preprocess_alevin.png)
 
 ```{r read10x, live = TRUE}
-hodgkins_sce <- DropletUtils::read10xCounts(raw_matrix_dir)
+hodgkins_sce <- DropletUtils::read10xCounts(
+  raw_matrix_dir, 
+  # ensure barcodes are set as column names in the SCE object
+  col.names = TRUE
+)
 ```
 
 How many potential cells are there here?


### PR DESCRIPTION
Closes #804 

This PR adds the argument `col.names=TRUE` when calling `DropletUtils::read10xCounts()` so that we get nice things, like barcode column names. Let me know if we'd also like to see some text about this argument in addition to its usage.