### PR TITLE
Make sure that rm steps execute after renv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,9 +78,9 @@ RUN Rscript -e "install.packages('renv')"
 
 COPY renv.lock renv.lock
 RUN Rscript -e "renv::restore()" \
-    rm -rf ~/.cache/R/renv && \
-    rm -rf /tmp/downloaded_packages && \
-    rm -rf /tmp/Rtmp*
+    && rm -rf ~/.cache/R/renv \
+    && rm -rf /tmp/downloaded_packages \
+    && rm -rf /tmp/Rtmp*
 
 # copy aws, salmon, and fastp binaries from the build image
 COPY --from=build /usr/local/aws-cli/ /usr/local/aws-cli/


### PR DESCRIPTION
We were missing an `&&` which meant that the steps meant to reduce the size of the layer that installs all of the R packages were not executing. This was bloating the image, so we may be able to get a good amount of space back with this change.

related to #912 