### PR TITLE
Add filtering text to intro spatial notebook

### DIFF
--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -378,7 +378,7 @@ However, we'll learn in the following sections that we interpret and use these s
 
 ### Exploring global QC thresholds
 
-As a first step towards filtering, we'll calculate QC statitics and explore their distributions.
+As a first step towards filtering, we'll calculate QC statistics and explore their distributions.
 We'll use `scran::addPerCellQC()` to calculate these statistics; even though the function is called "per-cell," in this case it will calculate per _spot_.
 
 First we need to import our list of mitochondrial genes to use as part of these calculations.
@@ -512,7 +512,7 @@ These are spots whose properties differ from their local neighborhood of nearby 
 For this, we'll use the [`SpotSweeper`](https://www.bioconductor.org/packages/3.22/bioc/vignettes/SpotSweeper/inst/doc/getting_started.html) package, which offers several useful tools for quality control of spot-based data.
 
 We'll specifically their local outlier detection function `SpotSweeper::localOutliers()`.
-This function uses a k-nearest neighbors approach to define the neighbhorhood for each spot and then calculates _local_ means and variances of standard QC metrics to identify outlying spots within their local tissue context.
+This function uses a k-nearest neighbors approach to define the neighborhood for each spot and then calculates _local_ means and variances of standard QC metrics to identify outlying spots within their local tissue context.
 This approach reduces the chance that we'll bias filtering by tissue biology because we generally expect nearby spots in the same tissue region to be more biologically similar to each other. 
 
 (It's also worth noting that `SpotSweeper` also has the ability to detect so-called "hangnails," which are regional technical artifacts resulting from issues with tissue preparation.
@@ -558,7 +558,7 @@ colData(filtered_spe)
 * `sum_log`: The `log1p()` (i.e., `log(x+1)`) of the `sum` column.
 * `sum_outliers`: Whether or not the spot is a _local_ outlier in its local neighborhood.
 Generally we'll want to filter out rows where this is `FALSE`
-* `sum_z`: The _local_ z-score for `sum_log` used for identifying outliers relative to the specified cutff (here, 3)
+* `sum_z`: The _local_ z-score for `sum_log` used for identifying outliers relative to the specified cutoff (here, -3)
   * A value of 0 means the spot is, on average, the same as its neighbors
   * A high positive value means the spot has a much higher `sum` than its local neighborhood
   * A low negative value means the spot has a much lower `sum` than its local neighborhood.

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -313,12 +313,18 @@ We can override this if we want, but we really want to remove those spots entire
 
 ## Filtering empty spots
 
-We only care about spots on top of tissue, so let's begin by removing the `in_tissue = 0` spots.
-Note that if we had read in the `filtered_feature_bc_matrix` instead, the data would already be filtered to only `1` in this column, but we need to take this step because we read in the `raw`. 
-We can make a rough analogy, that this analysis step is like filtering empty droplets to retain only droplets with cells in scRNA-seq, but here we're retaining only spots over tissue.
+As stated, let's go ahead and remove those spots entirely.
+As a rough analogy, this analysis step is reminiscent of filtering empty droplets from single-cell data retain only droplets with cells, but in this case we want to retain only spots that overlap tissue.
 
-We can visualize which spots those are, and we'll do it over the H&E to clearly see the relationship.
-We'll use the `annotate` argument, but `plotVisium` sees that this column is an integer and forces it to use a continuous color scale; we'll go ahead and make it a factor version of it to plot with.
+Again, we need to take this step because we read in the `raw_feature_bc_matrix` output from 10x. 
+Had we read in the `filtered_feature_bc_matrix` instead, the data would already be filtered to only contain spots overlapping tissue. 
+Generally in your own analyses, it's very safe (and with other related Visium technologies, it's in fact recommended!) to start by reading in the `filtered_feature_bc_matrix`.
+Here, we're taking these steps to ensure a thorough exploration of the SPE object.
+
+Before we filter, it can help to visualize which spots we'll remove.
+We'll plot this on top of the H&E using `ggspavis::plotVisium()` to be able to clearly see the relationship between coordinates and tissue.
+For this, we'd like to  use the `annotate` argument to color by the `in_tissue` column, but `ggspavis` interprets this column as an integer and forces it to use a continuous color scale.
+So, before plotting, we'll recast this value to a factor so we can plot it as a discrete variable.
 
 ```{r plot_in_tissue}
 #| fig.width: 7
@@ -341,8 +347,12 @@ ggspavis::plotVisium(
   )
 ```
 
-- The purple tissue overhang on the left isn't colored at all - indeed, there aren't spots at those coordinates outside the slide
-- Red points are those to filter out - they are uninformative since they don't overlap tissue.
+In this plot, we see the following:
+
+* The purple tissue overhang on the left isn't colored at all; these spots are outside fiducial alignment frame and have no corresponding spots
+* The red points represent those we want to filter out as uninformative
+
+Let's go ahead and filter:
 
 ```{r filter_in_tissue, live = TRUE}
 # keep only spots that are in the tissue and save to filtered_spe
@@ -352,8 +362,8 @@ filtered_spe <- spe[, spe$in_tissue == 1]
 filtered_spe
 ```
 
-Now, we're down to 4210 spots from the original 4992, but that's still a pretty good amount. 
-But not all of these spots are necessarily good quality, so we'll want to do some additional QC filtering next.
+We've kept 4210 spots of the original 4992, meaning that the vast majority of spots are over tissue.
+But not all of those spots are necessarily good quality, so we'll want to do some additional QC filtering next.
 
 ## Filtering low-quality spots
 
@@ -363,8 +373,8 @@ When identifying low-quality spots in Visium data, we can use similar QC statist
 * Number of unique detected genes
 * Percentage of mitochondrial reads, where high values indicate cell damage
 
-However, unlike with scRNA-seq data, how we interpret and use these statistics is going to be somewhat different. 
-    
+However, we'll learn in the following sections that we interpret and use these statistics is somewhat differently from single-cell data.
+
 ### Exploring global QC thresholds
 
 As a first step towards filtering, we'll calculate QC statitics and explore their distributions.
