### PR TITLE
Update json for may 2026

### DIFF
--- a/current-modules.json
+++ b/current-modules.json
@@ -1,5 +1,5 @@
 {
-  "release-tag": "2025-may",
+  "release-tag": "2026-may",
   "modules": ["scRNA-seq"],
   "reference-modules": ["intro-to-R-tidyverse"]
 }

--- a/current-modules.json
+++ b/current-modules.json
@@ -1,5 +1,5 @@
 {
-  "release-tag": "2025-december",
-  "modules": ["scRNA-seq-advanced"],
-  "reference-modules": ["scRNA-seq"]
+  "release-tag": "2025-may",
+  "modules": ["scRNA-seq"],
+  "reference-modules": ["intro-to-R-tidyverse"]
 }

--- a/current-modules.json
+++ b/current-modules.json
@@ -1,5 +1,5 @@
 {
   "release-tag": "2026-may",
-  "modules": ["scRNA-seq"],
-  "reference-modules": ["intro-to-R-tidyverse"]
+  "modules": ["scRNA-seq", "intro-to-R-tidyverse"],
+  "reference-modules": [""]
 }

--- a/current-modules.json
+++ b/current-modules.json
@@ -1,5 +1,5 @@
 {
   "release-tag": "2026-may",
   "modules": ["scRNA-seq", "intro-to-R-tidyverse"],
-  "reference-modules": [""]
+  "reference-modules": []
 }


### PR DESCRIPTION
Towards https://github.com/AlexsLemonade/training-admin/issues/1513

This PR updated `current-modules.json` for scRNA-seq. I included intro-R as a module, not a reference module.