### PR TITLE
Notebook fixes from June 2024

### DIFF
--- a/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
+++ b/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
@@ -22,7 +22,7 @@ This notebook will demonstrate how to:
 ---
 
 In this notebook, we will review basic processing for single-cell RNA-seq data, starting with the output from Cell Ranger, and proceeding through filtering, quality control, normalization, and dimension reduction. We will perform these tasks using tools from the [Bioconductor project](https://bioconductor.org), in particular [`SingleCellExperiment` objects](https://bioconductor.org/packages/release/bioc/html/SingleCellExperiment.html) and functions that work with those objects.
-Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/3.16/OSCA/).
+Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/release/OSCA/).
 
 ![Single-cell roadmap: Overview](diagrams/roadmap_single_overview.png)
 
@@ -109,7 +109,7 @@ Whether the 10x Cell Ranger data is in Matrix Exchange format or in an HDF5 file
 (Though again, we do not recommend using the `.h5` file if you can avoid it, _especially_ for raw (unfiltered) data.)
 
 If you used something other than Cell Ranger to process the raw data, you would need to use a different function to read it in and create the `SingleCellExperiment` object.
-Some of these functions for other common data formats are discussed in [Chapter 3 of OSCA] (http://bioconductor.org/books/3.16/OSCA.intro/getting-scrna-seq-datasets.html#reading-counts-into-r).
+Some of these functions for other common data formats are discussed in [Chapter 3 of OSCA] (http://bioconductor.org/books/3.19/OSCA.intro/getting-scrna-seq-datasets.html#reading-counts-into-r).
 
 ```{r read SCE, live=TRUE}
 # read SCE from matrix directory
@@ -133,7 +133,7 @@ One of our first steps will be to filter out barcodes that were never seen, or t
 ### Structure of the `SingleCellExperiment` object
 
 In addition to the main `counts` matrix, listed as an `assay` in the SCE summary above, the SCE object can contain a number of other tables and matrices, each stored in a "slot" with a particular format.
-The overall structure of the object can be seen in the figure below, which comes from an [OSCA Introduction chapter](http://bioconductor.org/books/3.16/OSCA.intro/the-singlecellexperiment-class.html).
+The overall structure of the object can be seen in the figure below, which comes from an [OSCA Introduction chapter](http://bioconductor.org/books/3.19/OSCA.intro/the-singlecellexperiment-class.html).
 
 ![Structure of a SingleCellExperiment object](diagrams/SingleCellExperiment.png)
 
@@ -373,7 +373,7 @@ Now that we have done our filtering, we can start analyzing the expression count
 The next step at this point is to convert the raw counts into a measure that accounts for differences in sequencing depth between cells, and to convert the distribution of expression values from the skewed distribution we expect to see in raw counts to one that is more normally distributed.
 
 We will do this using functions from the `scran` and `scuttle` packages.
-The procedure we will use here is derived from the [OSCA chapter on normalization](http://bioconductor.org/books/3.16/OSCA.basic/normalization.html#normalization-by-deconvolution).
+The procedure we will use here is derived from the [OSCA chapter on normalization](http://bioconductor.org/books/3.19/OSCA.basic/normalization.html#normalization-by-deconvolution).
 The idea is that the varying expression patterns that different cell types exhibit will affect the scaling factors that we would apply.
 To account for that variation, we first do a rough clustering of cells by their expression with `scran::quickCluster()`, then use that clustering to calculate the scaling factor for each cell within the clusters using `scran::computeSumFactors()`.
 Finally, we apply the scaling factor to the expression values for each cell and calculate the log-scaled expression values using the `scuttle::logNormCounts()` function.

--- a/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
+++ b/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
@@ -22,7 +22,7 @@ This notebook will demonstrate how to:
 ---
 
 In this notebook, we will review basic processing for single-cell RNA-seq data, starting with the output from Cell Ranger, and proceeding through filtering, quality control, normalization, and dimension reduction. We will perform these tasks using tools from the [Bioconductor project](https://bioconductor.org), in particular [`SingleCellExperiment` objects](https://bioconductor.org/packages/release/bioc/html/SingleCellExperiment.html) and functions that work with those objects.
-Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/3.16/OSCA/).
+Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/release/OSCA/).
 
 ![Single-cell roadmap: Overview](diagrams/roadmap_single_overview.png)
 
@@ -109,7 +109,7 @@ Whether the 10x Cell Ranger data is in Matrix Exchange format or in an HDF5 file
 (Though again, we do not recommend using the `.h5` file if you can avoid it, _especially_ for raw (unfiltered) data.)
 
 If you used something other than Cell Ranger to process the raw data, you would need to use a different function to read it in and create the `SingleCellExperiment` object.
-Some of these functions for other common data formats are discussed in [Chapter 3 of OSCA] (http://bioconductor.org/books/3.16/OSCA.intro/getting-scrna-seq-datasets.html#reading-counts-into-r).
+Some of these functions for other common data formats are discussed in [Chapter 3 of OSCA] (http://bioconductor.org/books/release/OSCA.intro/getting-scrna-seq-datasets.html#reading-counts-into-r).
 
 ```{r read SCE, live=TRUE}
 # read SCE from matrix directory
@@ -133,7 +133,7 @@ One of our first steps will be to filter out barcodes that were never seen, or t
 ### Structure of the `SingleCellExperiment` object
 
 In addition to the main `counts` matrix, listed as an `assay` in the SCE summary above, the SCE object can contain a number of other tables and matrices, each stored in a "slot" with a particular format.
-The overall structure of the object can be seen in the figure below, which comes from an [OSCA Introduction chapter](http://bioconductor.org/books/3.16/OSCA.intro/the-singlecellexperiment-class.html).
+The overall structure of the object can be seen in the figure below, which comes from an [OSCA Introduction chapter](http://bioconductor.org/books/release/OSCA.intro/the-singlecellexperiment-class.html).
 
 ![Structure of a SingleCellExperiment object](diagrams/SingleCellExperiment.png)
 
@@ -373,7 +373,7 @@ Now that we have done our filtering, we can start analyzing the expression count
 The next step at this point is to convert the raw counts into a measure that accounts for differences in sequencing depth between cells, and to convert the distribution of expression values from the skewed distribution we expect to see in raw counts to one that is more normally distributed.
 
 We will do this using functions from the `scran` and `scuttle` packages.
-The procedure we will use here is derived from the [OSCA chapter on normalization](http://bioconductor.org/books/3.16/OSCA.basic/normalization.html#normalization-by-deconvolution).
+The procedure we will use here is derived from the [OSCA chapter on normalization](http://bioconductor.org/books/release/OSCA.basic/normalization.html#normalization-by-deconvolution).
 The idea is that the varying expression patterns that different cell types exhibit will affect the scaling factors that we would apply.
 To account for that variation, we first do a rough clustering of cells by their expression with `scran::quickCluster()`, then use that clustering to calculate the scaling factor for each cell within the clusters using `scran::computeSumFactors()`.
 Finally, we apply the scaling factor to the expression values for each cell and calculate the log-scaled expression values using the `scuttle::logNormCounts()` function.

--- a/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
+++ b/scRNA-seq-advanced/01-read_filter_normalize_scRNA.Rmd
@@ -22,7 +22,7 @@ This notebook will demonstrate how to:
 ---
 
 In this notebook, we will review basic processing for single-cell RNA-seq data, starting with the output from Cell Ranger, and proceeding through filtering, quality control, normalization, and dimension reduction. We will perform these tasks using tools from the [Bioconductor project](https://bioconductor.org), in particular [`SingleCellExperiment` objects](https://bioconductor.org/packages/release/bioc/html/SingleCellExperiment.html) and functions that work with those objects.
-Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/release/OSCA/).
+Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/3.16/OSCA/).
 
 ![Single-cell roadmap: Overview](diagrams/roadmap_single_overview.png)
 
@@ -109,7 +109,7 @@ Whether the 10x Cell Ranger data is in Matrix Exchange format or in an HDF5 file
 (Though again, we do not recommend using the `.h5` file if you can avoid it, _especially_ for raw (unfiltered) data.)
 
 If you used something other than Cell Ranger to process the raw data, you would need to use a different function to read it in and create the `SingleCellExperiment` object.
-Some of these functions for other common data formats are discussed in [Chapter 3 of OSCA] (http://bioconductor.org/books/release/OSCA.intro/getting-scrna-seq-datasets.html#reading-counts-into-r).
+Some of these functions for other common data formats are discussed in [Chapter 3 of OSCA] (http://bioconductor.org/books/3.16/OSCA.intro/getting-scrna-seq-datasets.html#reading-counts-into-r).
 
 ```{r read SCE, live=TRUE}
 # read SCE from matrix directory
@@ -133,7 +133,7 @@ One of our first steps will be to filter out barcodes that were never seen, or t
 ### Structure of the `SingleCellExperiment` object
 
 In addition to the main `counts` matrix, listed as an `assay` in the SCE summary above, the SCE object can contain a number of other tables and matrices, each stored in a "slot" with a particular format.
-The overall structure of the object can be seen in the figure below, which comes from an [OSCA Introduction chapter](http://bioconductor.org/books/release/OSCA.intro/the-singlecellexperiment-class.html).
+The overall structure of the object can be seen in the figure below, which comes from an [OSCA Introduction chapter](http://bioconductor.org/books/3.16/OSCA.intro/the-singlecellexperiment-class.html).
 
 ![Structure of a SingleCellExperiment object](diagrams/SingleCellExperiment.png)
 
@@ -373,7 +373,7 @@ Now that we have done our filtering, we can start analyzing the expression count
 The next step at this point is to convert the raw counts into a measure that accounts for differences in sequencing depth between cells, and to convert the distribution of expression values from the skewed distribution we expect to see in raw counts to one that is more normally distributed.
 
 We will do this using functions from the `scran` and `scuttle` packages.
-The procedure we will use here is derived from the [OSCA chapter on normalization](http://bioconductor.org/books/release/OSCA.basic/normalization.html#normalization-by-deconvolution).
+The procedure we will use here is derived from the [OSCA chapter on normalization](http://bioconductor.org/books/3.16/OSCA.basic/normalization.html#normalization-by-deconvolution).
 The idea is that the varying expression patterns that different cell types exhibit will affect the scaling factors that we would apply.
 To account for that variation, we first do a rough clustering of cells by their expression with `scran::quickCluster()`, then use that clustering to calculate the scaling factor for each cell within the clusters using `scran::computeSumFactors()`.
 Finally, we apply the scaling factor to the expression values for each cell and calculate the log-scaled expression values using the `scuttle::logNormCounts()` function.

--- a/scRNA-seq-advanced/02-dataset_integration.Rmd
+++ b/scRNA-seq-advanced/02-dataset_integration.Rmd
@@ -34,7 +34,7 @@ To learn about integration, we'll have a look at four samples from the [`SCPCP00
 The particular libraries we'll integrate come from two rhabdomyosarcoma (RMS) patients, with two samples from each of two patients, all sequenced with 10x Chromium v3 technology.
 Each library is from a separate biological sample.
 
-We'll be integrating these samples with two different tools, [`fastMNN`](http://www.bioconductor.org/packages/3.16/bioc/html/batchelor.html) ([Haghverdi _et al._ 2018](https://doi.org/10.1038/nbt.4091)) and [`harmony`](https://portals.broadinstitute.org/harmony/) ([Korsunsky _et al._ 2019](https://doi.org/10.1038/s41592-019-0619-0)).
+We'll be integrating these samples with two different tools, [`fastMNN`](http://www.bioconductor.org/packages/release/bioc/html/batchelor.html) ([Haghverdi _et al._ 2018](https://doi.org/10.1038/nbt.4091)) and [`harmony`](https://portals.broadinstitute.org/harmony/) ([Korsunsky _et al._ 2019](https://doi.org/10.1038/s41592-019-0619-0)).
 Integration corrects for batch effects that arise from different library preparations, genetic backgrounds, and other sample-specific factors, so that datasets can be jointly analyzed at the cell level.
 `fastMNN` corrects for batch effects using a faster variant of the mutual-nearest neighbors algorithm, the technical details of which you can learn more about from this [vignette by Lun (2019)](https://marionilab.github.io/FurtherMNN2018/theory/description.html).
 `harmony`, on the other hand, corrects for batch effects using an iterative clustering approach, and unlike `fastMNN`, it is also able to consider additional covariates beyond just the batch groupings.
@@ -573,7 +573,7 @@ What similarities do you think the integrated UMAP will have to this plot?
 ### Integration with `fastMNN`
 
 Finally, we're ready to integrate!
-To start, we'll use the `fastMNN` approach from the Bioconductor [`batchelor` package](http://www.bioconductor.org/packages/3.16/bioc/html/batchelor.html).
+To start, we'll use the `fastMNN` approach from the Bioconductor [`batchelor` package](http://www.bioconductor.org/packages/release/bioc/html/batchelor.html).
 
 `fastMNN` takes as input the `merged_sce` object to integrate, and the first step it performs is actually to run `batchelor::multiBatchPCA()` on that SCE.
 It then uses that batch-weighted PCA matrix to perform the actual batch correction.
@@ -602,7 +602,7 @@ There are couple pieces of information here of interest:
 
 - The `corrected` reduced dimension represents the batch-corrected PCA that `fastMNN` calculated.
 - The `reconstructed` assay represents the batch-corrected normalized expression values, which `fastMNN` "back-calculated" from the batch-corrected PCA (`corrected`).
-Generally speaking, these expression values are not stand-alone values that you should use for other applications like differential gene expression, as described in [_Orchestrating Single Cell Analyses_](http://bioconductor.org/books/3.16/OSCA.multisample/using-corrected-values.html).
+Generally speaking, these expression values are not stand-alone values that you should use for other applications like differential gene expression, as described in [_Orchestrating Single Cell Analyses_](http://bioconductor.org/books/3.19/OSCA.multisample/using-corrected-values.html).
 If the `subset.row` argument is provided (as it was here), only genes present in `subset.row` will be included in these reconstructed expression values, but this setting can be overridden so that all genes have reconstructed expression with the argument `correct.all = TRUE`.
 
 We're mostly interested in the PCA that `fastMNN` calculated, so let's save that information (with an informative and unique name) into our `merged_sce` object:
@@ -625,7 +625,7 @@ merged_sce <- scater::runUMAP(
 
 First, let's plot the integrated UMAP highlighting the different batches.
 A well-integrated dataset will show batch mixing, but a poorly-integrated dataset will show more separation among batches, similar to the uncorrected UMAP.
-Note that this is a more qualitative way to assess the success of integration, but there are formal metrics one can use to assess batch mixing, which you can read more about in [this chapter of OSCA](http://bioconductor.org/books/3.16/OSCA.multisample/correction-diagnostics.html).
+Note that this is a more qualitative way to assess the success of integration, but there are formal metrics one can use to assess batch mixing, which you can read more about in [this chapter of OSCA](http://bioconductor.org/books/3.19/OSCA.multisample/correction-diagnostics.html).
 
 ```{r plot fastmnn umap batches}
 scater::plotReducedDim(merged_sce,

--- a/scRNA-seq-advanced/03-differential_expression.Rmd
+++ b/scRNA-seq-advanced/03-differential_expression.Rmd
@@ -8,7 +8,7 @@ output:
     toc_float: yes
 ---
 
-## Objectives 
+## Objectives
 
 This notebook will demonstrate how to:
 
@@ -21,7 +21,7 @@ This notebook will demonstrate how to:
 Just like bulk RNA-seq, it is likely that one of the goals when performing scRNA-seq will be to compare the gene expression of multiple samples to each other.
 Unlike bulk RNA-seq analysis, scRNA-seq analysis allows us to identify and annotate cell types or subpopulations of cells present in each of our samples.
 This means that we can account for differences in cell type composition across samples and specifically focus on cell types or populations of interest when performing differential expression (DE) analysis.
-In this notebook, we will work with multiple samples to identify differentially expressed genes across cell types of interest using the [`DESeq2`](https://bioconductor.org/packages/3.16/bioc/html/DESeq2.html) package. 
+In this notebook, we will work with multiple samples to identify differentially expressed genes across cell types of interest using the [`DESeq2`](https://bioconductor.org/packages/release/bioc/html/DESeq2.html) package.
 
 ![Single-cell roadmap: Differential expression](diagrams/roadmap_differential_expression.png)
 
@@ -42,7 +42,7 @@ set.seed(2022)
 
 # load libraries
 library(ggplot2) # plotting functions
-library(SingleCellExperiment) 
+library(SingleCellExperiment)
 
 # package used for differential expression analysis
 library(DESeq2)
@@ -63,18 +63,18 @@ Each row in this file corresponds to a sample found in the integrated SCE object
 To begin, let's set up our directories and files:
 
 ```{r filepaths}
-# set up file paths 
+# set up file paths
 # data directory for RMS data
 data_dir <- file.path("data", "rms")
 
 # integrated file containing samples to use for DE analysis
-integrated_sce_file <- file.path(data_dir, 
-                                 "integrated", 
+integrated_sce_file <- file.path(data_dir,
+                                 "integrated",
                                  "rms_all_sce.rds")
 
 # sample metadata to set up DE analysis
-sample_metadata_file <- file.path(data_dir, 
-                                  "annotations", 
+sample_metadata_file <- file.path(data_dir,
+                                  "annotations",
                                   "rms_sample_metadata.tsv")
 
 # directory to store output
@@ -82,12 +82,12 @@ deseq_dir <- file.path("analysis", "rms", "deseq")
 fs::dir_create(deseq_dir)
 
 # results file to output from DE analysis
-deseq_output_file <- file.path(deseq_dir, 
+deseq_output_file <- file.path(deseq_dir,
                                "rms_myoblast_deseq_results.tsv")
 
 # output integrated sce object
-output_sce_file <- file.path(data_dir, 
-                             "integrated", 
+output_sce_file <- file.path(data_dir,
+                             "integrated",
                              "rms_subset_sce.rds")
 ```
 
@@ -97,7 +97,7 @@ We can go ahead and read in the SCE object and the metadata file.
 # read in the SCE object that has already been integrated
 integrated_sce <- readr::read_rds(integrated_sce_file)
 
-# read in sample metadata file 
+# read in sample metadata file
 sample_metadata <- readr::read_tsv(sample_metadata_file)
 ```
 
@@ -120,10 +120,10 @@ integrated_sce
 assayNames(integrated_sce)
 ```
 
-When we look at the assay names we should see that there are 3 matrices, `counts`, `logcounts`, and `fastmnn_corrected`. 
+When we look at the assay names we should see that there are 3 matrices, `counts`, `logcounts`, and `fastmnn_corrected`.
 The `counts` and `logcounts` assays correspond to the uncorrected gene expression data that has been merged but NOT integrated.
-The `fastmnn_corrected` data contains the corrected gene expression data obtained from integration. 
-For this exercise we will not be using the `fastmnn_corrected` data (more on why not once we get to setting up the differential expression), but we need to be aware that it is present and be able to distinguish it from our uncorrected data. 
+The `fastmnn_corrected` data contains the corrected gene expression data obtained from integration.
+For this exercise we will not be using the `fastmnn_corrected` data (more on why not once we get to setting up the differential expression), but we need to be aware that it is present and be able to distinguish it from our uncorrected data.
 
 
 ```{r print reducedDim names, live=TRUE}
@@ -170,7 +170,7 @@ This will allow us to match each of the samples in the SCE object with the RMS s
 coldata_df <- colData(integrated_sce) |>
   # convert from DataFrame to data.frame
   as.data.frame() |>
-  # merge with sample metadata 
+  # merge with sample metadata
   dplyr::left_join(sample_metadata, by = c("sample" = "library_id")) |>
   # create new columns
   # cell_id is a combination of barcode and sample
@@ -183,7 +183,7 @@ coldata_df <- colData(integrated_sce) |>
                 ))
 
 # add modified data frame back to SCE as DataFrame
-colData(integrated_sce) <- DataFrame(coldata_df, 
+colData(integrated_sce) <- DataFrame(coldata_df,
                                      row.names = coldata_df$cell_id)
 ```
 
@@ -208,10 +208,10 @@ scater::plotReducedDim(integrated_sce,
                        dimred = "fastmnn_UMAP",
                        color_by = "diagnosis_group",
                        point_size= 0.5,
-                       point_alpha = 0.2) 
+                       point_alpha = 0.2)
 ```
 
-Interestingly, it looks like samples from the ARMS and ERMS subtypes tend to group with samples of the same subtype rather than all together. 
+Interestingly, it looks like samples from the ARMS and ERMS subtypes tend to group with samples of the same subtype rather than all together.
 
 In the integration notebook we also looked at the distribution of cell types after integration.
 In that notebook, we discussed that cells of the same cell type are expected to integrate with other cells of the same type.
@@ -229,7 +229,7 @@ scater::plotReducedDim(integrated_sce,
                        dimred = "fastmnn_UMAP",
                        # color each point by cell type
                        color_by = "celltype_broad",
-                       point_size= 0.5, 
+                       point_size= 0.5,
                        point_alpha = 0.4)
 ```
 
@@ -249,7 +249,7 @@ scater::plotReducedDim(integrated_sce,
                        dimred = "fastmnn_UMAP",
                        # color each point by cell type
                        color_by = "celltype_broad",
-                       point_size= 0.5, 
+                       point_size= 0.5,
                        point_alpha = 0.4,
                        # tell scater to use diagnosis_group for plotting
                        other_fields = "diagnosis_group") +
@@ -268,18 +268,18 @@ tumor_cells_df <- coldata_df |>
   dplyr::filter(stringr::str_detect(celltype_broad, "Tumor"))
 
 # create a stacked barplot
-ggplot(tumor_cells_df, aes(x = sample, fill = celltype_broad)) + 
+ggplot(tumor_cells_df, aes(x = sample, fill = celltype_broad)) +
     geom_bar(position = "fill", color = "black", size = 0.2) +
     labs(
       x = "Sample",
-      y = "Proportion of cells", 
+      y = "Proportion of cells",
       fill = "Cell type"
     ) +
   scale_fill_brewer(palette = "Dark2") +
   theme_bw() +
   theme(axis.text.x = element_text(angle = 90, vjust = 0.5))+
-  # facet by diagnosis group 
-  facet_grid(cols = vars(diagnosis_group), 
+  # facet by diagnosis group
+  facet_grid(cols = vars(diagnosis_group),
              # only show non-NA values on x-axis
              scales = "free_x",
              space = "free_x")
@@ -287,13 +287,13 @@ ggplot(tumor_cells_df, aes(x = sample, fill = celltype_broad)) +
 
 Similar to the UMAP, this plot shows that ARMS and ERMS share a lot of the same cell types.
 
-We also see that only 6 of these libraries have tumor cells that have been further classified into mesoderm, myoblast, and myocyte. 
+We also see that only 6 of these libraries have tumor cells that have been further classified into mesoderm, myoblast, and myocyte.
 3 libraries contain cells that are only classified as tumor or non-tumor, and tumor cells are not further classified, and the remaining library is not even present in our plot because it was not assigned any cell types (all are `NA`).
 We will continue our analysis only using the 6 libraries with fully classified cell types, removing the other 4 before we proceed with differential expression.
 
 ### Filtering samples
 
-The reason we want to pare down our list of samples to consider is that we want to ensure that the cell types (or subpopulations) that we are interested in are present in all samples included in our DE analysis. 
+The reason we want to pare down our list of samples to consider is that we want to ensure that the cell types (or subpopulations) that we are interested in are present in all samples included in our DE analysis.
 We want to remove any samples that do not contain our cell population(s) of interest as they have no counts to contribute to the DE analysis.
 
 ```{r subset sce}
@@ -307,15 +307,15 @@ library_ids <- c(
   "SCPCL000491"
 )
 
-# subset sce to only contain samples of interest 
+# subset sce to only contain samples of interest
 samples_to_keep <- integrated_sce$sample %in% library_ids
 rms_sce <- integrated_sce[, samples_to_keep]
 
-# print out our new SCE 
+# print out our new SCE
 rms_sce
 ```
 
-Before we move on, we'll remove the original integrated object from our environment to save some memory. 
+Before we move on, we'll remove the original integrated object from our environment to save some memory.
 
 ```{r remove sce}
 rm(integrated_sce)
@@ -331,11 +331,11 @@ readr::write_rds(rms_sce, file = output_sce_file, compress = "gz")
 We now have an updated SCE object that contains 6 samples that were obtained from a mix of ARMS and ERMS patients.
 We can then ask the question, do specific tumor cell types contain sets of differentially expressed genes between ARMS and ERMS samples?
 
-We should make sure that we have enough biological replicates from each group to set up our experiment. 
+We should make sure that we have enough biological replicates from each group to set up our experiment.
 It is imperative to consider good experimental design and ensure that we have enough biological replicates (at least 3 for each group) when performing differential gene expression analysis.
 
 If we look back at our stacked barplot we see that we picked 3 ARMS and 3 ERMS samples.
-We can also see that the majority of cells are tumor cells, in particular the largest population of cells appears to be the `Tumor_Myoblast`. 
+We can also see that the majority of cells are tumor cells, in particular the largest population of cells appears to be the `Tumor_Myoblast`.
 For this example we will focus on identifying DE genes in these `Tumor_Myoblast` cells, but the principles applied below can be applied to any cell types or subpopulations of interest.
 
 ## Differential expression analysis
@@ -344,26 +344,26 @@ Now we are ready to start preparing for our DE analysis, where we will compare t
 
 Throughout the notebook we have been working with an integrated dataset that contains corrected gene expression data (`fastmnn_corrected` assay) and a corrected UMAP.
 As a reminder, the uncorrected gene expression data, found in the `counts` and `logcounts` assays, correspond to data that has been merged (the first step we walked through prior to integration) into the same SCE but not yet integrated.
-We do not want to use corrected gene expression values for differential expression; `DESeq2` expects the original raw counts as input so we will be using data found in the `counts` assay of the `SingleCellExperiment` object. 
+We do not want to use corrected gene expression values for differential expression; `DESeq2` expects the original raw counts as input so we will be using data found in the `counts` assay of the `SingleCellExperiment` object.
 
 It is advised to only use the corrected values for any analyses being performed at the cell level, e.g., dimensionality reduction.
 In contrast, it is not advised to use corrected values for any analyses that are gene-based, such as differential expression or marker gene detection, because within-batch and between-batch gene expression differences are no longer preserved.
 The reason for this is two-fold – many of the DE models will expect uncorrected counts because they will account for between-sample variation within the model, and we want to ensure we are preserving variation that is present so as not to artificially inflate differences between populations.
-See the [OSCA chapter on Using the corrected values](https://bioconductor.org/books/3.16/OSCA.multisample/using-corrected-values.html#using-corrected-values) for more insight.
+See the [OSCA chapter on Using the corrected values](https://bioconductor.org/books/3.19/OSCA.multisample/using-corrected-values.html#using-corrected-values) for more insight.
 
-### Pseudo-bulking 
+### Pseudo-bulking
 
-Before we can compare the gene expression profiles of myoblasts in ARMS vs. ERMS samples, we will need to "pseudo-bulk" the gene counts. 
-Pseudo-bulking creates a new counts matrix that contains the sum of the counts from all cells with a given label (e.g., cell type) for each sample ([Tung _et al._ 2017](https://doi.org/10.1038/srep39921)). 
-If we were to keep each cell's counts separate, they would be treated as replicates, leading to inflated statistics. 
+Before we can compare the gene expression profiles of myoblasts in ARMS vs. ERMS samples, we will need to "pseudo-bulk" the gene counts.
+Pseudo-bulking creates a new counts matrix that contains the sum of the counts from all cells with a given label (e.g., cell type) for each sample ([Tung _et al._ 2017](https://doi.org/10.1038/srep39921)).
+If we were to keep each cell's counts separate, they would be treated as replicates, leading to inflated statistics.
 By pseudo-bulking first, we will now have one count for each gene for each sample and we can take advantage of well-established methods for differential expression with bulk RNA-seq.
 
-Pseudo-bulking is implemented prior to differential expression analysis on single-cell data because it: 
+Pseudo-bulking is implemented prior to differential expression analysis on single-cell data because it:
 
-- Produces larger and less sparse counts, which allows us to use standard normalization and differential expression methods used by bulk RNA-seq. 
+- Produces larger and less sparse counts, which allows us to use standard normalization and differential expression methods used by bulk RNA-seq.
 - Collapses gene expression counts by sample, so that samples, rather than cells, represent replicates.
 - Masks variance within a sample to emphasize variance across samples.
-This can be both good and bad! 
+This can be both good and bad!
 Masking intra-sample variation means you might not identify genes where average expression doesn't change between samples but the degree of cell-to-cell variation does.
 
 Before we apply pseudo-bulking to our dataset, let's look at a simple example of how pseudo-bulking works.
@@ -372,7 +372,7 @@ We'll start by creating a fake matrix of counts.
 ```{r create matrix}
 # create an example counts matrix
 counts_mtx <- matrix(
-  1:12, 
+  1:12,
   ncol = 4,
   dimnames = list(c("geneA", "geneB", "geneC"),
                   c("A-cell1", "A-cell2", "B-cell1", "B-cell2"))
@@ -388,35 +388,35 @@ To do this we will use the `DelayedArray::colsum()` function, which allows us to
 groups <- c("A", "A", "B", "B")
 
 # sum counts across cells (columns) by group label
-pb_counts <- DelayedArray::colsum(counts_mtx, 
+pb_counts <- DelayedArray::colsum(counts_mtx,
                                   groups)
-pb_counts  
+pb_counts
 ```
 
 Looking at this output, you should see that the original 4 columns have been condensed to only 2 columns: 1 column to represent all cells from group `A`, and 1 column to represent all cells from group `B`.
 
-Now the actual pseudo-bulking for our dataset! 
+Now the actual pseudo-bulking for our dataset!
 
 We will use the [`scuttle::aggregateAcrossCells()` function](https://rdrr.io/github/LTLA/scuttle/man/aggregateAcrossCells.html) to pseudo-bulk our dataset.
 This function takes as input an SCE object and the grouping assignments for each cell.
-The output will be an SCE object that contains only the pseudo-bulked counts for all genes across all specified groups, rather than across all cells. 
-We can then subset this SCE to just include our cell type of interest (tumor myoblasts) for input to the DE analysis. 
+The output will be an SCE object that contains only the pseudo-bulked counts for all genes across all specified groups, rather than across all cells.
+We can then subset this SCE to just include our cell type of interest (tumor myoblasts) for input to the DE analysis.
 
 We can pseudo-bulk using any grouping that we are interested in.
-For right now, we are interested in looking at gene expression across cell types, so we want to group the pseudo-bulked counts matrix by both cell type and original sample. 
+For right now, we are interested in looking at gene expression across cell types, so we want to group the pseudo-bulked counts matrix by both cell type and original sample.
 
 ```{r pseudobulk sce}
-# first subset the coldata 
-# to only have the columns we care about for pseudo-bulking 
+# first subset the coldata
+# to only have the columns we care about for pseudo-bulking
 pb_groups <- colData(rms_sce)[, c("celltype_broad", "sample")]
 
-# create a new SCE object that contains 
-# the pseudo-bulked counts across the provided groups 
-pb_sce <- scuttle::aggregateAcrossCells(rms_sce, 
+# create a new SCE object that contains
+# the pseudo-bulked counts across the provided groups
+pb_sce <- scuttle::aggregateAcrossCells(rms_sce,
                                         id = pb_groups)
 
-# column names aren't automatically added to the pseudo-bulked sce, 
-# so let's add them in 
+# column names aren't automatically added to the pseudo-bulked sce,
+# so let's add them in
 colnames(pb_sce) <- glue::glue(
   "{pb_sce$celltype_broad}_{pb_sce$sample}"
 )
@@ -424,18 +424,18 @@ colnames(pb_sce) <- glue::glue(
 pb_sce
 ```
 
-How does the new pseudo-bulked `SingleCellExperiment` look different? 
-How many columns does it have? 
+How does the new pseudo-bulked `SingleCellExperiment` look different?
+How many columns does it have?
 
-Let's take a look at what the `colData` looks like in the pseudo-bulked SCE object. 
+Let's take a look at what the `colData` looks like in the pseudo-bulked SCE object.
 
 ```{r pseudobulk colData, live=TRUE}
-# note the new column with number of cells per group 
+# note the new column with number of cells per group
 head(colData(pb_sce)) |>
   as.data.frame()
 ```
 
-You should see that columns such as `sum`, `detected`, `subsets_mito_sum`, and other columns that typically contain per cell QC statistics now contain `NA` rather than numeric values. 
+You should see that columns such as `sum`, `detected`, `subsets_mito_sum`, and other columns that typically contain per cell QC statistics now contain `NA` rather than numeric values.
 This is because these values were initially calculated on a per cell level (we did this using `scuttle::addPerCellQCMetrics()`), but we no longer have a single column per cell.
 Instead, each column now represents a _group_ of cells, in this case comprised of cells of a given cell type and sample combination.
 Therefore, the values that we calculated on a per-cell level are no longer applicable to this pseudo-bulked SCE object.
@@ -461,7 +461,7 @@ We can then take a look and see how many cell type-sample columns we removed, if
 # print out dimensions of unfiltered pseudobulk sce
 dim(pb_sce)
 
-# dimensions of filtered pseudobulk sce 
+# dimensions of filtered pseudobulk sce
 dim(filter_pb_sce)
 ```
 
@@ -534,7 +534,7 @@ As a reminder, this is NOT required for running `DESeq2` analysis; we are just u
 deseq_object <- DESeq2::estimateSizeFactors(deseq_object)
 
 # normalize and log transform to use for visualization
-normalized_object <- DESeq2::rlog(deseq_object, 
+normalized_object <- DESeq2::rlog(deseq_object,
                                   blind = TRUE)
 normalized_object
 ```
@@ -558,7 +558,7 @@ deseq_object <- DESeq2::DESeq(deseq_object)
 ```
 
 We can evaluate how well the model fit our data by looking at the dispersion estimates.
-We expect to see the dispersion estimates decrease as means are increasing and follow the line of best fit. 
+We expect to see the dispersion estimates decrease as means are increasing and follow the line of best fit.
 
 ```{r plot dispersion, live=TRUE}
 plotDispEsts(deseq_object)
@@ -589,8 +589,8 @@ DESeq2::resultsNames(deseq_object)
 ```{r shrinkage}
 # appyly logFC shrinkage using the default model
 shrink_results <- DESeq2::lfcShrink(
-  deseq_object, 
-  res = deseq_results, 
+  deseq_object,
+  res = deseq_results,
   coef = 2,
   type = "apeglm"
 )
@@ -607,13 +607,13 @@ deseq_results <- shrink_results |>
   # converting results into a data frame
   tibble::as_tibble(rownames = "ensembl_id")
 
-# convert rowdata to data frame 
+# convert rowdata to data frame
 sce_rowdata_df <- rowData(tumor_myoblast_sce) |>
   # create a column with rownames stored as ensembl id
   # use for joining with deseq results
   tibble::as_tibble(rownames = "ensembl_id")
 
-# combine deseq results with rowdata by ensembl id 
+# combine deseq results with rowdata by ensembl id
 deseq_results <- deseq_results |>
   dplyr::left_join(sce_rowdata_df, by = "ensembl_id")
 
@@ -631,7 +631,7 @@ The last thing that we will do is take a look at how many genes are significant.
 Here we will want to use the adjusted p-value, found in the `padj` column of the results, as this accounts for multiple test correction.
 
 ```{r significant results, live=TRUE}
-# first look at the significant results 
+# first look at the significant results
 deseq_results_sig <- deseq_results |>
   # filter based on adjusted pvalue
   dplyr::filter(padj <= 0.05)
@@ -640,7 +640,7 @@ head(deseq_results_sig)
 ```
 
 
-### Exploring the identified differentially expressed genes 
+### Exploring the identified differentially expressed genes
 
 Now that we have identified a set of genes that are differentially expressed in the tumor myoblasts between ARMS and ERMS subtypes, lets actually take a look at them and see if we can make some informative plots.
 The first plot we'll make is a volcano plot using the [`EnhancedVolcano` package](https://github.com/kevinblighe/EnhancedVolcano).
@@ -668,10 +668,10 @@ EnhancedVolcano::EnhancedVolcano(deseq_results,
 ```
 
 
-We can also return back to the SCE object that we used to create our pseudo-bulked SCE and look at gene expression of some of the significant genes. 
+We can also return back to the SCE object that we used to create our pseudo-bulked SCE and look at gene expression of some of the significant genes.
 We can create UMAP plots as we did previously, but instead of labeling each cell with metadata, we can color cells by a specified gene's expression levels.
 We will also use some of the `ggplot2` skills we picked up earlier, like `facet_grid()` to plot cells from different RMS subtypes separately.
-This can help us validate the `DESeq2` results so that we can visualize gene expression changes across our cell type of interest on a single-cell level. 
+This can help us validate the `DESeq2` results so that we can visualize gene expression changes across our cell type of interest on a single-cell level.
 
 ```{r expression umap, live=TRUE}
 # filter to just myoblast cells and remove any NA's before plotting
@@ -687,15 +687,15 @@ scater::plotReducedDim(myoblast_combined_sce,
   facet_grid(cols = vars(diagnosis_group))
 ```
 
-In the above plot we only plotted the tumor myoblast cells that we used in our DE analysis. 
+In the above plot we only plotted the tumor myoblast cells that we used in our DE analysis.
 However, we might be interested to see the expression of genes that are differentially expressed in other cell types present in our samples.
 
 ```{r celltype comparison}
 # let's compare gene expression across some other cell types
 # look at all tumor cells and pick one normal cell type
-celltypes <- c("Tumor_Myoblast", 
-               "Tumor_Mesoderm", 
-               "Tumor_Myocyte", 
+celltypes <- c("Tumor_Myoblast",
+               "Tumor_Mesoderm",
+               "Tumor_Myocyte",
                "Vascular Endothelium")
 
 # subset to just celltypes that we are interested in
@@ -710,24 +710,24 @@ One neat trick of the `scater::plotExpression()` function is that it actually cr
 We can then directly reference that `Feature` column when plotting, instead of using the `other_fields` option we used previously.
 
 ```{r multi-gene plot}
-# pick a couple genes to look at 
+# pick a couple genes to look at
 genes_to_plot <- c("ENSG00000196090", #PTPRT
                    "ENSG00000148935") #GAS2
 
-# create a violin plot 
+# create a violin plot
 scater::plotExpression(tumor_sce,
                        # a vector of genes to plot
-                       features = genes_to_plot, 
-                       x = "diagnosis_group", 
+                       features = genes_to_plot,
+                       x = "diagnosis_group",
                        color_by = "diagnosis_group",
                        other_fields = "celltype_broad",
                        point_size = 0.1) +
   # each celltype is its own column
   facet_grid(cols = vars(celltype_broad),
              # each feature (gene) is its own row
-             rows = vars(Feature)) + 
+             rows = vars(Feature)) +
   # change the font size of the facet labels
-  theme(strip.text = element_text(size = 7)) + 
+  theme(strip.text = element_text(size = 7)) +
   guides(color = guide_legend(
     title = "Subtype", # update the legend title
     # change the size of the legend colors
@@ -737,15 +737,15 @@ scater::plotExpression(tumor_sce,
 
 How do the expression of these genes change across cell types and RMS subtypes?
 
-Go ahead and explore some genes on your own! 
+Go ahead and explore some genes on your own!
 Feel free to plot any of the genes that are identified as significant, found in the DE results table, or your favorite gene.
 Remember, you need to use the Ensembl gene identifier to refer to each gene.
 
 ```{r explore}
-# now do some exploration of other genes on your own! 
+# now do some exploration of other genes on your own!
 ```
 
-## Print session info 
+## Print session info
 
 ```{r session info}
 sessionInfo()

--- a/scRNA-seq/01-scRNA_quant_qc.Rmd
+++ b/scRNA-seq/01-scRNA_quant_qc.Rmd
@@ -3,7 +3,7 @@ title: "Processing tag-based single-cell RNA-seq data with Alevin"
 author: CCDL for ALSF
 date: 2021
 output:
-  html_notebook: 
+  html_notebook:
     toc: true
     toc_float: true
 ---
@@ -13,8 +13,8 @@ output:
 This notebook will demonstrate how to:
 
 - Navigate the terminal interface
-- Quantify single cell expression data with Alevin 
-- Perform basic quality control and interpret results 
+- Quantify single cell expression data with Alevin
+- Perform basic quality control and interpret results
 
 ---
 
@@ -32,7 +32,7 @@ Each transcript will also contain a [Unique Molecular Identifiers (UMIs)](http:/
 We obtained these data from Tabula Muris project's [Figshare](https://figshare.com/projects/Tabula_Muris_Transcriptomic_characterization_of_20_organs_and_tissues_from_Mus_musculus_at_single_cell_resolution/27733).
 The BAM files that were on Figshare were converted to `fastq` files using
 [`bamtofastq`](https://support.10xgenomics.com/docs/bamtofastq) from 10x Genomics.
-We will process a `fastq` file from mouse bladder for this as an example.  
+We will process a `fastq` file from mouse bladder for this as an example.
 To limit the amount of time this takes to run in the context of this workshop,
 we are only running part of the sample's reads.
 
@@ -42,10 +42,10 @@ However, most public data is available in `fastq` format, and most sequencing co
 
 ## Checking directories and files
 
-If you have opened the `scRNA-seq.Rproj` file, your Terminal should already be set to the `scRNA-seq` directory, but it is worth checking with the `pwd` command in the Terminal 
-(or by looking at the path shown in the command prompt or at the top of the Terminal pane). 
+If you have opened the `scRNA-seq.Rproj` file, your Terminal should already be set to the `scRNA-seq` directory, but it is worth checking with the `pwd` command in the Terminal
+(or by looking at the path shown in the command prompt or at the top of the Terminal pane).
 
-If you are in a different directory, we will want to use `cd` to change to the `training-modules/scRNA-seq` directory. 
+If you are in a different directory, we will want to use `cd` to change to the `training-modules/scRNA-seq` directory.
 
 Copy and paste the text in the code blocks below into your `Terminal` window in RStudio.
 It should be in the lower left hand corner as a tab next to `Console`.
@@ -61,11 +61,11 @@ ls data/tabula-muris
 ```
 
 Here you will see the `fastq` directory, which is actually a link to a shared folder with the raw fastq files, split by sample.
-We will use these files, but we will not write to this directory. 
+We will use these files, but we will not write to this directory.
 
-We can look inside the contents of the `fastq` directory, and we should see 16 subfolders corresponding to 16 different samples. 
-Within each of these folders should be the `fastq` files associated with that sample. 
-Again, we can use the `ls` command to show the contents of each of the directories. 
+We can look inside the contents of the `fastq` directory, and we should see 16 subfolders corresponding to 16 different samples.
+Within each of these folders should be the `fastq` files associated with that sample.
+Again, we can use the `ls` command to show the contents of each of the directories.
 
 In this scenario, `10X_P4_3` refers to the sample name that we will be processing, which contains data from mouse bladder cells.
 
@@ -73,12 +73,12 @@ In this scenario, `10X_P4_3` refers to the sample name that we will be processin
 ls data/tabula-muris/fastq/10X_P4_3
 ```
 
-You should see a list of multiple `fastq` files all starting with `10X_P4_3`, indicating the sample name. 
+You should see a list of multiple `fastq` files all starting with `10X_P4_3`, indicating the sample name.
 
 If you notice, each `fastq` file name contains either `R1` or `R2`.
 These correspond to the two sequencing reads of a paired-end library.
 For 10x data, the first read (the `R1` file) will contain the cell barcode and UMI sequence, and the second read (the `R2` file) will contain a cDNA sequence corresponding to the captured transcript.
-We will need both of these files to quantify our data. 
+We will need both of these files to quantify our data.
 
 ```
 10X_P4_3_L001_R1_001.fastq.gz  10X_P4_3_L002_R1_001.fastq.gz
@@ -89,8 +89,8 @@ We will need both of these files to quantify our data.
 10X_P4_3_L001_R2_003.fastq.gz  10X_P4_3_L002_R2_003.fastq.gz
 ```
 
-Sequencing runs are often split into multiple `fastq` files, both when a sample was run across multiple lanes and to keep the individual file sizes down. 
-This was the case for the *Tabula Muris* data we are using here as well. 
+Sequencing runs are often split into multiple `fastq` files, both when a sample was run across multiple lanes and to keep the individual file sizes down.
+This was the case for the *Tabula Muris* data we are using here as well.
 The files that you see in the `data/tabula-muris/fastq/10X_P4_3` directory shown above represent 2 lanes worth of data, with three R1 and three R2 files per lane.
 
 You will also see the file `TM_droplet_metadata.csv`, which contains metadata for the *Tabula Muris* experiments.
@@ -106,9 +106,9 @@ mkdir -p data/tabula-muris/alevin-quant/10X_P4_3_subset
 
 ## Quantifying cell expression with Salmon Alevin
 
-[Alevin](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1670-y) is run from the command line (Terminal) to perform mapping and quantification of tag-based single cell expression data. 
+[Alevin](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1670-y) is run from the command line (Terminal) to perform mapping and quantification of tag-based single cell expression data.
 
-### Indexing the mouse transcriptome 
+### Indexing the mouse transcriptome
 
 Before you can quantify with Salmon and [Alevin](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1670-y) we need to index the transcriptome for the species we will be mapping to.
 This step would be the same for mapping bulk RNA-seq data, and you can use the same transcriptome indexes as bulk RNA-seq, however, due to the shorter read lengths in the 10x sequencing, we may want to use shorter kmers than the default index size that salmon uses.
@@ -124,7 +124,7 @@ But for your own reference, here is how you might do it yourself:
 #  -k 23
 ```
 
-Scripts to build the indexes like those we are using here (and others) can be found in [this repository](https://github.com/AlexsLemonade/training-txome-prep). 
+Scripts to build the indexes like those we are using here (and others) can be found in [this repository](https://github.com/AlexsLemonade/training-txome-prep).
 
 
 ### Running Salmon Alevin
@@ -132,8 +132,8 @@ Scripts to build the indexes like those we are using here (and others) can be fo
 Copy and paste this in your `Terminal` to run the Alevin quantification.
 This will take about 20 minutes to run, so we will start now, then talk about the options.
 
-Note that here we are only giving the full paths to one of the `R1` files and one of the `R2` files. 
-For the sake of time, we are only going to be running this on a subset of reads, but will also show you how to run it on the full sample.  
+Note that here we are only giving the full paths to one of the `R1` files and one of the `R2` files.
+For the sake of time, we are only going to be running this on a subset of reads, but will also show you how to run it on the full sample.
 
 ```bash
 salmon alevin \
@@ -161,21 +161,21 @@ Many of the options for the `salmon alevin` command are the same as those you wo
 
 
 #### `-l`
-The `-l` option is for designating the library format. 
+The `-l` option is for designating the library format.
 For most single-cell quantification, you will want to use the `ISR` library type.
 See [Salmon's documentation](https://salmon.readthedocs.io/en/latest/library_type.html#fraglibtype) for more information on fragment library types (and all of the other options available).
 Note that this option must come *before* the read files.
 
 #### `--chromium`
 Because we are using 10x v2 chromium data, we have to use this flag to tell `alevin` where to expect the barcodes, UMIs and sequence data.
-If we were using 10x v3 data, we would need the `--chromiumV3` flag instead. 
+If we were using 10x v3 data, we would need the `--chromiumV3` flag instead.
 Drop-seq data is also supported, for which we would use the `--dropseq` flag instead of this.
 
 
 #### `--tgMap`
 The transcriptome file that we are mapping to has separate sequences for each transcript of a gene, but due to the sparse nature of single-cell data, we are not likely to be able to meaningfully distinguish among different transcripts.
 For this reason, `alevin` will quantify our results at the gene level, so we need to provide a file that maps each transcript to its gene.
-For this example, we've pre-made the file `Mus_musculus.GRCm38.95.versioned_tx2gene.tsv` from the Ensembl transcriptome that we indexed above. 
+For this example, we've pre-made the file `Mus_musculus.GRCm38.95.versioned_tx2gene.tsv` from the Ensembl transcriptome that we indexed above.
 The file is a TSV (tab-separated values) file with 2 columns: one of transcripts and the other the gene that each comes from.
 
 
@@ -190,7 +190,7 @@ There are also a number of example analyses at the [Alevin tutorial](https://com
 
 When we took a look at the `data/tabula-muris/fastq/10X_P4_3` directory earlier, we noticed that there were multiple files representing 2 lanes worth of data, with three R1 and three R2 files per lane:
 
-We should really run all of these through Salmon, though that will take about six times as long as the single pair of reads we used. 
+We should really run all of these through Salmon, though that will take about six times as long as the single pair of reads we used.
 To do this, we could list each R1 and R2 file (space separated) after the `-1` and `-2` arguments, respectively.
 But that is a lot of typing, so a nice shortcut is to use a `*` character to represent a wildcard that will be filled in with whatever characters are present in the files at the given path.
 In the pattern `10X_P4_3_L*_R1_*.fastq.gz`, this would allow any lane number and any subset, so would match all of the following files (all the R1 files in this case):
@@ -232,36 +232,39 @@ The first argument needs to be where the sample's output data was put when Alevi
 The rest of `alevinQCReport()`'s arguments tell R where to put the output QC report.
 
 ```{r alevinQC, eval = FALSE}
+# Load the alevinQC library
+library(alevinQC)
+
 # First, define path to alevin output:
 alevin_path <- file.path("data", "tabula-muris", "alevin-quant", "10X_P4_3_subset")
 
 # Produce a QC report of results found in the `alevin_path` directory
-alevinQC::alevinQCReport(alevin_path,
-                         sampleId = "10X_P4_3_subset",
-                         outputFile = "10X_P4_3_subset-qc_report.html",
-                         outputDir = "qc-reports")
+alevinQCReport(alevin_path,
+               sampleId = "10X_P4_3_subset",
+               outputFile = "10X_P4_3_subset-qc_report.html",
+               outputDir = "qc-reports")
 ```
 
 Look for the `10X_P4_3_subset-qc_report.html` file created in the `qc-reports` directory to examine the quality of your data and performance of Alevin.
 
 We have also placed an example of a poor quality sample alevinQC report in the `qc-reports` directory, with the name `Bad_Example_10X_P4_2_qc_report.html`.
 
-This report will show a few key metrics that inform you about the quality of your sample. 
+This report will show a few key metrics that inform you about the quality of your sample.
 There is a lot of information included in the report, so some key metrics to note are included in the `Summary tables`:
 
-- Fraction of reads in whitelist barcodes 
+- Fraction of reads in whitelist barcodes
 - Mean number of reads per cell
-- Median number of detected genes per cell 
+- Median number of detected genes per cell
 
-The fraction of reads in whitelist barcodes is particularly important as a low percentage here means the library contains many reads that do not contain the expected cell barcodes. 
-This is indicative of poor single-cell capture during library construction. 
+The fraction of reads in whitelist barcodes is particularly important as a low percentage here means the library contains many reads that do not contain the expected cell barcodes.
+This is indicative of poor single-cell capture during library construction.
 
-The mean number of reads per cell and median number of detected genes per cell can be helpful in understanding how deeply the library was sequenced. 
-The higher these numbers are, the more information you will obtain per cell. 
+The mean number of reads per cell and median number of detected genes per cell can be helpful in understanding how deeply the library was sequenced.
+The higher these numbers are, the more information you will obtain per cell.
 
 The **knee plot** shows the number of distinct UMIs for each possible cell barcode on the y-axis, with the barcodes ranked from the most UMIs to the fewest along the x-axis.
 
-Cell barcodes with low UMI counts are likely to be empty droplets that did not contain a cell. 
+Cell barcodes with low UMI counts are likely to be empty droplets that did not contain a cell.
 These droplets must be filtered out so we only consider true cells for downstream analysis.
 
 To do this, we can look for a "knee" on the curve where the number of UMIs per barcode starts to drop off rapidly, with the intuition that this is where we are reaching the end of the UMIs per cell distribution for true cells.
@@ -273,7 +276,7 @@ This allows filtering to retain cells with low counts that are nonetheless likel
 
 ## Next steps: Loading Alevin output into R
 
-After we have successfully quantified our tag-based scRNA-seq data (and done some QC), we will want to read it into R to start to analyze it. 
+After we have successfully quantified our tag-based scRNA-seq data (and done some QC), we will want to read it into R to start to analyze it.
 The easiest way to do this is to use the `tximeta` package, which we will introduce in the next notebook.
 
 

--- a/scRNA-seq/02-filtering_scRNA.Rmd
+++ b/scRNA-seq/02-filtering_scRNA.Rmd
@@ -98,8 +98,8 @@ A quick aside!
 When we ran `alevinQC` on this data in the last notebook, we saw that `salmon alevin` had identified a "whitelist" of barcodes that passed its quality control standards.
 We could use this filtered list directly, but `salmon alevin` can be quite strict, and methods for filtering quite variable.
 Instead, we will use the default behavior of `tximeta()` and read in all of the barcodes for which there is a non-zero UMI count (after barcode correction).
-If you wanted instead to include only only barcodes that passed `salmon alevin`'s filter, you could supply the additional argument `alevinArgs = list(filterBarcodes=TRUE)` to the `tximeta()` function. 
-Even if you do choose to read in pre-filtered data, it's still important to explore the data as we're about to do here and potentially filter further based on your observations, in particular since mapping software's quality control measures (spoilers!) don't always filter based on mitochondrial gene content. 
+If you wanted instead to include only only barcodes that passed `salmon alevin`'s filter, you could supply the additional argument `alevinArgs = list(filterBarcodes=TRUE)` to the `tximeta()` function.
+Even if you do choose to read in pre-filtered data, it's still important to explore the data as we're about to do here and potentially filter further based on your observations, in particular since mapping software's quality control measures (spoilers!) don't always filter based on mitochondrial gene content.
 
 In the intro-to-R-tidyverse module notebook, `01-intro-to-base_R.Rmd`, we discuss base R object types, but there are some 'special' object types that are package-specific.
 `tximeta` creates a `SummarizedExperiment` object (or more specifically a `RangedSummarizedExperiment` object), which is used by many Bioconductor packages to store and process results from gene expression studies.
@@ -122,7 +122,7 @@ rowData(bladder_sce)
 We could leave the object as it is, but we can unlock some extra functionality by converting this from a `SummarizedExperiment` object to a `SingleCellExperiment`, so we will go ahead and do that next.
 `SingleCellExperiment` objects are a subtype of `SummarizedExperiment` objects that a lot of single-cell analysis R packages use, so we will try to get acquainted with them.
 
-For more information on `SingleCellExperiment` objects, as well as many other topics related to this course, we highly recommend the e-book [_Orchestrating Single-Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/3.16/OSCA/) and/or [Amezquita *et al.* (2020)](https://www.nature.com/articles/s41592-019-0654-x).
+For more information on `SingleCellExperiment` objects, as well as many other topics related to this course, we highly recommend the e-book [_Orchestrating Single-Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/release/OSCA/) and/or [Amezquita *et al.* (2020)](https://www.nature.com/articles/s41592-019-0654-x).
 
 Below is a figure from OSCA that shows the general structure of `SingleCellExperiment` objects.
 

--- a/scRNA-seq/02-filtering_scRNA.Rmd
+++ b/scRNA-seq/02-filtering_scRNA.Rmd
@@ -98,8 +98,8 @@ A quick aside!
 When we ran `alevinQC` on this data in the last notebook, we saw that `salmon alevin` had identified a "whitelist" of barcodes that passed its quality control standards.
 We could use this filtered list directly, but `salmon alevin` can be quite strict, and methods for filtering quite variable.
 Instead, we will use the default behavior of `tximeta()` and read in all of the barcodes for which there is a non-zero UMI count (after barcode correction).
-If you wanted instead to include only only barcodes that passed `salmon alevin`'s filter, you could supply the additional argument `alevinArgs = list(filterBarcodes=TRUE)` to the `tximeta()` function.
-Even if you do choose to read in pre-filtered data, it's still important to explore the data as we're about to do here and potentially filter further based on your observations, in particular since mapping software's quality control measures (spoilers!) don't always filter based on mitochondrial gene content.
+If you wanted instead to include only only barcodes that passed `salmon alevin`'s filter, you could supply the additional argument `alevinArgs = list(filterBarcodes=TRUE)` to the `tximeta()` function. 
+Even if you do choose to read in pre-filtered data, it's still important to explore the data as we're about to do here and potentially filter further based on your observations, in particular since mapping software's quality control measures (spoilers!) don't always filter based on mitochondrial gene content. 
 
 In the intro-to-R-tidyverse module notebook, `01-intro-to-base_R.Rmd`, we discuss base R object types, but there are some 'special' object types that are package-specific.
 `tximeta` creates a `SummarizedExperiment` object (or more specifically a `RangedSummarizedExperiment` object), which is used by many Bioconductor packages to store and process results from gene expression studies.
@@ -122,7 +122,7 @@ rowData(bladder_sce)
 We could leave the object as it is, but we can unlock some extra functionality by converting this from a `SummarizedExperiment` object to a `SingleCellExperiment`, so we will go ahead and do that next.
 `SingleCellExperiment` objects are a subtype of `SummarizedExperiment` objects that a lot of single-cell analysis R packages use, so we will try to get acquainted with them.
 
-For more information on `SingleCellExperiment` objects, as well as many other topics related to this course, we highly recommend the e-book [_Orchestrating Single-Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/release/OSCA/) and/or [Amezquita *et al.* (2020)](https://www.nature.com/articles/s41592-019-0654-x).
+For more information on `SingleCellExperiment` objects, as well as many other topics related to this course, we highly recommend the e-book [_Orchestrating Single-Cell Analysis with Bioconductor_ (OSCA)](http://bioconductor.org/books/3.16/OSCA/) and/or [Amezquita *et al.* (2020)](https://www.nature.com/articles/s41592-019-0654-x).
 
 Below is a figure from OSCA that shows the general structure of `SingleCellExperiment` objects.
 

--- a/scRNA-seq/03-normalizing_scRNA.Rmd
+++ b/scRNA-seq/03-normalizing_scRNA.Rmd
@@ -34,12 +34,15 @@ Load the libraries we will be using, and set the random number generation seed v
 # Set seed for reproducibility
 set.seed(1234)
 
-# GGPlot2 for the plots
+# Plotting functions
 library(ggplot2)
 
 # Packages for single cell processing
 library(scater)
 library(scran)
+
+# Set a ggplot2 theme for all plots
+theme_set(theme_bw())
 ```
 
 Now let's set up the files we will be using:
@@ -192,8 +195,7 @@ ggplot(log_pca_scores, aes(x = PC1, y = PC2, color = total_umi)) +
   geom_point() +
   labs(title = "Log counts (unnormalized) PCA scores",
        color = "Total UMI count")  +
-  scale_color_viridis_c() +
-  theme_bw()
+  scale_color_viridis_c()
 ```
 
 We've plotted the unnormalized data for you.
@@ -207,8 +209,7 @@ ggplot(norm_pca_scores, aes(x = PC1, y = PC2, color = total_umi)) +
   geom_point() +
   labs(title = "Normalized log counts PCA scores",
        color = "Total UMI count") +
-  scale_color_viridis_c() +
-  theme_bw()
+  scale_color_viridis_c()
 ```
 
 Do you see an effect from the normalization when comparing these plots?
@@ -224,16 +225,14 @@ ggplot(norm_pca_scores, aes(x = PC1, y = PC2, color = cell_type)) +
   geom_point() +
   labs(title = "Normalized log counts PCA scores",
        color = "Cell Type") +
-  scale_color_brewer(palette = "Dark2", na.value = "grey70") + # add a visually distinct color palette
-  theme_bw()
+  scale_color_brewer(palette = "Dark2", na.value = "grey70") # add a visually distinct color palette
 
 # Next, plot log count pca
 ggplot(log_pca_scores, aes(x = PC1, y = PC2, color = cell_type)) +
   geom_point() +
   labs(title = "Log counts (unnormalized) PCA scores",
        color = "Cell Type") +
-  scale_color_brewer(palette = "Dark2", na.value = "grey70") + # add a visually distinct color palette
-  theme_bw()
+  scale_color_brewer(palette = "Dark2", na.value = "grey70") # add a visually distinct color palette
 ```
 
 

--- a/scRNA-seq/05-clustering_markers_scRNA.Rmd
+++ b/scRNA-seq/05-clustering_markers_scRNA.Rmd
@@ -80,7 +80,7 @@ You might wonder: How many clusters should we use?
 That is a hard question!
 There are some heuristics we can use for deciding the "correct" number of clusters, but we will not be exploring those right now.
 
-For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
+For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/3.19/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
 
 We are going to use the function `clusterRows()` from the  Bioconductor `bluster` package for our clustering.
 This function takes a matrix where each sample (cell in our case) is a row and each column is a feature.
@@ -187,7 +187,7 @@ Again, you will have time to explore these more in the exercise notebook, and of
 Sadly, there are not always good answers to which set of inferred clusters is best!
 Which method and parameters you use may depend on the kind of question you are trying to answer.
 
-For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph).
+For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.19/OSCA.basic/clustering.html#clustering-graph).
 A recent review by [Kislev *et al.* (2019)](https://doi.org/10.1038/s41576-018-0088-9) also goes into some depth about the differences among algorithms and the general challenges associated with clustering single cell data.
 
 ## Identifying marker genes

--- a/scRNA-seq/05-clustering_markers_scRNA.Rmd
+++ b/scRNA-seq/05-clustering_markers_scRNA.Rmd
@@ -80,7 +80,7 @@ You might wonder: How many clusters should we use?
 That is a hard question!
 There are some heuristics we can use for deciding the "correct" number of clusters, but we will not be exploring those right now.
 
-For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
+For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/release/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
 
 We are going to use the function `clusterRows()` from the  Bioconductor `bluster` package for our clustering.
 This function takes a matrix where each sample (cell in our case) is a row and each column is a feature.
@@ -187,7 +187,7 @@ Again, you will have time to explore these more in the exercise notebook, and of
 Sadly, there are not always good answers to which set of inferred clusters is best!
 Which method and parameters you use may depend on the kind of question you are trying to answer.
 
-For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph).
+For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/release/OSCA.basic/clustering.html#clustering-graph).
 A recent review by [Kislev *et al.* (2019)](https://doi.org/10.1038/s41576-018-0088-9) also goes into some depth about the differences among algorithms and the general challenges associated with clustering single cell data.
 
 ## Identifying marker genes

--- a/scRNA-seq/05-clustering_markers_scRNA.Rmd
+++ b/scRNA-seq/05-clustering_markers_scRNA.Rmd
@@ -80,7 +80,7 @@ You might wonder: How many clusters should we use?
 That is a hard question!
 There are some heuristics we can use for deciding the "correct" number of clusters, but we will not be exploring those right now.
 
-For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/release/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
+For an intuitive visualization of the general k-means method, you might find [this StatQuest video](https://www.youtube.com/watch?v=4b5d3muPQmA) useful, and for more discussion of the method in a single-cell context, the [Orchestrating Single-Cell Analysis book section on k-means](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#vector-quantization-with-k-means) is a good reference.
 
 We are going to use the function `clusterRows()` from the  Bioconductor `bluster` package for our clustering.
 This function takes a matrix where each sample (cell in our case) is a row and each column is a feature.
@@ -187,7 +187,7 @@ Again, you will have time to explore these more in the exercise notebook, and of
 Sadly, there are not always good answers to which set of inferred clusters is best!
 Which method and parameters you use may depend on the kind of question you are trying to answer.
 
-For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/release/OSCA.basic/clustering.html#clustering-graph).
+For more detailed information about the methods presented here, including some ways to assess the "quality" of the clustering, I encourage you to explore at the relevant chapter of the [Orchestrating Single-Cell Analysis book](https://bioconductor.org/books/3.16/OSCA.basic/clustering.html#clustering-graph).
 A recent review by [Kislev *et al.* (2019)](https://doi.org/10.1038/s41576-018-0088-9) also goes into some depth about the differences among algorithms and the general challenges associated with clustering single cell data.
 
 ## Identifying marker genes

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -3,7 +3,7 @@ title: "Annotating cell types from scRNA-seq data"
 author: Data Lab for ALSF
 date: 2023
 output:
-  html_notebook: 
+  html_notebook:
     toc: true
     toc_float: true
 ---
@@ -21,18 +21,18 @@ This notebook will demonstrate how to:
 
 In this notebook, we will attempt to annotate cell types to each of the cells in a dataset, using some of the automated tools that are available within the Bioconductor universe.
 
-Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_](http://bioconductor.org/books/3.16/OSCA/). 
+Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_](http://bioconductor.org/books/release/OSCA/).
 
 The data we will use for this notebook is derived from a [10x Genomics dataset of human peripheral blood mononuclear cells (PBMCs)](https://software.10xgenomics.com/single-cell-gene-expression/datasets/6.0.0/10k_PBMCs_TotalSeq_B_3p).
-These data include both single cell RNA-seq counts and quantification of antibody-derived tags (ADTs) performed by sequencing short DNA barcodes attached to specific antibodies. 
-This type of ADT sequencing with single cells is commonly known as CITE-seq, after the protocol developed by [Stoeckius _et al._ (2017)](https://doi.org/10.1038/nmeth.4380).  
+These data include both single cell RNA-seq counts and quantification of antibody-derived tags (ADTs) performed by sequencing short DNA barcodes attached to specific antibodies.
+This type of ADT sequencing with single cells is commonly known as CITE-seq, after the protocol developed by [Stoeckius _et al._ (2017)](https://doi.org/10.1038/nmeth.4380).
 The antibodies used here are the [The TotalSeq™-B Human TBNK Cocktail](https://www.biolegend.com/en-us/products/totalseq-b-human-tbnk-cocktail-19043), a set of antibodies designed to react with immune cell surface markers.
 
 ![Single-cell roadmap: Cell type](diagrams/roadmap_single_celltype.png)
 
 The data here have already been filtered, normalized, and had dimension reductions calculated for the single-cell RNA-seq data.
 The ADT data has also been separately filtered and normalized.
-For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
+For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.19/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
 
 The processed gene expression and ADT data were saved into a combined `SingleCellExperiment` (SCE) object, and we will start with that object for our exploration here.
 
@@ -53,7 +53,7 @@ set.seed(12345)
 
 ### Directories and files
 
-As mentioned, our input file here is a single normalized and processed SCE object, stored as an `rds` file. 
+As mentioned, our input file here is a single normalized and processed SCE object, stored as an `rds` file.
 That should be all we need to read in!
 
 Our output will be a table of per-cell information, which will include the cell type assignments we have made throughout this notebook.
@@ -61,30 +61,30 @@ We aren't planning any significant modifications of the underlying data, so we w
 
 ```{r filepaths, live=TRUE}
 # directory for the input data
-data_dir <- file.path("data", 
-                      "PBMC-TotalSeqB", 
+data_dir <- file.path("data",
+                      "PBMC-TotalSeqB",
                       "normalized")
 
 # the input file itself
-sce_file <- file.path(data_dir, 
+sce_file <- file.path(data_dir,
                       "PBMC_TotalSeqB_normalized_sce.rds")
 
 # A directory to store outputs
-analysis_dir <- file.path("analysis", 
+analysis_dir <- file.path("analysis",
                           "PBMC-TotalSeqB")
 
 # Create directory if it doesn't exist
 fs::dir_create(analysis_dir)
 
 # output table path
-cellinfo_file <- file.path(analysis_dir, 
+cellinfo_file <- file.path(analysis_dir,
                            "PBMC_TotalSeqB_cellinfo.tsv")
 ```
 
 
 ## Exploring a CITE-seq `SingleCellExperiment`
 
-Now that the preliminary setup is out of the way, we can get started. 
+Now that the preliminary setup is out of the way, we can get started.
 First we will read in the `SingleCellExperiment` from the input file we defined earlier.
 
 ```{r read SCE, live=TRUE}
@@ -101,7 +101,7 @@ But where are the data from the ADTs?
 We wouldn't necessarily want those stored in the main data matrices, as the characteristics of ADT barcode data is going to be quite different from gene expression data.
 
 To keep the ADT data separate from the RNA gene expression data, we have split this data off into an _alternative experiment_ (`altExp`) slot.
-You can see the name of this `altExp` on the line `altExpNames` above. 
+You can see the name of this `altExp` on the line `altExpNames` above.
 We _could_ have more than one type of alternative experiment (such as spike-in or ATAC-seq), but in this case, just the one.
 
 To access the contents of the `altExp` slot, we can use the `altExp()` function.
@@ -112,16 +112,16 @@ Let's look at what we have in that slot:
 altExp(sce, "ADT")
 ```
 
-It is another `SingleCellExperiment`! 
+It is another `SingleCellExperiment`!
 Inception!
 Let's look at that embedded SCE more closely.
 
-The first thing to note is that this `altExp` has the same number of columns as did the main SCE object. 
+The first thing to note is that this `altExp` has the same number of columns as did the main SCE object.
 Those corresponded to the individual cells before, and still do!
 
-There are only 10 rows, however, and these correspond to the ADTs that were assayed by this particular experiment. 
+There are only 10 rows, however, and these correspond to the ADTs that were assayed by this particular experiment.
 Just as we did with the full SCE, we can use `rowData()` to view the table containing metadata associated with each of these rows.
-We'll add the `altExp()` function to point it to the embedded object we are interested in. 
+We'll add the `altExp()` function to point it to the embedded object we are interested in.
 Since there is only one `altExp`, we don't need the second (name) argument (`"ADT"`) that we used above; the default behavior of `altExp()` is to just give us the first `altExp`, and that is the one (and only) that we need.
 
 ```{r adt rows, live=TRUE}
@@ -130,7 +130,7 @@ rowData(altExp(sce))
 ```
 
 You can see here the names and symbols of the tags used, along with the designation that all have an "Antibody Capture" type (as opposed to "Gene Expression" for the RNA data).
-One you might note looks different is the `IgG1` control, which is actually a mouse antibody used as a negative control. 
+One you might note looks different is the `IgG1` control, which is actually a mouse antibody used as a negative control.
 
 
 ### Clustering redux
@@ -145,7 +145,7 @@ While we have the ADT data, it is _not_ being used for this stage of the analysi
 # perform clustering
 nn_clusters <- bluster::clusterRows(
   # PCA input
-  reducedDim(sce, "PCA"), 
+  reducedDim(sce, "PCA"),
   # graph clustering & parameters
   bluster::NNGraphParam()
 )
@@ -154,16 +154,16 @@ nn_clusters <- bluster::clusterRows(
 sce$nn_cluster <- nn_clusters
 ```
 
-Now we can plot the clusters we have identified with `scater::plotUMAP()`. 
+Now we can plot the clusters we have identified with `scater::plotUMAP()`.
 This is a shortcut for `scater::plotReducedDim(dimred = "UMAP", ...)`, which can save us a lot of typing as we do this repeatedly!
 
 ```{r plot clusters}
 # plot clusters
-scater::plotUMAP(sce, color_by = "nn_cluster") + 
+scater::plotUMAP(sce, color_by = "nn_cluster") +
   # rename the legend
   guides(color = guide_legend(title = "Cluster"))
 ```
-But what are these clusters, really? 
+But what are these clusters, really?
 Do they correspond to particular cell types that we are interested in?
 
 Does it bother you that we just used the default nearest-neighbor graph clustering parameters?
@@ -177,7 +177,7 @@ The first way we will identify cell types of individual cells is to use the ADT 
 These antibody markers were (hopefully) chosen for their relevance to the sequenced cell population.
 
 The first marker we will look at is `CD3`, which is a protein complex that is found on the surface of T cells.
-We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels. 
+We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels.
 
 Note that this function can plot data from the `colData` table (as we used it above when plotting clusters), in the main gene expression matrix (as we used it in the previous notebook), *AND* in `altExp` tables and matrices!
 So to color by the ADT levels (as normalized in the `logcounts` matrix) we only need to provide the tag name that we want to plot in the `color_by` argument.
@@ -199,13 +199,13 @@ Let's plot the ADT results for those two markers as well below:
 
 ```{r plot CD4, live=TRUE}
 # plot CD4 marker
-scater::plotUMAP(sce, 
+scater::plotUMAP(sce,
                  color_by = "CD4")
 ```
 
 ```{r plot CD8, live=TRUE}
 # plot CD8 marker
-scater::plotUMAP(sce, 
+scater::plotUMAP(sce,
                  color_by = "CD8")
 ```
 
@@ -216,15 +216,15 @@ Plotting the levels of the ADTs provides a nice visual representation, but what 
 Such classification could be considered as analogous to a cell-sorter assay, where we would set up some rules to look at a few markers for each cell and use those to assign a cell type.
 The simplest type of rule might be one where we use a threshold to call a marker as present or absent, and then use the presence of a marker to indicate a specific cell type.
 
-To do this, we will need to make some decisions, such as the thresholds we should use to determine whether a cell is or is not expressing a particular marker. 
+To do this, we will need to make some decisions, such as the thresholds we should use to determine whether a cell is or is not expressing a particular marker.
 In general, markers that are useful for this cell-typing approach will have a bimodal distribution of expression levels which can be used to separate the population into two groups of cells.
 One group of cells will have only a background level signal for each marker (due to non-specific binding or other factors), while the other group, those that express the protein, will have a much higher level of binding and higher counts.
 
 To assess whether the ADTs we have chosen have a useful distribution of expression values, and to identify thresholds we might use, we would like to plot each ADT tag.
-To do this, we will pull out the expression values for these markers from the SCE object and do some data wrangling. 
+To do this, we will pull out the expression values for these markers from the SCE object and do some data wrangling.
 
 We are interested in the normalized counts for the ADT tags, which are stored in the `logcounts` assay of the `altExp`.
-If you recall, this matrix is stored with the columns as cells and rows as markers, but we really want it with each row a cell and each column a marker. 
+If you recall, this matrix is stored with the columns as cells and rows as markers, but we really want it with each row a cell and each column a marker.
 So we will first transpose the data, then convert it to a data frame for our next steps.
 Because the SCE object stores the assay data matrices in a specialized format, we have to do one extra step convert it first to a "regular" R matrix or R won't know how to convert it to a data frame.
 
@@ -242,7 +242,7 @@ head(adt_df)
 If we just wanted to plot one of these tags, we could do so right away, but with a bit more data wrangling, we can convert these results into a "tidier" format, that will allow us to take full advantage of `tidyverse` tools!
 In particular, it will let us plot them all at once with `ggplot2` faceting.
 
-Right now the data is in a "wide" format, such that each column is a different tag. 
+Right now the data is in a "wide" format, such that each column is a different tag.
 But the data in all of the columns is the same type, and measures something similar: the normalized count of an ADT.
 One could even argue that each row contains 10 different observations, where the "tidy" data ideal, as espoused by [Wickham (2014)](https://doi.org/10.18637/jss.v059.i10), requires a single observation per row, a "long" format.
 This long format will have one column that tells us which ADT was measured and a second column with the measurement value itself.
@@ -270,7 +270,7 @@ Now we can make a density plot with `ggplot2` for all three ADTs we are interest
 
 ```{r plot ADTs, live=TRUE}
 # plot logcounts by ADT
-ggplot(adt_df_long, aes(x = logcount, fill = ADT)) + 
+ggplot(adt_df_long, aes(x = logcount, fill = ADT)) +
   geom_density() + # density plot
   facet_grid(rows = vars(ADT)) + # facet by ADT
   theme_bw() + # nicer theme
@@ -281,8 +281,8 @@ These look pretty good!
 Each of these markers has a bimodal distribution: A lower peak consisting of cells that do not express the protein but which still have a background level of antibody binding, and an upper peak of cells that do express the protein of interest.
 The background level does vary by antibody marker, so we will need a different threshold value for each one.
 
-We can now use the values from these plots to construct a set of rules to classify the T cells. 
-We will do this using the "wide" data frame from earlier. 
+We can now use the values from these plots to construct a set of rules to classify the T cells.
+We will do this using the "wide" data frame from earlier.
 
 The thresholds we are using here were identified just "by eye", so this is not a particularly principled method of cell type assignment, but it can be fairly effective.
 Here we are assigning only three cell types; cells that do not fit any of these criteria will be set as `NA`.
@@ -307,24 +307,24 @@ Creating and assigning values to this column can be done with the `$` shortcut, 
 
 ```{r plot thresholds}
 sce$threshold_celltype <- adt_df$celltype
-scater::plotUMAP(sce, 
-                 color_by = "threshold_celltype") + 
+scater::plotUMAP(sce,
+                 color_by = "threshold_celltype") +
   guides(color = guide_legend(title = "Cell type"))
 ```
 
-How did we do? 
+How did we do?
 
 Note that while we applied this technique to assign cell types using the ADT data, we could use the same type of procedure using gene expression data alone, or a combination of gene expression data and tag data.
 
 However, what we did here was very ad-hoc and quite manual!
 We didn't calculate any statistics, and we had to look at every tag we were interested in to pick thresholds.
-A different dataset might have different background levels, which would require different thresholds. 
+A different dataset might have different background levels, which would require different thresholds.
 
 While this technique might be good for some simple experiments, and can be useful for manual curation, it might not translate well to more complex datasets with multiple samples.
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
-For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/3.16/bioc/html/AUCell.html).
-For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
+For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/release/bioc/html/AUCell.html).
+For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.19/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
 
 
 ## Cell type annotation with `SingleR`
@@ -332,9 +332,9 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 An alternative approach to using known marker genes for classification is to instead classify cells by comparing them to a reference expression dataset.
 To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
 We can then train a model based on this dataset and look at each of the cells in our new dataset to determine which (if any) of the known cell types has the most similar expression pattern.
-The details of how such a model may be constructed and trained will vary by the specific method, but this overall approach is widely applied. 
+The details of how such a model may be constructed and trained will vary by the specific method, but this overall approach is widely applied.
 
-For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
+For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/release/SingleRBook/).
 
 ### Reference datasets
 
@@ -343,11 +343,11 @@ At the most basic level, if the reference dataset does not include the types of 
 So we will want a reference dataset that has as many as possible of the cell types that we expect to find in our dataset, at a level of granularity that aligns with our goals.
 
 For `SingleR` that reference data can be from bulk RNA sequencing or from other single-cell experiments.
-`SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available. 
+`SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available.
 
 One convenient source of cell reference data is the `celldex` package, which is what we will use here.
-This package includes functions to download a variety of well-annotated reference datasets in a common format.  
-For more information on the datasets available, you will want to refer to [the `celldex` summary vignette](https://bioconductor.org/packages/3.16/data/experiment/vignettes/celldex/inst/doc/userguide.html).
+This package includes functions to download a variety of well-annotated reference datasets in a common format.
+For more information on the datasets available, you will want to refer to [the `celldex` summary vignette](https://bioconductor.org/packages/release/data/experiment/vignettes/celldex/inst/doc/userguide.html).
 
 We will start by using a reference dataset of sorted immune cells from [GSE107011 (Monaco _et al._ 2019)](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE107011).
 This particular reference was chosen because it is well-suited to PBMC datasets, with a good level of granularity.
@@ -358,7 +358,7 @@ The `celldex` functions also have a convenient option to convert gene symbols to
 # Bioconductor "Hub" packages provide the option to cache
 #   downloads, but the interactive prompt can be annoying
 #   when working with notebooks.
-# These options disable the prompt by giving permission 
+# These options disable the prompt by giving permission
 #   to create the cache automatically
 ExperimentHub::setExperimentHubOption("ASK", FALSE)
 AnnotationHub::setAnnotationHubOption("ASK", FALSE)
@@ -385,37 +385,37 @@ colData(monaco_ref)
 
 There are three main columns for the sample data:
 
-- `label.main` is a more general cell type assignment.  
+- `label.main` is a more general cell type assignment.
 
 - `label.fine` is a fine-level cell type with more specific labels.
 The exact level of granularity of these `main` and `fine` designations (and indeed the label names themselves) will vary among datasets, so it is important to look at the reference to see whether it is suitable for your application.
 
-- `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier. 
-Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop. 
+- `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier.
+Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop.
 
-Another component we would like to explore is how many of each of these cell types we have in the reference dataset. 
+Another component we would like to explore is how many of each of these cell types we have in the reference dataset.
 A bit of quick `dplyr` wrangling can give us the answer.
 
 ```{r count cell types}
-colData(monaco_ref) |> 
+colData(monaco_ref) |>
   as.data.frame() |>
   dplyr::count(label.main, label.fine)
 ```
 
-This is pretty good! 
+This is pretty good!
 Most cell types have 4 replicates, which is more replicates than we often find.
 
 ### What does `SingleR` do?
 
 As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new datasets.
 
-`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference dataset. 
+`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference dataset.
 It does this by performing pairwise comparisons among all of the cell types, and retaining the top set of genes differentiating each pair.
 The idea is that this set of genes will be the most informative for differentiating cell types.
 
 Then, for each cell, `SingleR` calculates the Spearman correlation between expression of that cell and each cell type (using the only the genes chosen earlier).
 Notably, this is a non-parametric correlation, so the scaling and normalization that we apply (or don't) should not matter!
-Note that if you used a single-cell technology that produces full-length transcripts (i.e., SMART-seq), you will probably want to convert your counts to Transcripts per Million (TPM), to allow more consistent ranking among transcripts of different lengths. 
+Note that if you used a single-cell technology that produces full-length transcripts (i.e., SMART-seq), you will probably want to convert your counts to Transcripts per Million (TPM), to allow more consistent ranking among transcripts of different lengths.
 
 The reference cell type with the highest correlation is then chosen as the cell type assignment for that cell.
 If there are multiple cell types with high scores, an optional fine-tuning step repeats the process using only the most relevant genes for those cell types.
@@ -428,7 +428,7 @@ For this we need only supply three main arguments: Our SCE object, a reference m
 We also need to be sure that our sample and the reference data use the same gene IDs, which is why we requested the Ensembl IDs when getting the reference dataset.
 
 Because this function is doing many repetitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
-This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions. 
+This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions.
 In this case, we will use the argument `BiocParallel::MulticoreParam(4)` to specify we want to use local multicore processing with 4 "workers".
 
 ```{r simple SingleR, live=TRUE}
@@ -458,7 +458,7 @@ sce$celltype_main <- singler_result$pruned.labels
 Now we can plot the cell type assignments onto our UMAP to see how they compare to the patterns we saw there before.
 
 ```{r plot celltype umap, live=TRUE}
-scater::plotUMAP(sce, color_by = "celltype_main") 
+scater::plotUMAP(sce, color_by = "celltype_main")
 ```
 Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices.
 Luckily, since `plotUMAP()` returns a `ggplot` object, we can modify the color palette using `ggplot2` functions.
@@ -485,13 +485,13 @@ table(singler_result$pruned.labels, useNA = "ifany")
 
 ### Exploring finer labels
 
-In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the dataset in a bit more detail. 
+In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the dataset in a bit more detail.
 
-We will also take this time to dive a bit deeper into the steps that `SingleR` performed. 
+We will also take this time to dive a bit deeper into the steps that `SingleR` performed.
 As mentioned, the first step is training the model, during which we identify the genes that will be used for the correlation analysis later.
 While this step is not particularly slow, if we were classifying multiple samples, we would not want to have to repeat it for every sample.
 
-To do the training, we will use the `trainSingleR()` function. 
+To do the training, we will use the `trainSingleR()` function.
 For this we will start with our reference and the labels we want to train the model with.
 
 We can then specify the method used to select the genes that will be used for classification.
@@ -499,10 +499,10 @@ The default method is `"de"`, which performs a differential expression analysis 
 If we want to get really fancy, we could even provide a specific list of genes to use.
 
 We should note here that the reference dataset for `SingleR` does not need to be from a compendium like `celldex`!
-If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
-You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible. 
+If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample.
+You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible.
 You can even use a previously-annotated `SingleCellExperiment` as a reference for a new dataset.
-For more details about custom references, see the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#using-custom-references)
+For more details about custom references, see the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.19/OSCA.basic/cell-type-annotation.html#using-custom-references)
 
 We do want to be sure that the genes selected for the model will be among those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
 This step would happen automatically with the `SingleR::SingleR()` function, but we need to add it manually for this use case.
@@ -514,7 +514,7 @@ singler_finemodel <- SingleR::trainSingleR(
   monaco_ref, # reference dataset
   labels = monaco_ref$label.fine, # labels for training dataset
   # use DE to select genes (default)
-  genes = "de", 
+  genes = "de",
   # only use genes in the sce object
   restrict = rownames(sce),
   # parallel processing
@@ -556,7 +556,7 @@ The `NA` cells also got taken off completely, which is not ideal.
 
 One thing we can do is to use some functions from the `tidyverse` package [`forcats`](https://forcats.tidyverse.org), which can be very handy for dealing with categorical variables like these cell types.
 
-We will use two of these functions in the chunk below: 
+We will use two of these functions in the chunk below:
 First we will use `fct_collapse` to take some of the finer labels that we might not be as interested in and collapse them into logical groupings (in this case, the `main` label that they were part of).
 After that, we will use `fct_relevel` to put the remaining factor levels in the order we would like them to appear for plotting.
 
@@ -564,8 +564,8 @@ After that, we will use `fct_relevel` to put the remaining factor levels in the 
 collapsed_labels <- singler_result_fine$pruned.labels |>
   forcats::fct_collapse(
     "Monocytes" = c(
-        "Classical monocytes", 
-        "Intermediate monocytes", 	
+        "Classical monocytes",
+        "Intermediate monocytes",
         "Non classical monocytes"),
     "Dendritic cells" = c(
         "Myeloid dendritic cells",
@@ -576,8 +576,8 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
         "Vd2 gd T cells"),
     "Helper T cells" = c(
         "Th1 cells",
-        "Th1/Th17 cells", 
-        "Th17 cells", 
+        "Th1/Th17 cells",
+        "Th17 cells",
         "Th2 cells",
         "Follicular helper T cells"),
     "B cells" = c(
@@ -585,7 +585,7 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
         "Switched memory B cells",
         "Non-switched memory B cells",
         "Exhausted B cells",
-        "Plasmablasts"		
+        "Plasmablasts"
     )
   ) |>
   # order for plotting
@@ -612,7 +612,7 @@ Now that we have that set up, we can plot using our collapsed and ordered cell t
 
 ```{r plot collapsed, live=TRUE}
 sce$celltype_collapsed <- collapsed_labels
-scater::plotUMAP(sce, 
+scater::plotUMAP(sce,
                  color_by = "celltype_collapsed")
 ```
 
@@ -621,7 +621,7 @@ scater::plotUMAP(sce,
 
 Let's look at how the cell type assignments we obtained using `SingleR` compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
 
-To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with. 
+To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with.
 
 ```{r type cluster table}
 # create a table of clusters & cell type counts
@@ -633,20 +633,20 @@ type_cluster_tab[1:5, 1:5]
 
 As you can see, this produced a table with rows for each cell type and columns for each cluster number.
 The values are the count of cells for each cluster/cell type combination.
-However, these raw counts are not quite what we'll want for visualization. 
+However, these raw counts are not quite what we'll want for visualization.
 Since the total number of cells differs across clusters, we'd like to convert these counts into the _proportions_ of each cell type in each cluster.
 
 We'll do this by going through the table column by column and dividing each value by the sum for that cluster.
 This will give us normalized values where the values in each column now sum to 1.
 To do that, we will use the `apply` function, which allows us to operate on a matrix row by row or column by column, applying a function to each "slice".
-Since the function we want to apply is very short, we will use R's new (as of  version 4.1) anonymous function shorthand: 
+Since the function we want to apply is very short, we will use R's new (as of  version 4.1) anonymous function shorthand:
 `\(x) ...` can be used to define a function that that takes as input values `x` (where the `...` is where you would put the expression to calculate).
 Here we will apply the expression `x/sum(x)`, which will divide each element of a vector `x` by the sum of its values.
 
 ```{r normalize by column}
 # normalize by the number of cells in each cluster (columns)
 type_cluster_tab <- apply(
-  type_cluster_tab, 
+  type_cluster_tab,
   2, # apply function to columns
   \(x) x/sum(x) # function to apply
 )
@@ -654,7 +654,7 @@ type_cluster_tab <- apply(
 type_cluster_tab[1:5, 1:5]
 ```
 
-Now we can plot these results as a heatmap, using the `pheatmap` package. 
+Now we can plot these results as a heatmap, using the `pheatmap` package.
 There is a lot of customization we could do here, but `pheatmap` (pretty heatmap) has good defaults, so we won't spend too much time on it for now.
 
 ```{r cluster heatmap, live=TRUE}
@@ -667,11 +667,11 @@ There are also some places where single cell types are spread across a few diffe
 
 ### Classifying by clusters
 
-While most of the time we will want to classify single cells, sometimes the sparseness of the data may mean that individual cells do not provide reliable estimates of cell types. 
+While most of the time we will want to classify single cells, sometimes the sparseness of the data may mean that individual cells do not provide reliable estimates of cell types.
 
 An alternative approach is to classify the clusters as a whole, assuming that the clusters we have identified represent a single cell state.
-If that is the case, then we should be able to combine the data for all cells across each cluster, then apply our cell typing method to this group of cells. 
-This is similar to an approach we will return to later in the context of differential expression. 
+If that is the case, then we should be able to combine the data for all cells across each cluster, then apply our cell typing method to this group of cells.
+This is similar to an approach we will return to later in the context of differential expression.
 
 The first step here is to create a new matrix where we sum the counts across cells that are from the same type according to our clustering.
 Because `SingleR` is a non-parametric approach, we can perform this step with the raw counts matrix.
@@ -703,7 +703,7 @@ head(singler_cluster)
 ```
 
 The result is a fairly small table of results, but we are most interested in the labels, which we would like to associate with each cell in our SCE object for visualization.
-Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to. 
+Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to.
 (In this case the cluster names are all numbers, but that might not always be the case.)
 We'll select values repeatedly from the `singler_cluster` table, using the cluster assignment to pick a row, and then always picking the `pruned.labels` column.
 
@@ -717,14 +717,14 @@ Now we can plot these cluster-based cell type assignments using the now familiar
 scater::plotUMAP(sce, color_by = "celltype_cluster")
 ```
 
-This sure looks nice and clean, but what have we really done here? 
+This sure looks nice and clean, but what have we really done here?
 We are _assuming_ that each cluster has only a single cell type, which is a pretty bold assumption, as we really aren't sure that the clusters we created were correct.
 You may recall that clustering algorithms are quite sensitive to parameter choice, so a different parameter choice could quite likely give a different result.
 
 ### MetaCell approaches
 
-As a middle ground between the potentially messy single-cell cell type assignment and the almost-certainly overconfident cluster-based assignment above, we can take approach inspired by [Baran _et al._ (2019)](https://doi.org/10.1186/s13059-019-1812-2) using something they called _metacells_. 
-The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters as "metacells" to use for further analysis. 
+As a middle ground between the potentially messy single-cell cell type assignment and the almost-certainly overconfident cluster-based assignment above, we can take approach inspired by [Baran _et al._ (2019)](https://doi.org/10.1186/s13059-019-1812-2) using something they called _metacells_.
+The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters as "metacells" to use for further analysis.
 The original paper includes a number of optimizations to make sure that the metacell clusters have desirable properties for downstream analysis.
 We won't go into that depth here, but we can apply similar ideas.
 
@@ -736,9 +736,9 @@ While this is almost certainly more clusters than are "real" in this dataset, ou
 ```{r kmeans cluster}
 # perform k-means clustering
 kclusters <- bluster::clusterRows(
-  reducedDim(sce, "PCA"), 
+  reducedDim(sce, "PCA"),
   bluster::KmeansParam(
-    centers = 100, # the number of clusters 
+    centers = 100, # the number of clusters
     iter.max = 100 # more iterations to be sure of convergence
   )
 )
@@ -752,7 +752,7 @@ metacell_mat <- DelayedArray::colsum(counts(sce), kclusters)
 
 # apply SingleR model to metacell matrix
 metacell_singler <- SingleR::classifySingleR(
-  metacell_mat, 
+  metacell_mat,
   singler_finemodel
 )
 
@@ -766,13 +766,13 @@ Now we can plot the results as we have done before.
 scater::plotUMAP(sce, color_by = "celltype_metacell")
 ```
 
-What do you think of this plot? 
+What do you think of this plot?
 Is this more or less useful than the original cell-based clustering?
 
 
 ## Save results
 
-To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there. 
+To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there.
 Instead we will just write out the cell information table (`colData`) as a TSV file.
 
 ```{r save cell info, live=TRUE}

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -3,7 +3,7 @@ title: "Annotating cell types from scRNA-seq data"
 author: Data Lab for ALSF
 date: 2023
 output:
-  html_notebook:
+  html_notebook: 
     toc: true
     toc_float: true
 ---
@@ -21,18 +21,18 @@ This notebook will demonstrate how to:
 
 In this notebook, we will attempt to annotate cell types to each of the cells in a dataset, using some of the automated tools that are available within the Bioconductor universe.
 
-Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_](http://bioconductor.org/books/release/OSCA/).
+Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_](http://bioconductor.org/books/3.16/OSCA/). 
 
 The data we will use for this notebook is derived from a [10x Genomics dataset of human peripheral blood mononuclear cells (PBMCs)](https://software.10xgenomics.com/single-cell-gene-expression/datasets/6.0.0/10k_PBMCs_TotalSeq_B_3p).
-These data include both single cell RNA-seq counts and quantification of antibody-derived tags (ADTs) performed by sequencing short DNA barcodes attached to specific antibodies.
-This type of ADT sequencing with single cells is commonly known as CITE-seq, after the protocol developed by [Stoeckius _et al._ (2017)](https://doi.org/10.1038/nmeth.4380).
+These data include both single cell RNA-seq counts and quantification of antibody-derived tags (ADTs) performed by sequencing short DNA barcodes attached to specific antibodies. 
+This type of ADT sequencing with single cells is commonly known as CITE-seq, after the protocol developed by [Stoeckius _et al._ (2017)](https://doi.org/10.1038/nmeth.4380).  
 The antibodies used here are the [The TotalSeq™-B Human TBNK Cocktail](https://www.biolegend.com/en-us/products/totalseq-b-human-tbnk-cocktail-19043), a set of antibodies designed to react with immune cell surface markers.
 
 ![Single-cell roadmap: Cell type](diagrams/roadmap_single_celltype.png)
 
 The data here have already been filtered, normalized, and had dimension reductions calculated for the single-cell RNA-seq data.
 The ADT data has also been separately filtered and normalized.
-For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/release/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
+For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
 
 The processed gene expression and ADT data were saved into a combined `SingleCellExperiment` (SCE) object, and we will start with that object for our exploration here.
 
@@ -53,7 +53,7 @@ set.seed(12345)
 
 ### Directories and files
 
-As mentioned, our input file here is a single normalized and processed SCE object, stored as an `rds` file.
+As mentioned, our input file here is a single normalized and processed SCE object, stored as an `rds` file. 
 That should be all we need to read in!
 
 Our output will be a table of per-cell information, which will include the cell type assignments we have made throughout this notebook.
@@ -61,30 +61,30 @@ We aren't planning any significant modifications of the underlying data, so we w
 
 ```{r filepaths, live=TRUE}
 # directory for the input data
-data_dir <- file.path("data",
-                      "PBMC-TotalSeqB",
+data_dir <- file.path("data", 
+                      "PBMC-TotalSeqB", 
                       "normalized")
 
 # the input file itself
-sce_file <- file.path(data_dir,
+sce_file <- file.path(data_dir, 
                       "PBMC_TotalSeqB_normalized_sce.rds")
 
 # A directory to store outputs
-analysis_dir <- file.path("analysis",
+analysis_dir <- file.path("analysis", 
                           "PBMC-TotalSeqB")
 
 # Create directory if it doesn't exist
 fs::dir_create(analysis_dir)
 
 # output table path
-cellinfo_file <- file.path(analysis_dir,
+cellinfo_file <- file.path(analysis_dir, 
                            "PBMC_TotalSeqB_cellinfo.tsv")
 ```
 
 
 ## Exploring a CITE-seq `SingleCellExperiment`
 
-Now that the preliminary setup is out of the way, we can get started.
+Now that the preliminary setup is out of the way, we can get started. 
 First we will read in the `SingleCellExperiment` from the input file we defined earlier.
 
 ```{r read SCE, live=TRUE}
@@ -101,7 +101,7 @@ But where are the data from the ADTs?
 We wouldn't necessarily want those stored in the main data matrices, as the characteristics of ADT barcode data is going to be quite different from gene expression data.
 
 To keep the ADT data separate from the RNA gene expression data, we have split this data off into an _alternative experiment_ (`altExp`) slot.
-You can see the name of this `altExp` on the line `altExpNames` above.
+You can see the name of this `altExp` on the line `altExpNames` above. 
 We _could_ have more than one type of alternative experiment (such as spike-in or ATAC-seq), but in this case, just the one.
 
 To access the contents of the `altExp` slot, we can use the `altExp()` function.
@@ -112,16 +112,16 @@ Let's look at what we have in that slot:
 altExp(sce, "ADT")
 ```
 
-It is another `SingleCellExperiment`!
+It is another `SingleCellExperiment`! 
 Inception!
 Let's look at that embedded SCE more closely.
 
-The first thing to note is that this `altExp` has the same number of columns as did the main SCE object.
+The first thing to note is that this `altExp` has the same number of columns as did the main SCE object. 
 Those corresponded to the individual cells before, and still do!
 
-There are only 10 rows, however, and these correspond to the ADTs that were assayed by this particular experiment.
+There are only 10 rows, however, and these correspond to the ADTs that were assayed by this particular experiment. 
 Just as we did with the full SCE, we can use `rowData()` to view the table containing metadata associated with each of these rows.
-We'll add the `altExp()` function to point it to the embedded object we are interested in.
+We'll add the `altExp()` function to point it to the embedded object we are interested in. 
 Since there is only one `altExp`, we don't need the second (name) argument (`"ADT"`) that we used above; the default behavior of `altExp()` is to just give us the first `altExp`, and that is the one (and only) that we need.
 
 ```{r adt rows, live=TRUE}
@@ -130,7 +130,7 @@ rowData(altExp(sce))
 ```
 
 You can see here the names and symbols of the tags used, along with the designation that all have an "Antibody Capture" type (as opposed to "Gene Expression" for the RNA data).
-One you might note looks different is the `IgG1` control, which is actually a mouse antibody used as a negative control.
+One you might note looks different is the `IgG1` control, which is actually a mouse antibody used as a negative control. 
 
 
 ### Clustering redux
@@ -145,7 +145,7 @@ While we have the ADT data, it is _not_ being used for this stage of the analysi
 # perform clustering
 nn_clusters <- bluster::clusterRows(
   # PCA input
-  reducedDim(sce, "PCA"),
+  reducedDim(sce, "PCA"), 
   # graph clustering & parameters
   bluster::NNGraphParam()
 )
@@ -154,16 +154,16 @@ nn_clusters <- bluster::clusterRows(
 sce$nn_cluster <- nn_clusters
 ```
 
-Now we can plot the clusters we have identified with `scater::plotUMAP()`.
+Now we can plot the clusters we have identified with `scater::plotUMAP()`. 
 This is a shortcut for `scater::plotReducedDim(dimred = "UMAP", ...)`, which can save us a lot of typing as we do this repeatedly!
 
 ```{r plot clusters}
 # plot clusters
-scater::plotUMAP(sce, color_by = "nn_cluster") +
+scater::plotUMAP(sce, color_by = "nn_cluster") + 
   # rename the legend
   guides(color = guide_legend(title = "Cluster"))
 ```
-But what are these clusters, really?
+But what are these clusters, really? 
 Do they correspond to particular cell types that we are interested in?
 
 Does it bother you that we just used the default nearest-neighbor graph clustering parameters?
@@ -177,7 +177,7 @@ The first way we will identify cell types of individual cells is to use the ADT 
 These antibody markers were (hopefully) chosen for their relevance to the sequenced cell population.
 
 The first marker we will look at is `CD3`, which is a protein complex that is found on the surface of T cells.
-We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels.
+We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels. 
 
 Note that this function can plot data from the `colData` table (as we used it above when plotting clusters), in the main gene expression matrix (as we used it in the previous notebook), *AND* in `altExp` tables and matrices!
 So to color by the ADT levels (as normalized in the `logcounts` matrix) we only need to provide the tag name that we want to plot in the `color_by` argument.
@@ -199,13 +199,13 @@ Let's plot the ADT results for those two markers as well below:
 
 ```{r plot CD4, live=TRUE}
 # plot CD4 marker
-scater::plotUMAP(sce,
+scater::plotUMAP(sce, 
                  color_by = "CD4")
 ```
 
 ```{r plot CD8, live=TRUE}
 # plot CD8 marker
-scater::plotUMAP(sce,
+scater::plotUMAP(sce, 
                  color_by = "CD8")
 ```
 
@@ -216,15 +216,15 @@ Plotting the levels of the ADTs provides a nice visual representation, but what 
 Such classification could be considered as analogous to a cell-sorter assay, where we would set up some rules to look at a few markers for each cell and use those to assign a cell type.
 The simplest type of rule might be one where we use a threshold to call a marker as present or absent, and then use the presence of a marker to indicate a specific cell type.
 
-To do this, we will need to make some decisions, such as the thresholds we should use to determine whether a cell is or is not expressing a particular marker.
+To do this, we will need to make some decisions, such as the thresholds we should use to determine whether a cell is or is not expressing a particular marker. 
 In general, markers that are useful for this cell-typing approach will have a bimodal distribution of expression levels which can be used to separate the population into two groups of cells.
 One group of cells will have only a background level signal for each marker (due to non-specific binding or other factors), while the other group, those that express the protein, will have a much higher level of binding and higher counts.
 
 To assess whether the ADTs we have chosen have a useful distribution of expression values, and to identify thresholds we might use, we would like to plot each ADT tag.
-To do this, we will pull out the expression values for these markers from the SCE object and do some data wrangling.
+To do this, we will pull out the expression values for these markers from the SCE object and do some data wrangling. 
 
 We are interested in the normalized counts for the ADT tags, which are stored in the `logcounts` assay of the `altExp`.
-If you recall, this matrix is stored with the columns as cells and rows as markers, but we really want it with each row a cell and each column a marker.
+If you recall, this matrix is stored with the columns as cells and rows as markers, but we really want it with each row a cell and each column a marker. 
 So we will first transpose the data, then convert it to a data frame for our next steps.
 Because the SCE object stores the assay data matrices in a specialized format, we have to do one extra step convert it first to a "regular" R matrix or R won't know how to convert it to a data frame.
 
@@ -242,7 +242,7 @@ head(adt_df)
 If we just wanted to plot one of these tags, we could do so right away, but with a bit more data wrangling, we can convert these results into a "tidier" format, that will allow us to take full advantage of `tidyverse` tools!
 In particular, it will let us plot them all at once with `ggplot2` faceting.
 
-Right now the data is in a "wide" format, such that each column is a different tag.
+Right now the data is in a "wide" format, such that each column is a different tag. 
 But the data in all of the columns is the same type, and measures something similar: the normalized count of an ADT.
 One could even argue that each row contains 10 different observations, where the "tidy" data ideal, as espoused by [Wickham (2014)](https://doi.org/10.18637/jss.v059.i10), requires a single observation per row, a "long" format.
 This long format will have one column that tells us which ADT was measured and a second column with the measurement value itself.
@@ -270,7 +270,7 @@ Now we can make a density plot with `ggplot2` for all three ADTs we are interest
 
 ```{r plot ADTs, live=TRUE}
 # plot logcounts by ADT
-ggplot(adt_df_long, aes(x = logcount, fill = ADT)) +
+ggplot(adt_df_long, aes(x = logcount, fill = ADT)) + 
   geom_density() + # density plot
   facet_grid(rows = vars(ADT)) + # facet by ADT
   theme_bw() + # nicer theme
@@ -281,8 +281,8 @@ These look pretty good!
 Each of these markers has a bimodal distribution: A lower peak consisting of cells that do not express the protein but which still have a background level of antibody binding, and an upper peak of cells that do express the protein of interest.
 The background level does vary by antibody marker, so we will need a different threshold value for each one.
 
-We can now use the values from these plots to construct a set of rules to classify the T cells.
-We will do this using the "wide" data frame from earlier.
+We can now use the values from these plots to construct a set of rules to classify the T cells. 
+We will do this using the "wide" data frame from earlier. 
 
 The thresholds we are using here were identified just "by eye", so this is not a particularly principled method of cell type assignment, but it can be fairly effective.
 Here we are assigning only three cell types; cells that do not fit any of these criteria will be set as `NA`.
@@ -307,24 +307,24 @@ Creating and assigning values to this column can be done with the `$` shortcut, 
 
 ```{r plot thresholds}
 sce$threshold_celltype <- adt_df$celltype
-scater::plotUMAP(sce,
-                 color_by = "threshold_celltype") +
+scater::plotUMAP(sce, 
+                 color_by = "threshold_celltype") + 
   guides(color = guide_legend(title = "Cell type"))
 ```
 
-How did we do?
+How did we do? 
 
 Note that while we applied this technique to assign cell types using the ADT data, we could use the same type of procedure using gene expression data alone, or a combination of gene expression data and tag data.
 
 However, what we did here was very ad-hoc and quite manual!
 We didn't calculate any statistics, and we had to look at every tag we were interested in to pick thresholds.
-A different dataset might have different background levels, which would require different thresholds.
+A different dataset might have different background levels, which would require different thresholds. 
 
 While this technique might be good for some simple experiments, and can be useful for manual curation, it might not translate well to more complex datasets with multiple samples.
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/3.16/bioc/html/AUCell.html).
-For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/release/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
+For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
 
 
 ## Cell type annotation with `SingleR`
@@ -332,9 +332,9 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 An alternative approach to using known marker genes for classification is to instead classify cells by comparing them to a reference expression dataset.
 To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
 We can then train a model based on this dataset and look at each of the cells in our new dataset to determine which (if any) of the known cell types has the most similar expression pattern.
-The details of how such a model may be constructed and trained will vary by the specific method, but this overall approach is widely applied.
+The details of how such a model may be constructed and trained will vary by the specific method, but this overall approach is widely applied. 
 
-For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/release/SingleRBook/).
+For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
 
 ### Reference datasets
 
@@ -343,10 +343,10 @@ At the most basic level, if the reference dataset does not include the types of 
 So we will want a reference dataset that has as many as possible of the cell types that we expect to find in our dataset, at a level of granularity that aligns with our goals.
 
 For `SingleR` that reference data can be from bulk RNA sequencing or from other single-cell experiments.
-`SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available.
+`SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available. 
 
 One convenient source of cell reference data is the `celldex` package, which is what we will use here.
-This package includes functions to download a variety of well-annotated reference datasets in a common format.
+This package includes functions to download a variety of well-annotated reference datasets in a common format.  
 For more information on the datasets available, you will want to refer to [the `celldex` summary vignette](https://bioconductor.org/packages/3.16/data/experiment/vignettes/celldex/inst/doc/userguide.html).
 
 We will start by using a reference dataset of sorted immune cells from [GSE107011 (Monaco _et al._ 2019)](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE107011).
@@ -358,7 +358,7 @@ The `celldex` functions also have a convenient option to convert gene symbols to
 # Bioconductor "Hub" packages provide the option to cache
 #   downloads, but the interactive prompt can be annoying
 #   when working with notebooks.
-# These options disable the prompt by giving permission
+# These options disable the prompt by giving permission 
 #   to create the cache automatically
 ExperimentHub::setExperimentHubOption("ASK", FALSE)
 AnnotationHub::setAnnotationHubOption("ASK", FALSE)
@@ -385,37 +385,37 @@ colData(monaco_ref)
 
 There are three main columns for the sample data:
 
-- `label.main` is a more general cell type assignment.
+- `label.main` is a more general cell type assignment.  
 
 - `label.fine` is a fine-level cell type with more specific labels.
 The exact level of granularity of these `main` and `fine` designations (and indeed the label names themselves) will vary among datasets, so it is important to look at the reference to see whether it is suitable for your application.
 
-- `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier.
-Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop.
+- `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier. 
+Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop. 
 
-Another component we would like to explore is how many of each of these cell types we have in the reference dataset.
+Another component we would like to explore is how many of each of these cell types we have in the reference dataset. 
 A bit of quick `dplyr` wrangling can give us the answer.
 
 ```{r count cell types}
-colData(monaco_ref) |>
+colData(monaco_ref) |> 
   as.data.frame() |>
   dplyr::count(label.main, label.fine)
 ```
 
-This is pretty good!
+This is pretty good! 
 Most cell types have 4 replicates, which is more replicates than we often find.
 
 ### What does `SingleR` do?
 
 As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new datasets.
 
-`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference dataset.
+`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference dataset. 
 It does this by performing pairwise comparisons among all of the cell types, and retaining the top set of genes differentiating each pair.
 The idea is that this set of genes will be the most informative for differentiating cell types.
 
 Then, for each cell, `SingleR` calculates the Spearman correlation between expression of that cell and each cell type (using the only the genes chosen earlier).
 Notably, this is a non-parametric correlation, so the scaling and normalization that we apply (or don't) should not matter!
-Note that if you used a single-cell technology that produces full-length transcripts (i.e., SMART-seq), you will probably want to convert your counts to Transcripts per Million (TPM), to allow more consistent ranking among transcripts of different lengths.
+Note that if you used a single-cell technology that produces full-length transcripts (i.e., SMART-seq), you will probably want to convert your counts to Transcripts per Million (TPM), to allow more consistent ranking among transcripts of different lengths. 
 
 The reference cell type with the highest correlation is then chosen as the cell type assignment for that cell.
 If there are multiple cell types with high scores, an optional fine-tuning step repeats the process using only the most relevant genes for those cell types.
@@ -428,7 +428,7 @@ For this we need only supply three main arguments: Our SCE object, a reference m
 We also need to be sure that our sample and the reference data use the same gene IDs, which is why we requested the Ensembl IDs when getting the reference dataset.
 
 Because this function is doing many repetitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
-This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions.
+This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions. 
 In this case, we will use the argument `BiocParallel::MulticoreParam(4)` to specify we want to use local multicore processing with 4 "workers".
 
 ```{r simple SingleR, live=TRUE}
@@ -458,7 +458,7 @@ sce$celltype_main <- singler_result$pruned.labels
 Now we can plot the cell type assignments onto our UMAP to see how they compare to the patterns we saw there before.
 
 ```{r plot celltype umap, live=TRUE}
-scater::plotUMAP(sce, color_by = "celltype_main")
+scater::plotUMAP(sce, color_by = "celltype_main") 
 ```
 Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices.
 Luckily, since `plotUMAP()` returns a `ggplot` object, we can modify the color palette using `ggplot2` functions.
@@ -485,13 +485,13 @@ table(singler_result$pruned.labels, useNA = "ifany")
 
 ### Exploring finer labels
 
-In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the dataset in a bit more detail.
+In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the dataset in a bit more detail. 
 
-We will also take this time to dive a bit deeper into the steps that `SingleR` performed.
+We will also take this time to dive a bit deeper into the steps that `SingleR` performed. 
 As mentioned, the first step is training the model, during which we identify the genes that will be used for the correlation analysis later.
 While this step is not particularly slow, if we were classifying multiple samples, we would not want to have to repeat it for every sample.
 
-To do the training, we will use the `trainSingleR()` function.
+To do the training, we will use the `trainSingleR()` function. 
 For this we will start with our reference and the labels we want to train the model with.
 
 We can then specify the method used to select the genes that will be used for classification.
@@ -499,10 +499,10 @@ The default method is `"de"`, which performs a differential expression analysis 
 If we want to get really fancy, we could even provide a specific list of genes to use.
 
 We should note here that the reference dataset for `SingleR` does not need to be from a compendium like `celldex`!
-If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample.
-You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible.
+If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
+You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible. 
 You can even use a previously-annotated `SingleCellExperiment` as a reference for a new dataset.
-For more details about custom references, see the [OSCA chapter on cell type annotation](http://bioconductor.org/books/release/OSCA.basic/cell-type-annotation.html#using-custom-references)
+For more details about custom references, see the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#using-custom-references)
 
 We do want to be sure that the genes selected for the model will be among those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
 This step would happen automatically with the `SingleR::SingleR()` function, but we need to add it manually for this use case.
@@ -514,7 +514,7 @@ singler_finemodel <- SingleR::trainSingleR(
   monaco_ref, # reference dataset
   labels = monaco_ref$label.fine, # labels for training dataset
   # use DE to select genes (default)
-  genes = "de",
+  genes = "de", 
   # only use genes in the sce object
   restrict = rownames(sce),
   # parallel processing
@@ -556,7 +556,7 @@ The `NA` cells also got taken off completely, which is not ideal.
 
 One thing we can do is to use some functions from the `tidyverse` package [`forcats`](https://forcats.tidyverse.org), which can be very handy for dealing with categorical variables like these cell types.
 
-We will use two of these functions in the chunk below:
+We will use two of these functions in the chunk below: 
 First we will use `fct_collapse` to take some of the finer labels that we might not be as interested in and collapse them into logical groupings (in this case, the `main` label that they were part of).
 After that, we will use `fct_relevel` to put the remaining factor levels in the order we would like them to appear for plotting.
 
@@ -564,8 +564,8 @@ After that, we will use `fct_relevel` to put the remaining factor levels in the 
 collapsed_labels <- singler_result_fine$pruned.labels |>
   forcats::fct_collapse(
     "Monocytes" = c(
-        "Classical monocytes",
-        "Intermediate monocytes",
+        "Classical monocytes", 
+        "Intermediate monocytes", 	
         "Non classical monocytes"),
     "Dendritic cells" = c(
         "Myeloid dendritic cells",
@@ -576,8 +576,8 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
         "Vd2 gd T cells"),
     "Helper T cells" = c(
         "Th1 cells",
-        "Th1/Th17 cells",
-        "Th17 cells",
+        "Th1/Th17 cells", 
+        "Th17 cells", 
         "Th2 cells",
         "Follicular helper T cells"),
     "B cells" = c(
@@ -585,7 +585,7 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
         "Switched memory B cells",
         "Non-switched memory B cells",
         "Exhausted B cells",
-        "Plasmablasts"
+        "Plasmablasts"		
     )
   ) |>
   # order for plotting
@@ -612,7 +612,7 @@ Now that we have that set up, we can plot using our collapsed and ordered cell t
 
 ```{r plot collapsed, live=TRUE}
 sce$celltype_collapsed <- collapsed_labels
-scater::plotUMAP(sce,
+scater::plotUMAP(sce, 
                  color_by = "celltype_collapsed")
 ```
 
@@ -621,7 +621,7 @@ scater::plotUMAP(sce,
 
 Let's look at how the cell type assignments we obtained using `SingleR` compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
 
-To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with.
+To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with. 
 
 ```{r type cluster table}
 # create a table of clusters & cell type counts
@@ -633,20 +633,20 @@ type_cluster_tab[1:5, 1:5]
 
 As you can see, this produced a table with rows for each cell type and columns for each cluster number.
 The values are the count of cells for each cluster/cell type combination.
-However, these raw counts are not quite what we'll want for visualization.
+However, these raw counts are not quite what we'll want for visualization. 
 Since the total number of cells differs across clusters, we'd like to convert these counts into the _proportions_ of each cell type in each cluster.
 
 We'll do this by going through the table column by column and dividing each value by the sum for that cluster.
 This will give us normalized values where the values in each column now sum to 1.
 To do that, we will use the `apply` function, which allows us to operate on a matrix row by row or column by column, applying a function to each "slice".
-Since the function we want to apply is very short, we will use R's new (as of  version 4.1) anonymous function shorthand:
+Since the function we want to apply is very short, we will use R's new (as of  version 4.1) anonymous function shorthand: 
 `\(x) ...` can be used to define a function that that takes as input values `x` (where the `...` is where you would put the expression to calculate).
 Here we will apply the expression `x/sum(x)`, which will divide each element of a vector `x` by the sum of its values.
 
 ```{r normalize by column}
 # normalize by the number of cells in each cluster (columns)
 type_cluster_tab <- apply(
-  type_cluster_tab,
+  type_cluster_tab, 
   2, # apply function to columns
   \(x) x/sum(x) # function to apply
 )
@@ -654,7 +654,7 @@ type_cluster_tab <- apply(
 type_cluster_tab[1:5, 1:5]
 ```
 
-Now we can plot these results as a heatmap, using the `pheatmap` package.
+Now we can plot these results as a heatmap, using the `pheatmap` package. 
 There is a lot of customization we could do here, but `pheatmap` (pretty heatmap) has good defaults, so we won't spend too much time on it for now.
 
 ```{r cluster heatmap, live=TRUE}
@@ -667,11 +667,11 @@ There are also some places where single cell types are spread across a few diffe
 
 ### Classifying by clusters
 
-While most of the time we will want to classify single cells, sometimes the sparseness of the data may mean that individual cells do not provide reliable estimates of cell types.
+While most of the time we will want to classify single cells, sometimes the sparseness of the data may mean that individual cells do not provide reliable estimates of cell types. 
 
 An alternative approach is to classify the clusters as a whole, assuming that the clusters we have identified represent a single cell state.
-If that is the case, then we should be able to combine the data for all cells across each cluster, then apply our cell typing method to this group of cells.
-This is similar to an approach we will return to later in the context of differential expression.
+If that is the case, then we should be able to combine the data for all cells across each cluster, then apply our cell typing method to this group of cells. 
+This is similar to an approach we will return to later in the context of differential expression. 
 
 The first step here is to create a new matrix where we sum the counts across cells that are from the same type according to our clustering.
 Because `SingleR` is a non-parametric approach, we can perform this step with the raw counts matrix.
@@ -703,7 +703,7 @@ head(singler_cluster)
 ```
 
 The result is a fairly small table of results, but we are most interested in the labels, which we would like to associate with each cell in our SCE object for visualization.
-Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to.
+Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to. 
 (In this case the cluster names are all numbers, but that might not always be the case.)
 We'll select values repeatedly from the `singler_cluster` table, using the cluster assignment to pick a row, and then always picking the `pruned.labels` column.
 
@@ -717,14 +717,14 @@ Now we can plot these cluster-based cell type assignments using the now familiar
 scater::plotUMAP(sce, color_by = "celltype_cluster")
 ```
 
-This sure looks nice and clean, but what have we really done here?
+This sure looks nice and clean, but what have we really done here? 
 We are _assuming_ that each cluster has only a single cell type, which is a pretty bold assumption, as we really aren't sure that the clusters we created were correct.
 You may recall that clustering algorithms are quite sensitive to parameter choice, so a different parameter choice could quite likely give a different result.
 
 ### MetaCell approaches
 
-As a middle ground between the potentially messy single-cell cell type assignment and the almost-certainly overconfident cluster-based assignment above, we can take approach inspired by [Baran _et al._ (2019)](https://doi.org/10.1186/s13059-019-1812-2) using something they called _metacells_.
-The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters as "metacells" to use for further analysis.
+As a middle ground between the potentially messy single-cell cell type assignment and the almost-certainly overconfident cluster-based assignment above, we can take approach inspired by [Baran _et al._ (2019)](https://doi.org/10.1186/s13059-019-1812-2) using something they called _metacells_. 
+The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters as "metacells" to use for further analysis. 
 The original paper includes a number of optimizations to make sure that the metacell clusters have desirable properties for downstream analysis.
 We won't go into that depth here, but we can apply similar ideas.
 
@@ -736,9 +736,9 @@ While this is almost certainly more clusters than are "real" in this dataset, ou
 ```{r kmeans cluster}
 # perform k-means clustering
 kclusters <- bluster::clusterRows(
-  reducedDim(sce, "PCA"),
+  reducedDim(sce, "PCA"), 
   bluster::KmeansParam(
-    centers = 100, # the number of clusters
+    centers = 100, # the number of clusters 
     iter.max = 100 # more iterations to be sure of convergence
   )
 )
@@ -752,7 +752,7 @@ metacell_mat <- DelayedArray::colsum(counts(sce), kclusters)
 
 # apply SingleR model to metacell matrix
 metacell_singler <- SingleR::classifySingleR(
-  metacell_mat,
+  metacell_mat, 
   singler_finemodel
 )
 
@@ -766,13 +766,13 @@ Now we can plot the results as we have done before.
 scater::plotUMAP(sce, color_by = "celltype_metacell")
 ```
 
-What do you think of this plot?
+What do you think of this plot? 
 Is this more or less useful than the original cell-based clustering?
 
 
 ## Save results
 
-To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there.
+To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there. 
 Instead we will just write out the cell information table (`colData`) as a TSV file.
 
 ```{r save cell info, live=TRUE}

--- a/scRNA-seq/06-celltype_annotation.Rmd
+++ b/scRNA-seq/06-celltype_annotation.Rmd
@@ -3,7 +3,7 @@ title: "Annotating cell types from scRNA-seq data"
 author: Data Lab for ALSF
 date: 2023
 output:
-  html_notebook: 
+  html_notebook:
     toc: true
     toc_float: true
 ---
@@ -21,18 +21,18 @@ This notebook will demonstrate how to:
 
 In this notebook, we will attempt to annotate cell types to each of the cells in a dataset, using some of the automated tools that are available within the Bioconductor universe.
 
-Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_](http://bioconductor.org/books/3.16/OSCA/). 
+Much of the material in this notebook is directly inspired by, and draws heavily on, material presented in the book [_Orchestrating Single Cell Analysis with Bioconductor_](http://bioconductor.org/books/release/OSCA/).
 
 The data we will use for this notebook is derived from a [10x Genomics dataset of human peripheral blood mononuclear cells (PBMCs)](https://software.10xgenomics.com/single-cell-gene-expression/datasets/6.0.0/10k_PBMCs_TotalSeq_B_3p).
-These data include both single cell RNA-seq counts and quantification of antibody-derived tags (ADTs) performed by sequencing short DNA barcodes attached to specific antibodies. 
-This type of ADT sequencing with single cells is commonly known as CITE-seq, after the protocol developed by [Stoeckius _et al._ (2017)](https://doi.org/10.1038/nmeth.4380).  
+These data include both single cell RNA-seq counts and quantification of antibody-derived tags (ADTs) performed by sequencing short DNA barcodes attached to specific antibodies.
+This type of ADT sequencing with single cells is commonly known as CITE-seq, after the protocol developed by [Stoeckius _et al._ (2017)](https://doi.org/10.1038/nmeth.4380).
 The antibodies used here are the [The TotalSeq™-B Human TBNK Cocktail](https://www.biolegend.com/en-us/products/totalseq-b-human-tbnk-cocktail-19043), a set of antibodies designed to react with immune cell surface markers.
 
 ![Single-cell roadmap: Cell type](diagrams/roadmap_single_celltype.png)
 
 The data here have already been filtered, normalized, and had dimension reductions calculated for the single-cell RNA-seq data.
 The ADT data has also been separately filtered and normalized.
-For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
+For details about how to perform these tasks with data that has been processed with Cell Ranger, you may want to look at the ["Integrating with protein abundance" chapter](http://bioconductor.org/books/release/OSCA.advanced/integrating-with-protein-abundance.html#setting-up-the-data) of OSCA.
 
 The processed gene expression and ADT data were saved into a combined `SingleCellExperiment` (SCE) object, and we will start with that object for our exploration here.
 
@@ -53,7 +53,7 @@ set.seed(12345)
 
 ### Directories and files
 
-As mentioned, our input file here is a single normalized and processed SCE object, stored as an `rds` file. 
+As mentioned, our input file here is a single normalized and processed SCE object, stored as an `rds` file.
 That should be all we need to read in!
 
 Our output will be a table of per-cell information, which will include the cell type assignments we have made throughout this notebook.
@@ -61,30 +61,30 @@ We aren't planning any significant modifications of the underlying data, so we w
 
 ```{r filepaths, live=TRUE}
 # directory for the input data
-data_dir <- file.path("data", 
-                      "PBMC-TotalSeqB", 
+data_dir <- file.path("data",
+                      "PBMC-TotalSeqB",
                       "normalized")
 
 # the input file itself
-sce_file <- file.path(data_dir, 
+sce_file <- file.path(data_dir,
                       "PBMC_TotalSeqB_normalized_sce.rds")
 
 # A directory to store outputs
-analysis_dir <- file.path("analysis", 
+analysis_dir <- file.path("analysis",
                           "PBMC-TotalSeqB")
 
 # Create directory if it doesn't exist
 fs::dir_create(analysis_dir)
 
 # output table path
-cellinfo_file <- file.path(analysis_dir, 
+cellinfo_file <- file.path(analysis_dir,
                            "PBMC_TotalSeqB_cellinfo.tsv")
 ```
 
 
 ## Exploring a CITE-seq `SingleCellExperiment`
 
-Now that the preliminary setup is out of the way, we can get started. 
+Now that the preliminary setup is out of the way, we can get started.
 First we will read in the `SingleCellExperiment` from the input file we defined earlier.
 
 ```{r read SCE, live=TRUE}
@@ -101,7 +101,7 @@ But where are the data from the ADTs?
 We wouldn't necessarily want those stored in the main data matrices, as the characteristics of ADT barcode data is going to be quite different from gene expression data.
 
 To keep the ADT data separate from the RNA gene expression data, we have split this data off into an _alternative experiment_ (`altExp`) slot.
-You can see the name of this `altExp` on the line `altExpNames` above. 
+You can see the name of this `altExp` on the line `altExpNames` above.
 We _could_ have more than one type of alternative experiment (such as spike-in or ATAC-seq), but in this case, just the one.
 
 To access the contents of the `altExp` slot, we can use the `altExp()` function.
@@ -112,16 +112,16 @@ Let's look at what we have in that slot:
 altExp(sce, "ADT")
 ```
 
-It is another `SingleCellExperiment`! 
+It is another `SingleCellExperiment`!
 Inception!
 Let's look at that embedded SCE more closely.
 
-The first thing to note is that this `altExp` has the same number of columns as did the main SCE object. 
+The first thing to note is that this `altExp` has the same number of columns as did the main SCE object.
 Those corresponded to the individual cells before, and still do!
 
-There are only 10 rows, however, and these correspond to the ADTs that were assayed by this particular experiment. 
+There are only 10 rows, however, and these correspond to the ADTs that were assayed by this particular experiment.
 Just as we did with the full SCE, we can use `rowData()` to view the table containing metadata associated with each of these rows.
-We'll add the `altExp()` function to point it to the embedded object we are interested in. 
+We'll add the `altExp()` function to point it to the embedded object we are interested in.
 Since there is only one `altExp`, we don't need the second (name) argument (`"ADT"`) that we used above; the default behavior of `altExp()` is to just give us the first `altExp`, and that is the one (and only) that we need.
 
 ```{r adt rows, live=TRUE}
@@ -130,7 +130,7 @@ rowData(altExp(sce))
 ```
 
 You can see here the names and symbols of the tags used, along with the designation that all have an "Antibody Capture" type (as opposed to "Gene Expression" for the RNA data).
-One you might note looks different is the `IgG1` control, which is actually a mouse antibody used as a negative control. 
+One you might note looks different is the `IgG1` control, which is actually a mouse antibody used as a negative control.
 
 
 ### Clustering redux
@@ -145,7 +145,7 @@ While we have the ADT data, it is _not_ being used for this stage of the analysi
 # perform clustering
 nn_clusters <- bluster::clusterRows(
   # PCA input
-  reducedDim(sce, "PCA"), 
+  reducedDim(sce, "PCA"),
   # graph clustering & parameters
   bluster::NNGraphParam()
 )
@@ -154,16 +154,16 @@ nn_clusters <- bluster::clusterRows(
 sce$nn_cluster <- nn_clusters
 ```
 
-Now we can plot the clusters we have identified with `scater::plotUMAP()`. 
+Now we can plot the clusters we have identified with `scater::plotUMAP()`.
 This is a shortcut for `scater::plotReducedDim(dimred = "UMAP", ...)`, which can save us a lot of typing as we do this repeatedly!
 
 ```{r plot clusters}
 # plot clusters
-scater::plotUMAP(sce, color_by = "nn_cluster") + 
+scater::plotUMAP(sce, color_by = "nn_cluster") +
   # rename the legend
   guides(color = guide_legend(title = "Cluster"))
 ```
-But what are these clusters, really? 
+But what are these clusters, really?
 Do they correspond to particular cell types that we are interested in?
 
 Does it bother you that we just used the default nearest-neighbor graph clustering parameters?
@@ -177,7 +177,7 @@ The first way we will identify cell types of individual cells is to use the ADT 
 These antibody markers were (hopefully) chosen for their relevance to the sequenced cell population.
 
 The first marker we will look at is `CD3`, which is a protein complex that is found on the surface of T cells.
-We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels. 
+We can again use the `plotUMAP()` function to color cells by `CD3` ADT levels.
 
 Note that this function can plot data from the `colData` table (as we used it above when plotting clusters), in the main gene expression matrix (as we used it in the previous notebook), *AND* in `altExp` tables and matrices!
 So to color by the ADT levels (as normalized in the `logcounts` matrix) we only need to provide the tag name that we want to plot in the `color_by` argument.
@@ -199,13 +199,13 @@ Let's plot the ADT results for those two markers as well below:
 
 ```{r plot CD4, live=TRUE}
 # plot CD4 marker
-scater::plotUMAP(sce, 
+scater::plotUMAP(sce,
                  color_by = "CD4")
 ```
 
 ```{r plot CD8, live=TRUE}
 # plot CD8 marker
-scater::plotUMAP(sce, 
+scater::plotUMAP(sce,
                  color_by = "CD8")
 ```
 
@@ -216,15 +216,15 @@ Plotting the levels of the ADTs provides a nice visual representation, but what 
 Such classification could be considered as analogous to a cell-sorter assay, where we would set up some rules to look at a few markers for each cell and use those to assign a cell type.
 The simplest type of rule might be one where we use a threshold to call a marker as present or absent, and then use the presence of a marker to indicate a specific cell type.
 
-To do this, we will need to make some decisions, such as the thresholds we should use to determine whether a cell is or is not expressing a particular marker. 
+To do this, we will need to make some decisions, such as the thresholds we should use to determine whether a cell is or is not expressing a particular marker.
 In general, markers that are useful for this cell-typing approach will have a bimodal distribution of expression levels which can be used to separate the population into two groups of cells.
 One group of cells will have only a background level signal for each marker (due to non-specific binding or other factors), while the other group, those that express the protein, will have a much higher level of binding and higher counts.
 
 To assess whether the ADTs we have chosen have a useful distribution of expression values, and to identify thresholds we might use, we would like to plot each ADT tag.
-To do this, we will pull out the expression values for these markers from the SCE object and do some data wrangling. 
+To do this, we will pull out the expression values for these markers from the SCE object and do some data wrangling.
 
 We are interested in the normalized counts for the ADT tags, which are stored in the `logcounts` assay of the `altExp`.
-If you recall, this matrix is stored with the columns as cells and rows as markers, but we really want it with each row a cell and each column a marker. 
+If you recall, this matrix is stored with the columns as cells and rows as markers, but we really want it with each row a cell and each column a marker.
 So we will first transpose the data, then convert it to a data frame for our next steps.
 Because the SCE object stores the assay data matrices in a specialized format, we have to do one extra step convert it first to a "regular" R matrix or R won't know how to convert it to a data frame.
 
@@ -242,7 +242,7 @@ head(adt_df)
 If we just wanted to plot one of these tags, we could do so right away, but with a bit more data wrangling, we can convert these results into a "tidier" format, that will allow us to take full advantage of `tidyverse` tools!
 In particular, it will let us plot them all at once with `ggplot2` faceting.
 
-Right now the data is in a "wide" format, such that each column is a different tag. 
+Right now the data is in a "wide" format, such that each column is a different tag.
 But the data in all of the columns is the same type, and measures something similar: the normalized count of an ADT.
 One could even argue that each row contains 10 different observations, where the "tidy" data ideal, as espoused by [Wickham (2014)](https://doi.org/10.18637/jss.v059.i10), requires a single observation per row, a "long" format.
 This long format will have one column that tells us which ADT was measured and a second column with the measurement value itself.
@@ -270,7 +270,7 @@ Now we can make a density plot with `ggplot2` for all three ADTs we are interest
 
 ```{r plot ADTs, live=TRUE}
 # plot logcounts by ADT
-ggplot(adt_df_long, aes(x = logcount, fill = ADT)) + 
+ggplot(adt_df_long, aes(x = logcount, fill = ADT)) +
   geom_density() + # density plot
   facet_grid(rows = vars(ADT)) + # facet by ADT
   theme_bw() + # nicer theme
@@ -281,8 +281,8 @@ These look pretty good!
 Each of these markers has a bimodal distribution: A lower peak consisting of cells that do not express the protein but which still have a background level of antibody binding, and an upper peak of cells that do express the protein of interest.
 The background level does vary by antibody marker, so we will need a different threshold value for each one.
 
-We can now use the values from these plots to construct a set of rules to classify the T cells. 
-We will do this using the "wide" data frame from earlier. 
+We can now use the values from these plots to construct a set of rules to classify the T cells.
+We will do this using the "wide" data frame from earlier.
 
 The thresholds we are using here were identified just "by eye", so this is not a particularly principled method of cell type assignment, but it can be fairly effective.
 Here we are assigning only three cell types; cells that do not fit any of these criteria will be set as `NA`.
@@ -307,24 +307,24 @@ Creating and assigning values to this column can be done with the `$` shortcut, 
 
 ```{r plot thresholds}
 sce$threshold_celltype <- adt_df$celltype
-scater::plotUMAP(sce, 
-                 color_by = "threshold_celltype") + 
+scater::plotUMAP(sce,
+                 color_by = "threshold_celltype") +
   guides(color = guide_legend(title = "Cell type"))
 ```
 
-How did we do? 
+How did we do?
 
 Note that while we applied this technique to assign cell types using the ADT data, we could use the same type of procedure using gene expression data alone, or a combination of gene expression data and tag data.
 
 However, what we did here was very ad-hoc and quite manual!
 We didn't calculate any statistics, and we had to look at every tag we were interested in to pick thresholds.
-A different dataset might have different background levels, which would require different thresholds. 
+A different dataset might have different background levels, which would require different thresholds.
 
 While this technique might be good for some simple experiments, and can be useful for manual curation, it might not translate well to more complex datasets with multiple samples.
 We also looked at each marker separately, which might not be the most efficient or robust method of analysis.
 
 For a more principled approach that allows identification of cell types by looking at the expression of sets of genes that are known to characterize each cell type, you might look at the [`AUCell` package](https://bioconductor.org/packages/3.16/bioc/html/AUCell.html).
-For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
+For more on that method, the OSCA section [Assigning cell labels from gene sets](http://bioconductor.org/books/release/OSCA.basic/cell-type-annotation.html#assigning-cell-labels-from-gene-sets) is a very good reference.
 
 
 ## Cell type annotation with `SingleR`
@@ -332,9 +332,9 @@ For more on that method, the OSCA section [Assigning cell labels from gene sets]
 An alternative approach to using known marker genes for classification is to instead classify cells by comparing them to a reference expression dataset.
 To do this, we will find a well-curated gene expression dataset that contains samples with known cell types.
 We can then train a model based on this dataset and look at each of the cells in our new dataset to determine which (if any) of the known cell types has the most similar expression pattern.
-The details of how such a model may be constructed and trained will vary by the specific method, but this overall approach is widely applied. 
+The details of how such a model may be constructed and trained will vary by the specific method, but this overall approach is widely applied.
 
-For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/3.16/SingleRBook/).
+For this section, we will focus on the `SingleR` package and its methods, which are described in detail in [_The SingleR Book_](https://bioconductor.org/books/release/SingleRBook/).
 
 ### Reference datasets
 
@@ -343,10 +343,10 @@ At the most basic level, if the reference dataset does not include the types of 
 So we will want a reference dataset that has as many as possible of the cell types that we expect to find in our dataset, at a level of granularity that aligns with our goals.
 
 For `SingleR` that reference data can be from bulk RNA sequencing or from other single-cell experiments.
-`SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available. 
+`SingleR` is also fairly robust to the method used for gene expression quantification, which means that we can use either RNA-seq datasets or microarrays, if those are more readily available.
 
 One convenient source of cell reference data is the `celldex` package, which is what we will use here.
-This package includes functions to download a variety of well-annotated reference datasets in a common format.  
+This package includes functions to download a variety of well-annotated reference datasets in a common format.
 For more information on the datasets available, you will want to refer to [the `celldex` summary vignette](https://bioconductor.org/packages/3.16/data/experiment/vignettes/celldex/inst/doc/userguide.html).
 
 We will start by using a reference dataset of sorted immune cells from [GSE107011 (Monaco _et al._ 2019)](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE107011).
@@ -358,7 +358,7 @@ The `celldex` functions also have a convenient option to convert gene symbols to
 # Bioconductor "Hub" packages provide the option to cache
 #   downloads, but the interactive prompt can be annoying
 #   when working with notebooks.
-# These options disable the prompt by giving permission 
+# These options disable the prompt by giving permission
 #   to create the cache automatically
 ExperimentHub::setExperimentHubOption("ASK", FALSE)
 AnnotationHub::setAnnotationHubOption("ASK", FALSE)
@@ -385,37 +385,37 @@ colData(monaco_ref)
 
 There are three main columns for the sample data:
 
-- `label.main` is a more general cell type assignment.  
+- `label.main` is a more general cell type assignment.
 
 - `label.fine` is a fine-level cell type with more specific labels.
 The exact level of granularity of these `main` and `fine` designations (and indeed the label names themselves) will vary among datasets, so it is important to look at the reference to see whether it is suitable for your application.
 
-- `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier. 
-Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop. 
+- `label.ont` is a standardized [Cell Ontology](https://www.ebi.ac.uk/ols/ontologies/cl) identifier.
+Using the cell ontology can allow for more complex representations of the relationships among different cell types, but investigating that is beyond the scope of this workshop.
 
-Another component we would like to explore is how many of each of these cell types we have in the reference dataset. 
+Another component we would like to explore is how many of each of these cell types we have in the reference dataset.
 A bit of quick `dplyr` wrangling can give us the answer.
 
 ```{r count cell types}
-colData(monaco_ref) |> 
+colData(monaco_ref) |>
   as.data.frame() |>
   dplyr::count(label.main, label.fine)
 ```
 
-This is pretty good! 
+This is pretty good!
 Most cell types have 4 replicates, which is more replicates than we often find.
 
 ### What does `SingleR` do?
 
 As mentioned earlier, `SingleR` builds a model from a set of training data, and then uses that model to classify cells (or groups of cells) in new datasets.
 
-`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference dataset. 
+`SingleR` works by first identifying a set of marker genes that can be used to differentiate among the cell types in the reference dataset.
 It does this by performing pairwise comparisons among all of the cell types, and retaining the top set of genes differentiating each pair.
 The idea is that this set of genes will be the most informative for differentiating cell types.
 
 Then, for each cell, `SingleR` calculates the Spearman correlation between expression of that cell and each cell type (using the only the genes chosen earlier).
 Notably, this is a non-parametric correlation, so the scaling and normalization that we apply (or don't) should not matter!
-Note that if you used a single-cell technology that produces full-length transcripts (i.e., SMART-seq), you will probably want to convert your counts to Transcripts per Million (TPM), to allow more consistent ranking among transcripts of different lengths. 
+Note that if you used a single-cell technology that produces full-length transcripts (i.e., SMART-seq), you will probably want to convert your counts to Transcripts per Million (TPM), to allow more consistent ranking among transcripts of different lengths.
 
 The reference cell type with the highest correlation is then chosen as the cell type assignment for that cell.
 If there are multiple cell types with high scores, an optional fine-tuning step repeats the process using only the most relevant genes for those cell types.
@@ -428,7 +428,7 @@ For this we need only supply three main arguments: Our SCE object, a reference m
 We also need to be sure that our sample and the reference data use the same gene IDs, which is why we requested the Ensembl IDs when getting the reference dataset.
 
 Because this function is doing many repetitive calculations (lots of correlations!), we can speed it up by including the `BPPARAM` argument.
-This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions. 
+This is a common argument in `Bioconductor` packages where `BP` stands for the `BiocParallel` package, which provides multiprocessing capabilities to many Bioconductor functions.
 In this case, we will use the argument `BiocParallel::MulticoreParam(4)` to specify we want to use local multicore processing with 4 "workers".
 
 ```{r simple SingleR, live=TRUE}
@@ -458,7 +458,7 @@ sce$celltype_main <- singler_result$pruned.labels
 Now we can plot the cell type assignments onto our UMAP to see how they compare to the patterns we saw there before.
 
 ```{r plot celltype umap, live=TRUE}
-scater::plotUMAP(sce, color_by = "celltype_main") 
+scater::plotUMAP(sce, color_by = "celltype_main")
 ```
 Annoyingly, the `NA` and `T cells` labels are quite close in color, and the `scater` and `SingleR` packages don't agree on color choices.
 Luckily, since `plotUMAP()` returns a `ggplot` object, we can modify the color palette using `ggplot2` functions.
@@ -485,13 +485,13 @@ table(singler_result$pruned.labels, useNA = "ifany")
 
 ### Exploring finer labels
 
-In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the dataset in a bit more detail. 
+In the previous cell typing, we used the `label.main` column, but we also had `label.fine`, so let's use that to explore the dataset in a bit more detail.
 
-We will also take this time to dive a bit deeper into the steps that `SingleR` performed. 
+We will also take this time to dive a bit deeper into the steps that `SingleR` performed.
 As mentioned, the first step is training the model, during which we identify the genes that will be used for the correlation analysis later.
 While this step is not particularly slow, if we were classifying multiple samples, we would not want to have to repeat it for every sample.
 
-To do the training, we will use the `trainSingleR()` function. 
+To do the training, we will use the `trainSingleR()` function.
 For this we will start with our reference and the labels we want to train the model with.
 
 We can then specify the method used to select the genes that will be used for classification.
@@ -499,10 +499,10 @@ The default method is `"de"`, which performs a differential expression analysis 
 If we want to get really fancy, we could even provide a specific list of genes to use.
 
 We should note here that the reference dataset for `SingleR` does not need to be from a compendium like `celldex`!
-If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample. 
-You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible. 
+If you have any well-classified dataset that you want to use as a reference, you can, as long as you can create a gene by sample expression matrix and a vector of cell types for each sample.
+You will want to ensure that the cell types you expect to see in your sample are present in the reference dataset, and data should be normalized, but otherwise the method can be quite flexible.
 You can even use a previously-annotated `SingleCellExperiment` as a reference for a new dataset.
-For more details about custom references, see the [OSCA chapter on cell type annotation](http://bioconductor.org/books/3.16/OSCA.basic/cell-type-annotation.html#using-custom-references)
+For more details about custom references, see the [OSCA chapter on cell type annotation](http://bioconductor.org/books/release/OSCA.basic/cell-type-annotation.html#using-custom-references)
 
 We do want to be sure that the genes selected for the model will be among those present in our SCE object, so we will use the `restrict` argument with a vector of the genes in our SCE.
 This step would happen automatically with the `SingleR::SingleR()` function, but we need to add it manually for this use case.
@@ -514,7 +514,7 @@ singler_finemodel <- SingleR::trainSingleR(
   monaco_ref, # reference dataset
   labels = monaco_ref$label.fine, # labels for training dataset
   # use DE to select genes (default)
-  genes = "de", 
+  genes = "de",
   # only use genes in the sce object
   restrict = rownames(sce),
   # parallel processing
@@ -556,7 +556,7 @@ The `NA` cells also got taken off completely, which is not ideal.
 
 One thing we can do is to use some functions from the `tidyverse` package [`forcats`](https://forcats.tidyverse.org), which can be very handy for dealing with categorical variables like these cell types.
 
-We will use two of these functions in the chunk below: 
+We will use two of these functions in the chunk below:
 First we will use `fct_collapse` to take some of the finer labels that we might not be as interested in and collapse them into logical groupings (in this case, the `main` label that they were part of).
 After that, we will use `fct_relevel` to put the remaining factor levels in the order we would like them to appear for plotting.
 
@@ -564,8 +564,8 @@ After that, we will use `fct_relevel` to put the remaining factor levels in the 
 collapsed_labels <- singler_result_fine$pruned.labels |>
   forcats::fct_collapse(
     "Monocytes" = c(
-        "Classical monocytes", 
-        "Intermediate monocytes", 	
+        "Classical monocytes",
+        "Intermediate monocytes",
         "Non classical monocytes"),
     "Dendritic cells" = c(
         "Myeloid dendritic cells",
@@ -576,8 +576,8 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
         "Vd2 gd T cells"),
     "Helper T cells" = c(
         "Th1 cells",
-        "Th1/Th17 cells", 
-        "Th17 cells", 
+        "Th1/Th17 cells",
+        "Th17 cells",
         "Th2 cells",
         "Follicular helper T cells"),
     "B cells" = c(
@@ -585,7 +585,7 @@ collapsed_labels <- singler_result_fine$pruned.labels |>
         "Switched memory B cells",
         "Non-switched memory B cells",
         "Exhausted B cells",
-        "Plasmablasts"		
+        "Plasmablasts"
     )
   ) |>
   # order for plotting
@@ -612,7 +612,7 @@ Now that we have that set up, we can plot using our collapsed and ordered cell t
 
 ```{r plot collapsed, live=TRUE}
 sce$celltype_collapsed <- collapsed_labels
-scater::plotUMAP(sce, 
+scater::plotUMAP(sce,
                  color_by = "celltype_collapsed")
 ```
 
@@ -621,7 +621,7 @@ scater::plotUMAP(sce,
 
 Let's look at how the cell type assignments we obtained using `SingleR` compare to the clusters that we found using the unsupervised clustering at the start of this notebook.
 
-To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with. 
+To do this, we will again use the `table()` function, but now with two vectors as input, to build a contingency table of the cell types and clusters that each cell was classified with.
 
 ```{r type cluster table}
 # create a table of clusters & cell type counts
@@ -633,20 +633,20 @@ type_cluster_tab[1:5, 1:5]
 
 As you can see, this produced a table with rows for each cell type and columns for each cluster number.
 The values are the count of cells for each cluster/cell type combination.
-However, these raw counts are not quite what we'll want for visualization. 
+However, these raw counts are not quite what we'll want for visualization.
 Since the total number of cells differs across clusters, we'd like to convert these counts into the _proportions_ of each cell type in each cluster.
 
 We'll do this by going through the table column by column and dividing each value by the sum for that cluster.
 This will give us normalized values where the values in each column now sum to 1.
 To do that, we will use the `apply` function, which allows us to operate on a matrix row by row or column by column, applying a function to each "slice".
-Since the function we want to apply is very short, we will use R's new (as of  version 4.1) anonymous function shorthand: 
+Since the function we want to apply is very short, we will use R's new (as of  version 4.1) anonymous function shorthand:
 `\(x) ...` can be used to define a function that that takes as input values `x` (where the `...` is where you would put the expression to calculate).
 Here we will apply the expression `x/sum(x)`, which will divide each element of a vector `x` by the sum of its values.
 
 ```{r normalize by column}
 # normalize by the number of cells in each cluster (columns)
 type_cluster_tab <- apply(
-  type_cluster_tab, 
+  type_cluster_tab,
   2, # apply function to columns
   \(x) x/sum(x) # function to apply
 )
@@ -654,7 +654,7 @@ type_cluster_tab <- apply(
 type_cluster_tab[1:5, 1:5]
 ```
 
-Now we can plot these results as a heatmap, using the `pheatmap` package. 
+Now we can plot these results as a heatmap, using the `pheatmap` package.
 There is a lot of customization we could do here, but `pheatmap` (pretty heatmap) has good defaults, so we won't spend too much time on it for now.
 
 ```{r cluster heatmap, live=TRUE}
@@ -667,11 +667,11 @@ There are also some places where single cell types are spread across a few diffe
 
 ### Classifying by clusters
 
-While most of the time we will want to classify single cells, sometimes the sparseness of the data may mean that individual cells do not provide reliable estimates of cell types. 
+While most of the time we will want to classify single cells, sometimes the sparseness of the data may mean that individual cells do not provide reliable estimates of cell types.
 
 An alternative approach is to classify the clusters as a whole, assuming that the clusters we have identified represent a single cell state.
-If that is the case, then we should be able to combine the data for all cells across each cluster, then apply our cell typing method to this group of cells. 
-This is similar to an approach we will return to later in the context of differential expression. 
+If that is the case, then we should be able to combine the data for all cells across each cluster, then apply our cell typing method to this group of cells.
+This is similar to an approach we will return to later in the context of differential expression.
 
 The first step here is to create a new matrix where we sum the counts across cells that are from the same type according to our clustering.
 Because `SingleR` is a non-parametric approach, we can perform this step with the raw counts matrix.
@@ -703,7 +703,7 @@ head(singler_cluster)
 ```
 
 The result is a fairly small table of results, but we are most interested in the labels, which we would like to associate with each cell in our SCE object for visualization.
-Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to. 
+Since the cluster labels are the row names of that table, we can perform a cute little trick to assign labels back to each cell based on the name of the cluster that it was assigned to.
 (In this case the cluster names are all numbers, but that might not always be the case.)
 We'll select values repeatedly from the `singler_cluster` table, using the cluster assignment to pick a row, and then always picking the `pruned.labels` column.
 
@@ -717,14 +717,14 @@ Now we can plot these cluster-based cell type assignments using the now familiar
 scater::plotUMAP(sce, color_by = "celltype_cluster")
 ```
 
-This sure looks nice and clean, but what have we really done here? 
+This sure looks nice and clean, but what have we really done here?
 We are _assuming_ that each cluster has only a single cell type, which is a pretty bold assumption, as we really aren't sure that the clusters we created were correct.
 You may recall that clustering algorithms are quite sensitive to parameter choice, so a different parameter choice could quite likely give a different result.
 
 ### MetaCell approaches
 
-As a middle ground between the potentially messy single-cell cell type assignment and the almost-certainly overconfident cluster-based assignment above, we can take approach inspired by [Baran _et al._ (2019)](https://doi.org/10.1186/s13059-019-1812-2) using something they called _metacells_. 
-The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters as "metacells" to use for further analysis. 
+As a middle ground between the potentially messy single-cell cell type assignment and the almost-certainly overconfident cluster-based assignment above, we can take approach inspired by [Baran _et al._ (2019)](https://doi.org/10.1186/s13059-019-1812-2) using something they called _metacells_.
+The idea is that we can perform fine-scaled clustering to identify groups of very similar cells, then sum the counts within those clusters as "metacells" to use for further analysis.
 The original paper includes a number of optimizations to make sure that the metacell clusters have desirable properties for downstream analysis.
 We won't go into that depth here, but we can apply similar ideas.
 
@@ -736,9 +736,9 @@ While this is almost certainly more clusters than are "real" in this dataset, ou
 ```{r kmeans cluster}
 # perform k-means clustering
 kclusters <- bluster::clusterRows(
-  reducedDim(sce, "PCA"), 
+  reducedDim(sce, "PCA"),
   bluster::KmeansParam(
-    centers = 100, # the number of clusters 
+    centers = 100, # the number of clusters
     iter.max = 100 # more iterations to be sure of convergence
   )
 )
@@ -752,7 +752,7 @@ metacell_mat <- DelayedArray::colsum(counts(sce), kclusters)
 
 # apply SingleR model to metacell matrix
 metacell_singler <- SingleR::classifySingleR(
-  metacell_mat, 
+  metacell_mat,
   singler_finemodel
 )
 
@@ -766,13 +766,13 @@ Now we can plot the results as we have done before.
 scater::plotUMAP(sce, color_by = "celltype_metacell")
 ```
 
-What do you think of this plot? 
+What do you think of this plot?
 Is this more or less useful than the original cell-based clustering?
 
 
 ## Save results
 
-To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there. 
+To save disk space (and time), we won't write out the whole SCE object, as we haven't changed any of the core data there.
 Instead we will just write out the cell information table (`colData`) as a TSV file.
 
 ```{r save cell info, live=TRUE}


### PR DESCRIPTION
Closes #773 
This PR does some miscellaneous training material updates. Some of the items noted in #773 apparently have been fixed in the meantime, so we get those for free - I edited those comments directly to reflect that they have been done already.

Changes I made include:

- Load `alevinQC` directly (https://github.com/AlexsLemonade/training-modules/issues/773#issuecomment-2161234296)
- Use `theme_set(theme_bw())` in `scRNA-seq/03-normalizing_scRNA.Rmd`, whose plots only ever uses this theme
- Update OSCA links
  - I updated other bioconductor links while doing this too, as discussed: https://github.com/AlexsLemonade/training-modules/issues/773#issuecomment-2686003590
  - (edit) I did this for the scRNA-seq-advanced module too, because might as well
  
PSA: turn off whitespace for review, since VS Code deleted a bunch of EOL whitespace