@@ -393,7 +403,7 @@ filtered_spe <- scuttle::addPerCellQC(
 colData(filtered_spe) |> head()
 ```
 
-Let's go ahead and look at the distributions of these statistics to see how many spots appear to be low-quality.
+We'll first look at the distributions of these statistics (always plots your data!) to see how many spots appear to be low-quality.
 
 ```{r global qc distributions}
 #| fig.width: 12
@@ -427,23 +437,24 @@ qc_plot_sum + qc_plot_detected + qc_plot_mito
 ```
 
 If you've worked with single-cell data lately, these distributions might look different from what you might have expected.
-In single-cell data, these distributions usually show a strong skew for low-quality cells, either with very few total UMIs or detected genes or with a very high mitochondrial percentage.
+In single-cell data, these distributions usually have long tails comprising low-quality cells that either have very few total UMIs, very few detected genes, or a very high mitochondrial percentage.
 
-But here, we see three unimodal distributions, and the tails seen in the `detected` and `subsets_mito_percent` distributions aren't really suggestive of low-quality spots. 
-We might be tempted to use these tails to inform global thresholds for filtering, but a closer look suggests that might not be what we want.
-For example, a natural threshold for this `subsets_mito_percent` distribution might be around 4%, but that's actually quite low mitochondrial percentage that does _not_ actually suggest cell damage so removing those spots would not actually help us here. 
+Here, we see three unimodal distributions without much skew, although the `detected` and `subsets_mito_percent` distributions do show some tails potentially indicating low-quality spots.
+We might be tempted to use these tails to inform global thresholds for filtering, but a closer look suggests that likely wouldn't help remove low-quality spots.
+For example, a natural threshold for this `subsets_mito_percent` distribution might be around 4%, but that's actually quite low mitochondrial percentage that does _not_ actually suggest those spots contain damaged cells. 
 
 What's actually going on here, and what should we do about it?
 
-* First, because each sequenced spot is an aggregate of cells, quality issues in individual cells can end up being smoothed out by their neighbors, so we may not easily perceive those signatures in per-spot statistics. 
+* First, because each sequenced spot is an aggregate of cells, quality issues in individual cells can end up being smoothed out by their neighbors, so we may not easily perceive those signatures in per-spot statistics.
 * Second, the technical factors that affect spatial transcriptomic data quality are fundamentally different from the factors that affect single-cell data quality.
 In single-cell data, differences in cell capture across droplets are a main source of quality issues that lead to cell damage or cells with very few UMIs or genes.
 Due to fundamental differences in library preparation, this is not a factor in spatial transcriptomic data; instead, problems with tissue preparation (e.g., tissue did not lay flat on the slide or was not permeabilized homogeneously) tend to be a more significant factor driving differences in QC statistics. 
 * Third, the biological heterogeneity in the tissue means that using global thresholds to filter has substantial potential to _bias_ analysis.
 For example, if a particular tissue compartment is dominated by cell types which naturally have lower expression, we might end up filtering out meaningful regions of the tissue.
-As such, the QC statistics themselves can be confounded with spatial biology, we we need to be mindful to not filter too aggressively.
+As such, the QC statistics themselves can be confounded with spatial biology.
+Filtering using global thresholds assumes that signal from low-quality cells (or spots) should trump signal from biological heterogeneity, but this assumption is not clearly met for spatial data.
 
-To get a clearer view of the relationship between QC statistics and tissue biology, we'll plot those same QC statistics directly on the slide coordinates to see their full spatial context.
+To see their full spatial context, we'll plot those same QC statistics directly on the slide coordinates to see their full spatial context.
 We'll also include the H&E plot here to be able to quickly compare patterns seen in each panel.
 
 ```{r global qc coords}
@@ -488,16 +499,16 @@ patchwork::wrap_plots(
 
 Compare the H&E image to these statistics: do you notice any patterns that suggest the statistics are confounded by spatial biology, in particular between stromal and blastemal regions?
 
-This shows us that if we were to filter out, for example, spots with overall lower total UMIs or detected genes, we would end up primarily if not only removing spots in stromal regions, which is probably not what we want! 
-As such, using global thresholds is not going to be suitable for spatial data, so we'll want to use a different approach to filter spots.
-(It's worth noting however this is not strictly a spatial transcriptomics issue; it's very possible for differences among cell types to confound QC statistics in single-cell data.
+This shows us that if we were to filter out, for example, spots with overall lower total UMIs or detected genes, we would end up primarily (if not only) removing spots in stromal regions, which is probably not what we want! 
+As such, using global thresholds is not going to be suitable for spatial data, so we'll need a different approach to filter spots.
+(It's worth noting that this is not strictly a spatial transcriptomics issue; it's very possible for differences among cell types to confound QC statistics in single-cell data too!
 Always plot your data to make sure your filters make sense for your data!)
 
 ### Filtering with local QC thresholds
 
 Rather than finding outliers based on overall QC statistics derived across biologically distinct tissue regions, we can instead look for _local_ outliers to filter.
 These are spots whose properties differ from their local neighborhood of nearby spots. 
-For this, we'll use the [`SpotSweeper`](https://www.bioconductor.org/packages/3.22/bioc/vignettes/SpotSweeper/inst/doc/getting_started.html) package, which offers several useful tools for quality control of spot-based data:
+For this, we'll use the [`SpotSweeper`](https://www.bioconductor.org/packages/3.22/bioc/vignettes/SpotSweeper/inst/doc/getting_started.html) package, which offers several useful tools for quality control of spot-based data.
 
 We'll specifically their local outlier detection function `SpotSweeper::localOutliers()`.
 This function uses a k-nearest neighbors approach to define the neighbhorhood for each spot and then calculates _local_ means and variances of standard QC metrics to identify outlying spots within their local tissue context.
@@ -522,7 +533,7 @@ Their hangnail detection uses variance in mitochondrial percentages, and since o
   * Lower values mean filtering will more strict (less tolerant of outliers, so more spots will be removed)
 
 
-Let's start off by looking for library size (column `sum` column) outliers:
+Let's start off by looking for outliers in the `sum` column, which represents library size (total UMIs).
 
 ```{r spotsweeper-sum, live = TRUE}
 filtered_spe <- SpotSweeper::localOutliers(
@@ -535,8 +546,7 @@ filtered_spe <- SpotSweeper::localOutliers(
 )
 ```
 
-
-What do we have now?
+What's in our `colData` now?
 
 ```{r coldata-spotsweeper-sum, live = TRUE}
 colData(filtered_spe)
@@ -544,7 +554,7 @@ colData(filtered_spe)
 
 `SpotSweeper` gave us a couple new columns:
 
-* `sum_log`: The `log1p()` (i.e., `log(x+1)`) of the `sum` column
+* `sum_log`: The `log1p()` (i.e., `log(x+1)`) of the `sum` column.
 * `sum_outliers`: Whether or not the spot is a _local_ outlier in its local neighborhood.
 Generally we'll want to filter out rows where this is `FALSE`
 * `sum_z`: The _local_ z-score for `sum_log` used for identifying outliers relative to the specified cutff (here, 3)
@@ -553,7 +563,7 @@ Generally we'll want to filter out rows where this is `FALSE`
   * A low negative value means the spot has a much lower `sum` than its local neighborhood.
   These are the spots we'll want to filter out
   
-Let's look at some of these values directly by plotting `sum_z` (local outlier statistics) against `sum_log` (log of a globally-calculated stat).
+Let's look at some of these values directly by plotting `sum_z against `sum_log`.
 
 ```{r sum_log_z_plot}
 # extract data frame for plotting
@@ -573,10 +583,10 @@ ggplot2::ggplot(filtered_spe_coldata) +
 We see here that most spots are not outliers for the `sum` metric.
 Most of the spots classified as outliers are fairly close to the -3 cutoff, but several are more extreme outliers.
 
-We also gain some insight from this plot about how performing filtering using global vs local outliers would play out.
+We also learn from this plot how performing filtering using global vs local outliers would play out.
 Imagine if we had performed global filtering with a threshold of 500, which has a log of 6.21.
-At a cutoff of `sum_log = 6.21, we would only have removed three spots.
-But, by using local outlier detection, we have identified several more spots to remove whose `sum` is much lower than their immediately surrounding spots, suggesting potential quality issues.
+At a cutoff of `sum_log = 6.21`, we would only have removed three spots.
+By using local outlier detection, we have identified several more spots to remove whose `sum` is much lower than their immediately surrounding spots, suggesting potential quality issues.
 On the whole though, this dataset is fairly good quality so there aren't many of these low-quality spots.
 
 We can also plot these results on the coordinates themselves, using the H&E image as a guide for interpretation.
@@ -618,7 +628,6 @@ sum_log_plot + sum_z_plot
 These plots show us how spots are distributed across the tissue.
 Are there spots you would expect to be flagged for filtering based on the `sum_log` plot?
 Are there spots you might not have expected to be filtered based on the `sum_log` plot?
-
 
 We can take the same approach for local outlier detection for the `detected` and `subsets_mito_percent` columns, and we'll proceed with the default cutoff of 3 with the default neighborhood size of 36.
 We'll do this one at a time below.

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -95,7 +95,7 @@ The count data is generally provided in two main formats, just as Cell Ranger wo
 1. A folder with a feature list, a barcode list, and a sparse matrix in ["Matrix Exchange" format](https://math.nist.gov/MatrixMarket/formats.html), and 
 2. An `HDF5` formatted file containing all this information.
 
-Because the data we're working with comes from the ScPCA Portal which only provides the folder format, that's what we'll read in here!
+Because the data we're working with comes from the ScPCA Portal which only provides the folder format, that's what we'll read in here.
 
 Space Ranger also outputs both filtered and raw matrices; today we will start with the raw matrix and perform all of our own filtering.
 
@@ -181,7 +181,7 @@ To import Visium data with the `VisiumIO` package, we'll need to specify three i
 - The path to the Space Ranger spatial output, which corresponds to the `spatial` directory
 - Which image(s) should be imported into the object
 
-By default, this function will try to import several images types, including the CytAssist image which we don't have here! 
+By default, this function will try to import several images types, including the CytAssist image which we don't have here.
 So, in this case we'll specify to import only the `lowres` version of the image.
 
 
@@ -237,7 +237,7 @@ colData(spe) |>
   head()
 ```
 
-The `colData` shows us spot coordinate information on the Visium slide, as well as an `in_tissue` column which is an important one!
+The `colData` shows us spot coordinate information on the Visium slide, as well as an `in_tissue` column which is an important one.
 An `in_tissue` value of 1 indicates spots that do overlap tissue, and a value of 0 indicates spots that don't.
 
 **Unlike** SCE objects, SPE objects contain two additional slots with spatial information.
@@ -269,7 +269,7 @@ This package contains a couple key functions we'll use to plot:
 - `ggspavis::plotVisium()`: Plot the tissue H&E image, with or without spots
 - `ggspavis::plotCoords()`: Plot the spots without the tissue
 
-Let's try it out!
+Let's try it out:
 
 ```{r plot-visium, live = TRUE}
 #| fig.width: 7
@@ -319,7 +319,7 @@ As a rough analogy, this analysis step is reminiscent of filtering empty droplet
 
 Again, we need to take this step because we read in the `raw_feature_bc_matrix` output from 10x. 
 Had we read in the `filtered_feature_bc_matrix` instead, the data would already be filtered to only contain spots overlapping tissue. 
-Generally in your own analyses, it's very safe (and with other related Visium technologies, it's in fact recommended!) to start by reading in the `filtered_feature_bc_matrix`.
+Generally in your own analyses, it's very safe (and with other related Visium technologies, it's often recommended) to start by reading in the `filtered_feature_bc_matrix`.
 Here, we're taking these steps to ensure a thorough exploration of the SPE object.
 
 Before we filter, it can help to visualize which spots we'll remove.
@@ -500,7 +500,7 @@ patchwork::wrap_plots(
 
 Compare the H&E image to these statistics: do you notice any patterns that suggest the statistics are confounded by spatial biology, in particular between stromal and blastemal regions?
 
-This shows us that if we were to filter out, for example, spots with overall lower total UMIs or detected genes, we would end up primarily (if not only) removing spots in stromal regions, which is probably not what we want! 
+This shows us that if we were to filter out, for example, spots with overall lower total UMIs or detected genes, we would end up primarily (if not only) removing spots in stromal regions, which is probably not what we want.
 As such, using global thresholds is not going to be suitable for spatial data, so we'll need a different approach to filter spots.
 (It's worth noting that this is not strictly a spatial transcriptomics issue; it's very possible for differences among cell types to confound QC statistics in single-cell data too.
 Always plot your data to make sure your filters make sense for your data!)
@@ -760,7 +760,7 @@ So, we'll instead use a "library size normalization approach" which treats each 
 It corrects for sequencing depth without smoothing out any heterogeneous signal.
 
 It's worth noting this approach doesn't take spatial information directly into account; there are some approaches out there which account for spatial information, but this aspect of analysis seems to be pretty in flux. 
-Also, bear in mind the caveat that in some cases library size itself is [also confounded with spatial structure](https://link.springer.com/article/10.1186/s13059-024-03241-7); so, keep your eyes peeled for normalization developments, since this space is evolving rapidly!
+Also, bear in mind the caveat that in some cases library size itself is [also confounded with spatial structure](https://link.springer.com/article/10.1186/s13059-024-03241-7); so, keep your eyes peeled for normalization developments, since this space is evolving rapidly.
 
 ```{r normalize-spe, live = TRUE}
 # calculate size factors

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -237,7 +237,7 @@ colData(spe) |>
   head()
 ```
 
-The `colData` shows us spot coordinate information on the Visium slide, as well as an `in_tissue` column --- it's an important one!
+The `colData` shows us spot coordinate information on the Visium slide, as well as an `in_tissue` column which is an important one!
 An `in_tissue` value of 1 indicates spots that do overlap tissue, and a value of 0 indicates spots that don't.
 
 **Unlike** SCE objects, SPE objects contain two additional slots with spatial information.
@@ -278,7 +278,8 @@ ggspavis::plotVisium(spe)
 ```
 
 Here, we see the spots overlaid on the slide as well as slide boundaries.
-You'll notice that every single spot is shown, including ones that don't overlap tissue directly --- indeed, all 4992 spots are present in the object right now.
+You'll notice that every single spot is shown, including ones that don't overlap tissue directly.
+Indeed, all 4992 spots are present in the object right now.
 
 By default, `ggspavis::plotVisium()` shows the spots, but we can hide them and zoom into the tissue on the slide.
 This is a helpful way to pop up the H&E for side-by-side comparisons with other plots we might make (foreshadowing!).

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -495,35 +495,36 @@ Always plot your data to make sure your filters make sense for your data!)
 
 ### Filtering with local QC thresholds
 
-Rather than finding outliers based on overall QC statistics derived across biologically distinct tissue regions, we can instead look for _local_ outliers to filter, i.e. spots with properties that deviate from their neighborhood of nearby spots.
-Placeholder text to introduce [`SpotSweeper`](https://www.bioconductor.org/packages/3.22/bioc/vignettes/SpotSweeper/inst/doc/getting_started.html):
+Rather than finding outliers based on overall QC statistics derived across biologically distinct tissue regions, we can instead look for _local_ outliers to filter.
+These are spots whose properties differ from their local neighborhood of nearby spots. 
+For this, we'll use the [`SpotSweeper`](https://www.bioconductor.org/packages/3.22/bioc/vignettes/SpotSweeper/inst/doc/getting_started.html) package, which offers several useful tools for quality control of spot-based data:
 
-- Evaluates spots relative to their local neighborhood which is defined with `kNN`
-- Calculates local means and variances of standard QC metrics to flag outliers for removal within a local tissue context
-- Can be used to find both individual outlying spots as well as so-called "hangnails" which are regional artifacts caused by e.g. issues in tissue prep or other technical issues
-  - Note that hangnail detection is performed using variance in mitochondrial percentages. 
-  Since our values for mitochondrial percentage are very low with minimal variance, hangnail detection won't be relevant for us here
+We'll specifically their local outlier detection function `SpotSweeper::localOutliers()`.
+This function uses a k-nearest neighbors approach to define the neighbhorhood for each spot and then calculates _local_ means and variances of standard QC metrics to identify outlying spots within their local tissue context.
+This approach reduces the chance that we'll bias filtering by tissue biology because we generally expect nearby spots in the same tissue region to be more biologically similar to each other. 
 
-We'll detect local outliers based using `SpotSweeper::localOutliers()` which takes these arguments:
+(It's also worth noting that `SpotSweeper` also has the ability to detect so-called "hangnails," which are regional technical artifacts resulting from issues with tissue preparation.
+Their hangnail detection uses variance in mitochondrial percentages, and since our mitochondrial percentage are very low with minimal variance, hangnail detection won't be relevant for us here.)
 
-- `metric`: name of column in `colData` with QC stat of interest
-- `direction`: are lower value or higher value outliers bad?
-  - e.g. we'd say "lower" for detected (we don't want low detected values), and we'd say "higher" for mitochondrial percentage
-- `n_neighbors`: number of neighbors for building the `kNN` graph; Default is 36
-- `log`: whether to consider the `log1p` of the metric; Default is `FALSE`
-  - The method assumes a normal distribution, so logging a metric may be needed to meet assumptions
-  - logging "detected" and "sum" is often recommended because these distributions are unbounded and span orders of magnitude
-  - logging "mitochondrial" is not often recommended because it's bounded `[0,100]` and logging percentages can distort the distribution
-- `cutoff`: Threshold for identifying outliers; Default is 3, meaning 3 standard deviations from the mean (think z-scores)
-  - Can make this lower to be more strict (more spots will get removed), lower to be less strict (more tolerant of outliers), but don't go too high or low or you're not really detecting outliers anymore
-- `workers`: Number of cores for parallel processing; Default is 1
 
-This function returns an `SPE` object with added `colData` columns we can use to find all the local outliers.
+`SpotSweeper::localOutliers()` returns an `SPE` object with added `colData` columns we can use to find all the local outliers and takes these arguments:
 
-Let's start off by looking for library size ("sum" column) outliers:
+* `metric`: Name of column in `colData` with QC stat of interest
+* `direction`: Either "lower" or "upper" depending on which direction should be filtered 
+  * We'll want to use "lower" for `detected` and `sum` (we don't want overly-low values), and we'll want to use `higher` for `subsets_mito_percent` (we don't want overly-high values)
+* `n_neighbors`: Number of neighbors for building the `kNN` graph; Default is 36
+* `log`: Whether to consider the `log1p` of the metric; Default is `FALSE`
+  * Because the outlier detection method used assumes a normal distribution, we often need to take the log of our statistics to meet assumptions
+  * We'll want to set `log = TRUE` for `detected` and `sum` because these distributions are unbounded and can span orders of magnitude
+  * We'll want to set `log = FALSE` for `subsets_mito_percent` because it's bounded between 0-100 so logging would distort the distribution
+- `cutoff`: Number of standard deviations for for identifying outliers; Default is 3
+  * Higher values mean filtering will be more permissive (more tolerant of outliers, so fewer spots will be removed)
+  * Lower values mean filtering will more strict (less tolerant of outliers, so more spots will be removed)
+
+
+Let's start off by looking for library size (column `sum` column) outliers:
 
 ```{r spotsweeper-sum, live = TRUE}
-# specify defaults for sum to be explicit
 filtered_spe <- SpotSweeper::localOutliers(
   filtered_spe, 
   metric = "sum", 
@@ -540,21 +541,26 @@ What do we have now?
 ```{r coldata-spotsweeper-sum, live = TRUE}
 colData(filtered_spe)
 ```
-New columns include:
 
-- `sum_log`: The `log1p()` (i.e., `log(x+1)`) of the `sum` column
-- `sum_outliers`: Logical whether or not the spot is an outlier
-- `sum_z`: The _local_ z-score for `sum_log`, among spots in the local neighborhood.
-  - 0: same as neighbors on average
-  - high positive value: much higher `sum` than neighbors
-  - low negative value: much lower `sum` than neighbors, which in this case would be the ones to filter
+`SpotSweeper` gave us a couple new columns:
+
+* `sum_log`: The `log1p()` (i.e., `log(x+1)`) of the `sum` column
+* `sum_outliers`: Whether or not the spot is a _local_ outlier in its local neighborhood.
+Generally we'll want to filter out rows where this is `FALSE`
+* `sum_z`: The _local_ z-score for `sum_log` used for identifying outliers relative to the specified cutff (here, 3)
+  * A value of 0 means the spot is, on average, the same as its neighbors
+  * A high positive value means the spot has a much higher `sum` than its local neighborhood
+  * A low negative value means the spot has a much lower `sum` than its local neighborhood.
+  These are the spots we'll want to filter out
   
-Let's see some of this relationship - we'll plot `sum_log` (log of a globally-calculated stat) against `sum_z` (stat for _local_ outlier), with a guiding line for the cutoff.
+Let's look at some of these values directly by plotting `sum_z` (local outlier statistics) against `sum_log` (log of a globally-calculated stat).
 
 ```{r sum_log_z_plot}
+# extract data frame for plotting
 filtered_spe_coldata <- colData(filtered_spe) |>
   as.data.frame()
 
+# Plot sum_z across sum_log
 ggplot2::ggplot(filtered_spe_coldata) + 
   ggplot2::aes(
     x = sum_log,
@@ -564,19 +570,21 @@ ggplot2::ggplot(filtered_spe_coldata) +
   ggplot2::geom_point(alpha = 0.5)
 ```
 
-Based on this metric, most spots are not outliers, and while most of the spots classified as outliers are fairly close to the 3 cutoff, several are are more extreme outliers!
-We also gain some insight about how global vs local filtering would play out.
-Let's imagine we did global filtering with a threshold of 500, whose log is 6.21.
-Looking at the x-axis here, that means we would only have removed three spots.
-But with local filtering, we are catching additional spots that deviate from their local neighborhood and filtering a few more out, but on the whole this dataset seems to be fairly good quality so it's not a ton.
+We see here that most spots are not outliers for the `sum` metric.
+Most of the spots classified as outliers are fairly close to the -3 cutoff, but several are more extreme outliers.
 
-Let's plot this next to the H&E:
-We'll use a plotting function from `SpotSweeper`, `SpotSweeper::plotQCmetrics()`, which will allow us to both color by a statistic and highlight outlier points.
-Well plot the `sum_log` side-by-side with `sum_z` to compare.
+We also gain some insight from this plot about how performing filtering using global vs local outliers would play out.
+Imagine if we had performed global filtering with a threshold of 500, which has a log of 6.21.
+At a cutoff of `sum_log = 6.21, we would only have removed three spots.
+But, by using local outlier detection, we have identified several more spots to remove whose `sum` is much lower than their immediately surrounding spots, suggesting potential quality issues.
+On the whole though, this dataset is fairly good quality so there aren't many of these low-quality spots.
+
+We can also plot these results on the coordinates themselves, using the H&E image as a guide for interpretation.
+For this, we'll use the function `SpotSweeper::plotQCmetrics()` which lets you both color by a statistic and highlight outlier points, so we'll plot both `sum_log` and `sum_z` with outliers highlighted.
 
 Tip!
-When using this function, the point color is a "fill" aesthetic (which can be customized), and the point outline is a "color" aesthetic.
-This insight will help us to customize the plot colors
+When using this function, the point color is a "fill" `ggplot2` aesthetic, and the point outline is a "color" `ggplot2` aesthetic.
+This insight will help us to customize the plot colors.
 
 ```{r spotsweeper-plotqc-sum}
 #| fig.width: 10
@@ -607,102 +615,13 @@ sum_z_plot <- SpotSweeper::plotQCmetrics(
 
 sum_log_plot + sum_z_plot
 ```
-Here, we can see how spots are distributed across the slide.
+These plots show us how spots are distributed across the tissue.
 Are there spots you would expect to be flagged for filtering based on the `sum_log` plot?
 Are there spots you might not have expected to be filtered based on the `sum_log` plot?
 
-#### Effect of neighborhood size
 
-**TODO: Decide final placement for this section. May move to an exercise, or may shift to a more open-ended individual exploration.**
-One key parameter that this relies on is the "neighborhood size" (`n_neighbors` argument).
-How would this have changed if we shifted the neighborhood size?
-To not clutter up our existing object, we'll save to new objects and plot as a exploration to learn about neighborhood size.
-
-```{r spotsweeper-compare-n-neighbors}
-#| fig.width: 10
-#| message: false
-
-# Detect outliers with a large neighborhood and make associated plot
-filtered_spe_n100 <- SpotSweeper::localOutliers(
-  filtered_spe, 
-  metric = "sum", 
-  direction = "lower", 
-  n_neighbors = 100
-)
-outlier_plot_n100 <- SpotSweeper::plotQCmetrics(
-  filtered_spe_n100, 
-  metric = "sum_log",
-  outliers = "sum_outliers", 
-  stroke = 0.75 
-) +
-  ggplot2::scale_fill_viridis_c() +
-  ggplot2::scale_color_manual(values = c(`TRUE` = "black", `FALSE` = "transparent")) +
-  ggplot2::ggtitle("neighborhood k = 100")
-
-
-# Detect outliers with a small neighborhood and make associated plot
-filtered_spe_n10 <- SpotSweeper::localOutliers(
-  filtered_spe, 
-  metric = "sum", 
-  direction = "lower", 
-  n_neighbors = 10
-)
-outlier_plot_n10 <- SpotSweeper::plotQCmetrics(
-  filtered_spe_n10, 
-  metric = "sum_log",
-  outliers = "sum_outliers",
-  stroke = 0.75 
-) +
-  ggplot2::scale_fill_viridis_c() +
-  ggplot2::scale_color_manual(values = c(`TRUE` = "black", `FALSE` = "transparent")) +
-  ggplot2::ggtitle("neighborhood k = 10")
-
-
-# Plot outliers detected with different neighborhood sizes
-## TODO: Include all tested neighborhood values
-outlier_plot_n100 + outlier_plot_n10
-```
-
-There's definitely some overlap, but also spots that are only filtered out for one of these neighborhood sizes.
-In particular, the spot on the top left: With a large neighborhood, its low value is an outlier, but with a small neighborhood it is not an outlier because the immediately surrounding spots are also lower.
-
-We can also see this difference by plotting the `sum_z` for each neighborhood size against each other on a scatterplot, coloring the global `sum_log`. 
-
-```{r sum-z-scatterplot}
-# create data frame for plotting
-compare_z_df <- data.frame(
-    n100_sum_z = filtered_spe_n100$sum_z, 
-    n10_sum_z = filtered_spe_n10$sum_z, 
-    # both versions have same value here since it's a global stat 
-    sum_log = filtered_spe_n10$sum_log
-  )
-
-ggplot2::ggplot(compare_z_df) + 
-  ggplot2::aes(x = n100_sum_z, y = n10_sum_z, color = sum_log) +
-  ggplot2::geom_point(alpha = 0.6) + 
-  ggplot2::labs(
-    x = "n_neighbors = 100", 
-    y = "n_neighbors = 10", 
-    title = "sum_z scores between neighorbhood sizes"
-  ) + 
-  ggplot2::geom_hline(yintercept = -3, color = "blue") +
-  ggplot2::geom_vline(xintercept = -3, color = "blue") +
-  ggplot2::scale_color_viridis_c(option = "magma") +
-  ggplot2::theme(aspect.ratio = 1)
-```
-The top right quadrant shows spots that both neighborhood sizes retain, and the bottom left quadrant shows spots that both neighborhood sizes will filter out.
-The top left shows spots that will only be filtered out for `n_neighbors = 100`, and the bottom right shows spots that will only be filtered out for `n_neighbors = 10`.
-Note there's at least one pretty low `sum_log` value retained in both versions.
-
-
-The point is, changing the cutoff or changing the neighborhood size will influence which spots are flagged for removal - plot your data!
-If you have specific biological intuition about how much variation you expect in the tissue, you might want to use that to inform cutoffs and the neighborhood size, and it's ok to explore.
-
-
-#### Detected gene and mitochondrial outliers
-
-Let's get back on track: let's do the same outlier detection for `detected` and `subsets_mito_percent`, and we'll proceed with the default cutoff of 3 with the default neighborhood size of 36.
-
+We can take the same approach for local outlier detection for the `detected` and `subsets_mito_percent` columns, and we'll proceed with the default cutoff of 3 with the default neighborhood size of 36.
+We'll do this one at a time below.
 
 ```{r spotsweeper-detected, live = TRUE}
 #| fig.width: 7
@@ -725,6 +644,9 @@ SpotSweeper::plotQCmetrics(
   ggplot2::scale_fill_viridis_c()
 ```
 
+As with local `sum` outliers, we see that the `detected` outliers are spread out across the whole tissue and not concentrated in specific tissue regions.
+
+Next, when calculating outliers for `subsets_mito_percent`, we'll need to specify `log = FALSE` and `direction = higher` since this is a bounded metric where we want to remove spots with higher than average values.
 
 ```{r spotsweeper-mito, live = TRUE}
 #| fig.width: 7
@@ -750,10 +672,11 @@ SpotSweeper::plotQCmetrics(
   ggplot2::scale_color_manual(values = c(`TRUE` = "black", `FALSE` = "transparent"))
 
 ```
-Even though mitochondrial percentages are fairly low across all spots, this approach helps us find spots that are much lower within their neighborhood, all of which we would miss with global filtering (where we might pick a threshold of 15-25% for single-cell data).
+Importantly, we see here that spots to remove are _not_ concentrated in tissue regions with higher mitochondrial percentages, but are instead spread across the tissue. 
+This shows us again that our local outlier detection approach allows us to avoid the confounding effects  of spatial heterogeneity. 
+It's also worth noting that none of these spots would have been removed with a typical global threshold used for single-cell data (e.g., 10-25%).
 
-
-Now that we've calculated all this, how many of each kind of outlier are there?
+Now that we've calculated all this, we can pool out outliers together: how many of outlier for each statistic are there?
 
 ```{r count-local-outliers}
 # Prepare data frame to count outliers
@@ -791,8 +714,10 @@ plot(
   fills = c("#F0E442", "#56B4E9", "#009E73")
 )
 ```
+We see substantial overlap between `sum` and `detected` outliers, but the `subsets_mito_percent` outliers appear to be mostly distinct. 
 
-Let's go ahead and filter all these spots out:
+Next, we'll build a filter representing the union of all types of outliers and use it to filter the SPE object.
+
 
 ```{r build-local-filter}
 # combine all outliers into "local_outliers" column to filter on

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -278,7 +278,7 @@ ggspavis::plotVisium(spe)
 ```
 
 Here, we see the spots overlaid on the slide as well as slide boundaries.
-You'll notice that every single spot is shown, including ones that don't overlap tissue directly --- indeed, all 4992 spots are present in the object right now!
+You'll notice that every single spot is shown, including ones that don't overlap tissue directly --- indeed, all 4992 spots are present in the object right now.
 
 By default, `ggspavis::plotVisium()` shows the spots, but we can hide them and zoom into the tissue on the slide.
 This is a helpful way to pop up the H&E for side-by-side comparisons with other plots we might make (foreshadowing!).
@@ -357,10 +357,20 @@ But not all of these spots are necessarily good quality, so we'll want to do som
 
 ## Filtering low-quality spots
 
+When identifying low-quality spots in Visium data, we can use similar QC statistics that we might use for filtering scRNA-seq data, such as:
+
+* Total UMIs, or library size
+* Number of unique detected genes
+* Percentage of mitochondrial reads, where high values indicate cell damage
+
+However, unlike with scRNA-seq data, how we interpret and use these statistics is going to be somewhat different. 
+    
 ### Exploring global QC thresholds
 
-As a first step towards filtering, we can borrow some approaches from scRNA-seq and calculate some quality-control measures. 
-Let's do that and have a look - we'll get our mitochondrial genes for QC calculations and we'll use `scran::addPerCellQC()` like we might for single-cell (except here it adds per spot).
+As a first step towards filtering, we'll calculate QC statitics and explore their distributions.
+We'll use `scran::addPerCellQC()` to calculate these statistics; even though the function is called "per-cell," in this case it will calculate per _spot_.
+
+First we need to import our list of mitochondrial genes to use as part of these calculations.
 
 ```{r get mitochondrial genes}
 # read in a table of mitochondrial genes and extract ids
@@ -371,7 +381,9 @@ mito_genes <- readr::read_tsv(mito_file) |>
   dplyr::pull(gene_id)
 ```
 
+
 ```{r calculate qc, live = TRUE}
+# calculate per-spot statistics
 filtered_spe <- scuttle::addPerCellQC(
   filtered_spe,
   subsets = list(mito = mito_genes)
@@ -381,8 +393,7 @@ filtered_spe <- scuttle::addPerCellQC(
 colData(filtered_spe) |> head()
 ```
 
-`ggspavis` comes with a helpful QC plotter (makes histograms by default but has a couple more options!).
-These are `ggplot2` objects, so we can use `ggplot2` code with them like add a title to each.
+Let's go ahead and look at the distributions of these statistics to see how many spots appear to be low-quality.
 
 ```{r global qc distributions}
 #| fig.width: 12
@@ -415,27 +426,29 @@ qc_plot_mito <- ggplot2::ggplot(coldata_df) +
 qc_plot_sum + qc_plot_detected + qc_plot_mito
 ```
 
-These distributions all look unimodal without too much skew, which is different from how distributions from single-cell data might look. 
+If you've worked with single-cell data lately, these distributions might look different from what you might have expected.
+In single-cell data, these distributions usually show a strong skew for low-quality cells, either with very few total UMIs or detected genes or with a very high mitochondrial percentage.
 
-Placeholder for discussion about differences/similarities in technical artifacts between data types:
+But here, we see three unimodal distributions, and the tails seen in the `detected` and `subsets_mito_percent` distributions aren't really suggestive of low-quality spots. 
+We might be tempted to use these tails to inform global thresholds for filtering, but a closer look suggests that might not be what we want.
+For example, a natural threshold for this `subsets_mito_percent` distribution might be around 4%, but that's actually quite low mitochondrial percentage that does _not_ actually suggest cell damage so removing those spots would not actually help us here. 
 
-- One of the reasons we filter on these metrics in single cell is due to potential differences in cell capture across droplets
-- This isn't a factor in spatial where QC stats are calculated per spot aka for aggregates of cells, extremes end up getting smoothed out
-  - Differences in capture aren't due to heterogeneity from droplet capture but because of tissue biology/prep:
-  - We have distinct regions of tissue or groups of cells that have less genes detected than other ones (biology) or because the tissue didn't lay on the slide completely flat or wasn't completely permeabilized in all spots equally
+What's actually going on here, and what should we do about it?
 
-For example, let's consider the mitochondria percent distribution:
+* First, because each sequenced spot is an aggregate of cells, quality issues in individual cells can end up being smoothed out by their neighbors, so we may not easily perceive those signatures in per-spot statistics. 
+* Second, the technical factors that affect spatial transcriptomic data quality are fundamentally different from the factors that affect single-cell data quality.
+In single-cell data, differences in cell capture across droplets are a main source of quality issues that lead to cell damage or cells with very few UMIs or genes.
+Due to fundamental differences in library preparation, this is not a factor in spatial transcriptomic data; instead, problems with tissue preparation (e.g., tissue did not lay flat on the slide or was not permeabilized homogeneously) tend to be a more significant factor driving differences in QC statistics. 
+* Third, the biological heterogeneity in the tissue means that using global thresholds to filter has substantial potential to _bias_ analysis.
+For example, if a particular tissue compartment is dominated by cell types which naturally have lower expression, we might end up filtering out meaningful regions of the tissue.
+As such, the QC statistics themselves can be confounded with spatial biology, we we need to be mindful to not filter too aggressively.
 
-- We do see a long right-tail for mitochondrial percentages, but the values are all really low which doesn't suggest any major quality issues.
-- The lower values here vs in single-cell data make sense because cells weren't stressed in the same way they would be for single-cell library prep; more likely to tell you about the tissue quality itself (biology) and not spot quality (technical) 
-
-Let's plot the same stats on the slide.
-We'll include the H&E plot here as well for an immediate comparison.
+To get a clearer view of the relationship between QC statistics and tissue biology, we'll plot those same QC statistics directly on the slide coordinates to see their full spatial context.
+We'll also include the H&E plot here to be able to quickly compare patterns seen in each panel.
 
 ```{r global qc coords}
 #| fig.width: 10
 #| message: false
-
 
 he_plot <- ggspavis::plotVisium(filtered_spe, spots = FALSE, zoom = TRUE) +
   ggplot2::ggtitle("H&E") +
@@ -473,22 +486,16 @@ patchwork::wrap_plots(
 )
 ```
 
-Now, we start to see there's more to the story.
-There is spatial heterogeneity in these QC stats:
+Compare the H&E image to these statistics: do you notice any patterns that suggest the statistics are confounded by spatial biology, in particular between stromal and blastemal regions?
 
-- the likely stromal regions have distinctly higher mitochondrial percentages (although again, these values are pretty low all around!) and fewer detected UMIs/genes
-- the likely blastema regions tend to have more detected UMIs/genes
-
-This tells us that there is local structure in the data that we might like our QC approach to take into consideration.
-Using these global thresholds, we can see that QC is confounded by biology. 
-If we filter these spots, we'll be removing spots associated with a particular tissue region.
-This shows that global thresholds may not be suitable for data with this kind of heterogeneity, so a different approach could be warranted.
-Worth noting, this is not strictly a spatial transcriptomics issue; there can be quite a bit of heterogeneity in scRNA-seq data too depending on what was sequenced!
-Always plot your data!
+This shows us that if we were to filter out, for example, spots with overall lower total UMIs or detected genes, we would end up primarily if not only removing spots in stromal regions, which is probably not what we want! 
+As such, using global thresholds is not going to be suitable for spatial data, so we'll want to use a different approach to filter spots.
+(It's worth noting however this is not strictly a spatial transcriptomics issue; it's very possible for differences among cell types to confound QC statistics in single-cell data.
+Always plot your data to make sure your filters make sense for your data!)
 
 ### Filtering with local QC thresholds
 
-Rather than finding outliers based on overall QC stats derived across biologically distinct domains/tissue regions, we can instead look for _local_ outliers to filter, i.e. spots with properties that deviate from their neighborhood of nearby spots.
+Rather than finding outliers based on overall QC statistics derived across biologically distinct tissue regions, we can instead look for _local_ outliers to filter, i.e. spots with properties that deviate from their neighborhood of nearby spots.
 Placeholder text to introduce [`SpotSweeper`](https://www.bioconductor.org/packages/3.22/bioc/vignettes/SpotSweeper/inst/doc/getting_started.html):
 
 - Evaluates spots relative to their local neighborhood which is defined with `kNN`

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -315,7 +315,7 @@ We can override this if we want, but we really want to remove those spots entire
 ## Filtering empty spots
 
 As stated, let's go ahead and remove those spots entirely.
-As a rough analogy, this analysis step is reminiscent of filtering empty droplets from single-cell data retain only droplets with cells, but in this case we want to retain only spots that overlap tissue.
+As a rough analogy, this analysis step is reminiscent of filtering empty droplets from single-cell data to retain only droplets with cells, but in this case, we want to retain only spots that overlap tissue.
 
 Again, we need to take this step because we read in the `raw_feature_bc_matrix` output from 10x. 
 Had we read in the `filtered_feature_bc_matrix` instead, the data would already be filtered to only contain spots overlapping tissue. 
@@ -350,7 +350,7 @@ ggspavis::plotVisium(
 
 In this plot, we see the following:
 
-* The purple tissue overhang on the left isn't colored at all; these spots are outside fiducial alignment frame and have no corresponding spots
+* The purple tissue overhang on the left isn't colored at all; these spots are outside the fiducial alignment frame and have no corresponding spots
 * The red points represent those we want to filter out as uninformative
 
 Let's go ahead and filter:
@@ -404,7 +404,7 @@ filtered_spe <- scuttle::addPerCellQC(
 colData(filtered_spe) |> head()
 ```
 
-We'll first look at the distributions of these statistics (always plots your data!) to see how many spots appear to be low-quality.
+We'll first look at the distributions of these statistics (always plot your data!) to see how many spots appear to be low-quality.
 
 ```{r global qc distributions}
 #| fig.width: 12
@@ -502,7 +502,7 @@ Compare the H&E image to these statistics: do you notice any patterns that sugge
 
 This shows us that if we were to filter out, for example, spots with overall lower total UMIs or detected genes, we would end up primarily (if not only) removing spots in stromal regions, which is probably not what we want! 
 As such, using global thresholds is not going to be suitable for spatial data, so we'll need a different approach to filter spots.
-(It's worth noting that this is not strictly a spatial transcriptomics issue; it's very possible for differences among cell types to confound QC statistics in single-cell data too!
+(It's worth noting that this is not strictly a spatial transcriptomics issue; it's very possible for differences among cell types to confound QC statistics in single-cell data too.
 Always plot your data to make sure your filters make sense for your data!)
 
 ### Filtering with local QC thresholds
@@ -511,12 +511,12 @@ Rather than finding outliers based on overall QC statistics derived across biolo
 These are spots whose properties differ from their local neighborhood of nearby spots. 
 For this, we'll use the [`SpotSweeper`](https://www.bioconductor.org/packages/3.22/bioc/vignettes/SpotSweeper/inst/doc/getting_started.html) package, which offers several useful tools for quality control of spot-based data.
 
-We'll specifically their local outlier detection function `SpotSweeper::localOutliers()`.
+We'll specifically use their local outlier detection function `SpotSweeper::localOutliers()`.
 This function uses a k-nearest neighbors approach to define the neighborhood for each spot and then calculates _local_ means and variances of standard QC metrics to identify outlying spots within their local tissue context.
 This approach reduces the chance that we'll bias filtering by tissue biology because we generally expect nearby spots in the same tissue region to be more biologically similar to each other. 
 
-(It's also worth noting that `SpotSweeper` also has the ability to detect so-called "hangnails," which are regional technical artifacts resulting from issues with tissue preparation.
-Their hangnail detection uses variance in mitochondrial percentages, and since our mitochondrial percentage are very low with minimal variance, hangnail detection won't be relevant for us here.)
+It's also worth noting that `SpotSweeper` also has the ability to detect so-called "hangnails," which are regional technical artifacts resulting from issues with tissue preparation.
+Their hangnail detection uses variance in mitochondrial percentages, and since our mitochondrial percentage are very low with minimal variance, hangnail detection won't be relevant for us here.
 
 
 `SpotSweeper::localOutliers()` returns an `SPE` object with added `colData` columns we can use to find all the local outliers and takes these arguments:
@@ -531,7 +531,7 @@ Their hangnail detection uses variance in mitochondrial percentages, and since o
   * We'll want to set `log = FALSE` for `subsets_mito_percent` because it's bounded between 0-100 so logging would distort the distribution
 - `cutoff`: Number of standard deviations for for identifying outliers; Default is 3
   * Higher values mean filtering will be more permissive (more tolerant of outliers, so fewer spots will be removed)
-  * Lower values mean filtering will more strict (less tolerant of outliers, so more spots will be removed)
+  * Lower values mean filtering will be more strict (less tolerant of outliers, so more spots will be removed)
 
 
 Let's start off by looking for outliers in the `sum` column, which represents library size (total UMIs).
@@ -683,10 +683,10 @@ SpotSweeper::plotQCmetrics(
 
 ```
 Importantly, we see here that spots to remove are _not_ concentrated in tissue regions with higher mitochondrial percentages, but are instead spread across the tissue. 
-This shows us again that our local outlier detection approach allows us to avoid the confounding effects  of spatial heterogeneity. 
+This shows us again that our local outlier detection approach allows us to avoid the confounding effects of spatial heterogeneity. 
 It's also worth noting that none of these spots would have been removed with a typical global threshold used for single-cell data (e.g., 10-25%).
 
-Now that we've calculated all this, we can pool out outliers together: how many of outlier for each statistic are there?
+Now that we've calculated all this, we can pool our outliers together: how many outliers are there for each statistic?
 
 ```{r count-local-outliers}
 # Prepare data frame to count outliers


### PR DESCRIPTION
Closes #945 
Closes #946 

This PR fills in the text for the filtering sections, including:
- remove in_tissue = 0 spots
- explore stat distributions and don't pick global thresholds
- local filtering with spotsweeper

I also ripped out the draft content exploring neighborhood sizes. 