### PR TITLE
Update GHA and dictionary

### DIFF
--- a/.github/workflows/make-live.yml
+++ b/.github/workflows/make-live.yml
@@ -73,7 +73,7 @@ jobs:
       # Make changes to pull request here
       - name: Create PR with rendered notebooks
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ env.DOCS_BOT_GITHUB_TOKEN }}
           commit-message: Live and rendered notebooks

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -35,6 +35,7 @@ Ballereau
 BAM
 Baran
 barcode
+barcoded
 barcodes
 Becht
 benchmarking
@@ -158,6 +159,7 @@ fiducials
 Figshare
 FLI
 FN
+folate
 FPKM
 frac
 Freitag
@@ -279,6 +281,7 @@ metacell
 MetaCell
 metacells
 MF
+microenvironment
 microglia
 miQC
 misordered


### PR DESCRIPTION
Our make-live GHA has been failing, but the analogous unsolve GHA in exercises succeeded. The main difference between them is the pr step version so I've bumped that here to v7 to hopefully get this GHA up and running again. This seems right given what I see in their repo - 

https://github.com/peter-evans/create-pull-request/issues/4272
https://github.com/peter-evans/create-pull-request/pull/4250

We could go to v8 which was just released, but we mostly know v7 should work so this seems fine and sufficiently recent.


While I was here, I also addressed some dictionary items surfaced in https://github.com/AlexsLemonade/training-modules/actions/runs/24790071690/job/72544809333