### PR TITLE
Remove platform  instructions from docker pull

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ In practice, this means that you will not need to add individual R packages to t
 To use the Docker image for development, pull from Docker Hub with:
 
 ```
-docker pull --platform linux/amd64 ccdl/training_rstudio:edge
+docker pull ccdl/training_rstudio:edge
 ```
 
 To run the container and mount a local volume, use the following from the root of this repository:

--- a/workshop-releases.md
+++ b/workshop-releases.md
@@ -76,7 +76,7 @@ You can also test the Docker image locally, which may be more convenient for tes
 To test the Docker image locally, you can use the following commands to pull the Docker image and run launch the container with an RStudio server session:
 
 ```bash
-docker pull --platform linux/amd64 ccdl/training_rstudio:edge
+docker pull ccdl/training_rstudio:edge
 docker run \
   -e PASSWORD={PASSWORD} \
   -p 8787:8787 \


### PR DESCRIPTION
Now that we have multi-platform builds, we don't need to pull with a specific platform anymore! So here I am updating the two places in this repo that mention that.

Please test that this all works for you as well!

If so, closes #888


