### PR TITLE
Remove the extra seed

### DIFF
--- a/scRNA-seq-advanced/05-aucell.Rmd
+++ b/scRNA-seq-advanced/05-aucell.Rmd
@@ -44,9 +44,6 @@ We will use an snRNA-seq of a Ewing sarcoma sample from the [`SCPCP000015` proje
 ### Libraries
 
 ```{r setup}
-# set seed for reproducibility
-set.seed(2025)
-
 # We will be loading a SingleCellExperiment object into our environment but don't need to see the startup messages
 suppressPackageStartupMessages({
   library(SingleCellExperiment)


### PR DESCRIPTION
Missed this in https://github.com/AlexsLemonade/training-modules/pull/849 - I had added a seed to this notebook in #846, but turns out it already had a seed!
https://github.com/AlexsLemonade/training-modules/blob/44b975629e2274109133e8ccbd32a64593346f14/scRNA-seq-advanced/05-aucell.Rmd#L185-L192

I removed the new and unneeded seed.

 After this I will re-run the GHA to render notebooks.