### PR TITLE
It's december, not dec

### DIFF
--- a/current-modules.json
+++ b/current-modules.json
@@ -1,5 +1,5 @@
 {
-  "release-tag": "2025-dec",
+  "release-tag": "2025-december",
   "modules": ["scRNA-seq-advanced"],
   "reference-modules": ["scRNA-seq"]
 }


### PR DESCRIPTION
Fun fact: `2025-dec != 2025-december`, which I learned from: https://github.com/AlexsLemonade/training-modules/actions/runs/19673083021

Will redo the release once this goes in! fwiw everything looked as expected for the `edge` docker image last pushed.
