### PR TITLE
Bump irlba version in renv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     fastqc \
     && apt-get clean
 
-
 # Python packages
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt --break-system-packages


### PR DESCRIPTION
May or may not close #907 

In this PR, I'm updating `irlba` to the most recent version. This time, I did the update on the RStudio Server, and there were no other changes besides `irlba` versioning in the snapshot....except for that one record which got changed from RSPM -> CRAN, but it is my understanding from comments in #905 that we accept our fate for that one.

To confirm, the normalization notebook which gave us the error in #906 is still running fine in this updated environment on the server for me.

Once this updated Docker image gets pushed, we can try again to run the GHA in #906 and see if this made an impact.