### PR TITLE
Data rearrangements to use spaceranger directory

### DIFF
--- a/scripts/link-data.sh
+++ b/scripts/link-data.sh
@@ -51,6 +51,7 @@ mkdir -p scRNA-seq-advanced/data/wilms-tumor
 # spatial module directories
 mkdir -p spatial/data/ovarian-carcinoma
 mkdir -p spatial/data/wilms-tumor/SCPCS000190
+mkdir -p spatial/data/osteo/GSM8478586
 
 # Machine learning module directory
 mkdir -p machine-learning/data
@@ -113,11 +114,9 @@ link_locs=(
   scRNA-seq-advanced/data/pancreas/processed
   scRNA-seq-advanced/gene-sets
   scRNA-seq-advanced/data/wilms-tumor/processed
-  spatial/data/ovarian-carcinoma/spatial
-  spatial/data/ovarian-carcinoma/feature_filtered_bc_matrix
-  spatial/data/wilms-tumor/SCPCS000190/spatial
-  spatial/data/wilms-tumor/SCPCS000190/raw_feature_bc_matrix
-  spatial/data/wilms-tumor/SCPCS000190/filtered_feature_bc_matrix
+  spatial/data/ovarian-carcinoma/spaceranger
+  spatial/data/wilms-tumor/SCPCS000190/spaceranger
+  spatial/data/osteo/GSM8478586/normalized
   machine-learning/data/open-pbta
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma

--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -55,9 +55,9 @@ sync_dirs=(
   scRNA-seq-advanced/data/rms/integrated
   scRNA-seq-advanced/data/pancreas/processed
   scRNA-seq-advanced/gene-sets
-  scRNA-seq-advanced/data/wilms-tumor/processed
-  spatial/data/ovarian-carcinoma/processed
-  spatial/data/wilms-tumor
+  scRNA-seq-advanced/data/wilms-tumor/spaceranger
+  spatial/data/ovarian-carcinoma/spaceranger
+  spatial/data/osteo/GSM8478586/spaceranger
   machine-learning/data/open-pbta/processed
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma
@@ -77,6 +77,7 @@ sync_files=(
   scRNA-seq-advanced/data/rms/annotations/rms_sample_metadata.tsv
   scRNA-seq-advanced/data/reference/hs_mitochondrial_genes.tsv
   spatial/data/reference/hs_mitochondrial_genes.tsv
+  spatial/data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds  
 )
 
 output_files=(

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -57,6 +57,9 @@ sample_id <- "SCPCS000190"
 # main data directory for this sample
 data_dir <- file.path("data/wilms-tumor", sample_id)
 
+# directory with spaceranger output
+spaceranger_dir <- file.path(data_dir, "spaceranger")
+
 # reference data directory
 ref_dir <- file.path("data/reference")
 
@@ -99,7 +102,7 @@ Before importing the data, let's go ahead and look what files we have:
 
 
 ```{r dir-data, live = TRUE}
-dir(data_dir)
+dir(spaceranger_dir)
 ```
 
 As described, the `raw_feature_bc_matrix` and `filtered_feature_bc_matrix` directories are analogous to what we might get from Cell Ranger for single-cell data.
@@ -114,7 +117,7 @@ Let's take a closer look at what's in the `spatial` directory:
 
 ```{r dir-spatial, live = TRUE}
 dir(
-  file.path(data_dir, "spatial")
+  file.path(spaceranger_dir, "spatial")
 )
 ```
 
@@ -185,10 +188,10 @@ So, in this case we'll specify to import only the `lowres` version of the image.
 
 ```{r import-visium, live = TRUE}
 # path to quantified RNA 10X output
-rna_dir <- file.path(data_dir, "raw_feature_bc_matrix")
+rna_dir <- file.path(spaceranger_dir, "raw_feature_bc_matrix")
 
 # path to spatial 10X output
-spatial_dir <- file.path(data_dir, "spatial")
+spatial_dir <- file.path(spaceranger_dir, "spatial")
 
 # import to an object called spe
 spe <- VisiumIO::import(

--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -22,18 +22,16 @@ This table was copied from `/shared/data/training-modules/scRNA-seq-advanced/dat
 ### Wilms tumor
 
 We use the `SCPCL000429_spatial` dataset from [`SCPCP000006`](https://scpca.alexslemonade.org/projects/SCPCP000006).
-Files for sample `SCPCS000190` were downloaded directly from the `ScPCA` portal, and we considered only files in `SCPCL000429_spatial/`.
-The `json` and `html` files were removed, and the remaining files were organized as:
+To obtain these files, use the script `wilms-tumor/download-wilms-tumor.R`.
+This will create a directory `../data/wilms-tumor/SCPCS00190/` with the following files:
 ```markdown
-└── SCPCS000190
-    ├── filtered_feature_bc_matrix
-    │   ├── barcodes.tsv.gz
-    │   ├── features.tsv.gz
-    │   └── matrix.mtx.gz
+SCPCS000190
+└── spaceranger
     ├── raw_feature_bc_matrix
-    │   ├── barcodes.tsv.gz
-    │   ├── features.tsv.gz
-    │   └── matrix.mtx.gz
+    │   ├── barcodes.tsv.gz
+    │   ├── features.tsv.gz
+    │   └── matrix.mtx.gz
+    ├── SCPCL000429_spaceranger-summary.html
     └── spatial
         ├── aligned_fiducials.jpg
         ├── detected_tissue_image.jpg
@@ -43,24 +41,35 @@ The `json` and `html` files were removed, and the remaining files were organized
         └── tissue_positions_list.csv
 ```
 
-The `SCPCS000190` directory was then placed in `/shared/data/training-modules/spatial/data/wilms-tumor/`.
-No further preparation was needed.
+The `SCPCS000190` directory was then copied to `/shared/data/training-modules/spatial/data/wilms-tumor/`.
+
 
 ### Ovarian carcinoma
 
 This data comes from this 10x Genomics dataset: <https://www.10xgenomics.com/datasets/human-ovarian-cancer-11-mm-capture-area-ffpe-2-standard>.
+This data, as well as its corresponding Visium probe set, can be downloaded with `ovarian-carcinoma/download-ovarian.R`.
+This will create a directory `../data/ovarian-carcinoma/spaceranger/` with the following files:
 
-This data, as well as its corresponding Visium probe set, were download from 10x as follows:
-
-```sh
-wget https://cf.10xgenomics.com/supp/spatial-exp/probeset/Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv
-wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_spatial.tar.gz | tar -xz
-wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_filtered_feature_bc_matrix.tar.gz | tar -xz
+```markdown
+spaceranger
+├── filtered_feature_bc_matrix
+│   ├── barcodes.tsv.gz
+│   ├── features.tsv.gz
+│   └── matrix.mtx.gz
+├── spatial
+│   ├── aligned_fiducials.jpg
+│   ├── aligned_tissue_image.jpg
+│   ├── cytassist_image.tiff
+│   ├── detected_tissue_image.jpg
+│   ├── scalefactors_json.json
+│   ├── spatial_enrichment.csv
+│   ├── tissue_hires_image.png
+│   ├── tissue_lowres_image.png
+│   └── tissue_positions.csv
+└── Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv
 ```
 
-The `Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv` file, the `spatial/` directory, and the `filtered_feature_bc_matrix/` directory were then placed in `/shared/data/training-modules/spatial/data/ovarian-carcinoma/`.
-No further preparation was needed.
-
+The `ovarian-carcinoma` directory was then copied to `/shared/data/training-modules/spatial/data/`.
 
 ### Osteosarcoma
 

--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -23,6 +23,8 @@ This table was copied from `/shared/data/training-modules/scRNA-seq-advanced/dat
 
 We use the `SCPCL000429_spatial` dataset from [`SCPCP000006`](https://scpca.alexslemonade.org/projects/SCPCP000006).
 To obtain these files, use the script `wilms-tumor/download-wilms-tumor.R`.
+This script requires the [`ScPCAr` package](https://alexslemonade.github.io/ScPCAr/), which can be installed with `remotes::install_github("AlexsLemonade/ScPCAr")`.
+
 This will create a directory `../data/wilms-tumor/SCPCS00190/` with the following files:
 ```markdown
 SCPCS000190

--- a/spatial/setup/osteo/Snakefile
+++ b/spatial/setup/osteo/Snakefile
@@ -1,29 +1,31 @@
 # Workflow for preparing the GSM8478586 osteosarcoma dataset
 configfile: "config.yaml"
 sample_dir = os.path.join(config["base_dir"], config["sample_id"])
+spaceranger_dir = os.path.join(sample_dir, "spaceranger")
+normalized_dir = os.path.join(sample_dir, "normalized")
 
 rule targets:
   input:
-    os.path.join(sample_dir, "normalized", config["output_rds"])
+    os.path.join(normalized_dir, config["output_rds"])
 
 rule download_spatial:
   output:
-    directory(os.path.join(sample_dir, "filtered_feature_bc_matrix")),
-    directory(os.path.join(sample_dir, "spatial")),
+    directory(os.path.join(spaceranger_dir, "filtered_feature_bc_matrix")),
+    directory(os.path.join(spaceranger_dir, "spatial")),
   params:
     url = config["url"]
   shell:
-    "curl -L {params.url} | tar xz --strip-components=1 -C {sample_dir}"
+    "curl -L {params.url} | tar xz --strip-components=1 -C {spaceranger_dir}"
 
 
 # import as SPE, filter, normalize, and export rds as preparation for the spatial clustering notebook
 rule prepare_sce:
   input:
-    filtered_matrix = os.path.join(sample_dir, "filtered_feature_bc_matrix"),
-    spatial         = os.path.join(sample_dir, "spatial"),
+    filtered_matrix = os.path.join(spaceranger_dir, "filtered_feature_bc_matrix"),
+    spatial         = os.path.join(spaceranger_dir, "spatial"),
     mito_genes_file = config["mito_genes_file"],
   output:
-    os.path.join(sample_dir, "normalized", config["output_rds"])
+    os.path.join(normalized_dir, config["output_rds"])
   params:
     notebook = "prepare-osteo-data.Rmd"
   shell:

--- a/spatial/setup/osteo/prepare-osteo-data.Rmd
+++ b/spatial/setup/osteo/prepare-osteo-data.Rmd
@@ -4,8 +4,8 @@ author: Stephanie Spielman for CCDL
 date: 2026
 output: html_notebook
 params:
-  filtered_matrix: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/outs/filtered_feature_bc_matrix"
-  spatial_dir: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/outs/spatial"
+  filtered_matrix: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/spaceranger/filtered_feature_bc_matrix"
+  spatial_dir: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/spaceranger/spatial"
   output_rds: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds"
   mito_genes_file: "/shared/data/training-modules/spatial/data/reference/hs_mitochondrial_genes.tsv"
 ---

--- a/spatial/setup/ovarian-carcinoma/download-ovarian.sh
+++ b/spatial/setup/ovarian-carcinoma/download-ovarian.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 outdir="../../data/ovarian-carcinoma/spaceranger"
 mkdir -p $outdir
 

--- a/spatial/setup/ovarian-carcinoma/download-ovarian.sh
+++ b/spatial/setup/ovarian-carcinoma/download-ovarian.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+outdir="../../data/ovarian-carcinoma/spaceranger"
+mkdir -p $outdir
+
+# Download files from 10x
+wget https://cf.10xgenomics.com/supp/spatial-exp/probeset/Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv
+wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_spatial.tar.gz | tar -xz
+wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_filtered_feature_bc_matrix.tar.gz | tar -xz
+
+# Move to outdir
+mv Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv $outdir/
+mv spatial $outdir/
+mv filtered_feature_bc_matrix $outdir/

--- a/spatial/setup/ovarian-carcinoma/download-ovarian.sh
+++ b/spatial/setup/ovarian-carcinoma/download-ovarian.sh
@@ -4,11 +4,6 @@ outdir="../../data/ovarian-carcinoma/spaceranger"
 mkdir -p $outdir
 
 # Download files from 10x
-wget https://cf.10xgenomics.com/supp/spatial-exp/probeset/Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv
-wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_spatial.tar.gz | tar -xz
-wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_filtered_feature_bc_matrix.tar.gz | tar -xz
-
-# Move to outdir
-mv Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv $outdir/
-mv spatial $outdir/
-mv filtered_feature_bc_matrix $outdir/
+wget -P "$outdir" https://cf.10xgenomics.com/supp/spatial-exp/probeset/Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv
+wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_spatial.tar.gz | tar -xz -C "$outdir"
+wget -qO- https://cf.10xgenomics.com/samples/spatial-exp/2.0.0/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma/CytAssist_11mm_FFPE_Human_Ovarian_Carcinoma_filtered_feature_bc_matrix.tar.gz | tar -xz -C "$outdir"

--- a/spatial/setup/wilms-tumor/download-wilms-data.R
+++ b/spatial/setup/wilms-tumor/download-wilms-data.R
@@ -23,7 +23,7 @@ stopifnot(
   "Must provide an email with --email" = !is.null(opt$email),
   "Must provide an outdir with --outdir" = !is.null(opt$outdir)
 )
-
+fs::dir_create(opt$outdir)
 
 
 # Get an authentication token for use with the ScPCA Portal
@@ -44,6 +44,7 @@ downloaded_dir <- file.path(
   "scpca_data",
   dir("scpca_data")
 )
+
 
 # Move & rename what we're keeping
 fs::file_move(

--- a/spatial/setup/wilms-tumor/download-wilms-data.R
+++ b/spatial/setup/wilms-tumor/download-wilms-data.R
@@ -1,0 +1,60 @@
+#!/usr/bin/env Rscript
+
+library(ScPCAr)
+library(optparse)
+
+option_list <- list(
+  make_option(
+    opt_str = c("--email"),
+    type = "character",
+    help = "Email to use for authenticating with ScPCA Portal"
+  ),
+  make_option(
+    opt_str = c("--outdir"),
+    type = "character",
+    default = "../../data/wilms-tumor/SCPCS000190",
+    help = "Path where spaceranger directory should live"
+  )
+)
+opt <- parse_args(OptionParser(option_list = option_list))
+
+
+stopifnot(
+  "Must provide an email with --email" = !is.null(opt$email),
+  "Must provide an outdir with --outdir" = !is.null(opt$outdir)
+)
+
+
+
+# Get an authentication token for use with the ScPCA Portal
+auth_token <- get_auth(email = opt$email, agree = TRUE)
+
+
+# Download a data for a sample
+file_paths <- download_sample(
+  sample_id = "SCPCS000190",
+  auth_token = auth_token,
+  destination = "scpca_data",
+  format = "spatial",
+  overwrite = TRUE
+)
+
+# capture output directory name
+downloaded_dir <- file.path(
+  "scpca_data",
+  dir("scpca_data")
+)
+
+# Move & rename what we're keeping
+fs::file_move(
+  file.path(downloaded_dir, "SCPCL000429_spatial"),
+  file.path(opt$outdir, "spaceranger")
+)
+
+# Delete what we don't want - keep the filtered output and summary report
+fs::file_delete(
+  file.path(opt$outdir, "spaceranger", "SCPCL000429_metadata.json")
+)
+
+# Clean up
+fs::dir_delete("scpca_data")


### PR DESCRIPTION
Closes #983

In this PR I do both some scripting and data rearranging (in parallel on S3 as well). I ended up adding some quick scripts to prep the ovarian carcinoma and wilms tumor data as well, since I was sad to find them missing from the server after it had to be restored from backup and having a script to bring them back would have been nice! I do have some questions about the code I've written though. 

- Generally speaking, spatial data now has a `spaceranger` directory to hold the spaceranger files. As such, the intro spatial notebook was updated; exercise notebook updates for this are being tracked in https://github.com/AlexsLemonade/exercise-notebook-answers/issues/294
- Note that for the wilms tumor data, I now keep the report around - can't hurt, someone might want to peek at it!
- For the ovarian carcinoma and wilms tumor prep scripts, I wrote them to place data into a local directory and then to manually copy over to `/shared/....` In looking over previous `setup` code, we have sometimes placed items directly into `/shared` and sometimes placed them locally. I think this is worth firming up _for the spatial module_, so I would welcome feedback about strategies there as part of review. Some aspect of this might involve some general code changes though to how we manage data. Still kind of mulling over this.
- Note that the wilms tumor script uses `ScPCAr` which is _not_ part of our Docker image. Let me know if you think this is worth actually adding to the image, or if it's fine to install on the fly when needed as I did here. 
- I think I've got things right in the link and sync scripts now, but I do not trust myself 😭 