### PR TITLE
Missing an "a"

### DIFF
--- a/scRNA-seq-advanced/02-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/02-dataset_integration.Rmd
@@ -739,8 +739,8 @@ Like `fastMNN`, `harmony` performs integration on a merged PCA matrix.
 However, unlike `fastMNN`, `harmony` does not "back-calculate" corrected expression from the corrected PCA matrix and it only returns the corrected PCA matrix itself.
 For input, `harmony` needs a couple pieces of information:
 
-- First, `harmony` takes batch-weighted PCA matrix directly to perform integration.
-Since we already calculated a batch-weighted PCA matrix (our `merged_PCA` reduced dimension), we'll provide this information directly.
+- First, `harmony` takes a batch-weighted PCA matrix to perform integration.
+We already calculated a batch-weighted PCA matrix (our `merged_PCA` reduced dimension), we'll provide this variable.
 - Second, we need to tell `harmony` about the covariates to use - `sample` and `patient`.
 To do this, we provide two arguments:
   - `meta_data`, a data frame that contains covariates across samples.


### PR DESCRIPTION
From https://github.com/AlexsLemonade/training-modules/pull/828/files#diff-5087a61eec8771e3887a8c4116446efda373a5550ad07c37b17cc7cc47cc9574

Added the missing "a", and tweaked a smidge more.