### PR TITLE
Update osteo data prep

### DIFF
--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -80,10 +80,9 @@ This data needs to be filtered and normalized for input to workshop notebooks.
 
 In addition, the [`OsteoCAR` mouse metastasis reference](https://figshare.com/articles/dataset/OsteoCAR_A_multi-species_single-cell_atlas_of_primary_and_metastatic_osteosarcoma/31029559) also needs to be obtained and prepared for the workshop as the osteosarcoma deconvolution reference.
 
-This code requires the `qs` (not `qs2`) package to read in the raw `OsteoCAR` reference.
-As of January 2026, this package is not currently from CRAN (but it may be back one day), so you may need to install with `remotes::install_github("qsbase/qs")`.
 
-To download and prepare input data and the reference for the workshop, change directories to the `setup/osteo` directory and run:
+To download and prepare input data and the reference for the workshop, change directories to the `setup/osteo` directory and run the following.
+Note that this assumes that the file `../../data/reference/mm_mitochondrial_genes.tsv` is present.
 
 ```sh
 snakemake -j2

--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -30,9 +30,9 @@ This will create a directory `../data/wilms-tumor/SCPCS00190/` with the followin
 SCPCS000190
 └── spaceranger
     ├── raw_feature_bc_matrix
-    │   ├── barcodes.tsv.gz
-    │   ├── features.tsv.gz
-    │   └── matrix.mtx.gz
+    │   ├── barcodes.tsv.gz
+    │   ├── features.tsv.gz
+    │   └── matrix.mtx.gz
     ├── SCPCL000429_spaceranger-summary.html
     └── spatial
         ├── aligned_fiducials.jpg
@@ -55,19 +55,19 @@ This will create a directory `../data/ovarian-carcinoma/spaceranger/` with the f
 ```markdown
 spaceranger
 ├── filtered_feature_bc_matrix
-│   ├── barcodes.tsv.gz
-│   ├── features.tsv.gz
-│   └── matrix.mtx.gz
+│   ├── barcodes.tsv.gz
+│   ├── features.tsv.gz
+│   └── matrix.mtx.gz
 ├── spatial
-│   ├── aligned_fiducials.jpg
-│   ├── aligned_tissue_image.jpg
-│   ├── cytassist_image.tiff
-│   ├── detected_tissue_image.jpg
-│   ├── scalefactors_json.json
-│   ├── spatial_enrichment.csv
-│   ├── tissue_hires_image.png
-│   ├── tissue_lowres_image.png
-│   └── tissue_positions.csv
+│   ├── aligned_fiducials.jpg
+│   ├── aligned_tissue_image.jpg
+│   ├── cytassist_image.tiff
+│   ├── detected_tissue_image.jpg
+│   ├── scalefactors_json.json
+│   ├── spatial_enrichment.csv
+│   ├── tissue_hires_image.png
+│   ├── tissue_lowres_image.png
+│   └── tissue_positions.csv
 └── Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv
 ```
 
@@ -78,13 +78,16 @@ The `ovarian-carcinoma` directory was then copied to `/shared/data/training-modu
 This data comes from this `GEO` record: <https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM8478586>, which is associated with [Reinecke et al. (2025)](https://aacrjournals.org/clincancerres/article/31/2/414/751106/Aberrant-Activation-of-Wound-Healing-Programs).
 This data needs to be filtered and normalized for input to workshop notebooks.
 
-To download and prepare input data for the workshop, change directories to the `setup/osteo` directory and run:
+In addition, the [OsteoCAR mouse metastasis reference](https://figshare.com/articles/dataset/OsteoCAR_A_multi-species_single-cell_atlas_of_primary_and_metastatic_osteosarcoma/31029559) also needs to be obtained and prepared for the workshop as the osteosarcoma deconvolution reference.
+
+This code requires the `qs` (not `qs2`) package to read in the raw osteo reference.
+As of January 2026, this package is not currently from CRAN (but it may be back one day), so you may need to install with `remotes::install_github("qsbase/qs")`.
+
+To download and prepare input data and the reference for the workshop, change directories to the `setup/osteo` directory and run:
 
 ```sh
 snakemake -j2
 ```
 
-This will place the downloaded files from GEO and the normalized SPE object into `/shared/data/training-modules/scRNA-seq-advanced/data/osteo/GSM8478586/`.
-
-
+This will place the downloaded files from GEO and the normalized SPE object into `/shared/data/training-modules/scRNA-seq-advanced/data/osteo/GSM8478586/`, and it will place the osteo reference into `/shared/data/training-modules/scRNA-seq-advanced/data/osteo/reference/`.
 

--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -78,9 +78,9 @@ The `ovarian-carcinoma` directory was then copied to `/shared/data/training-modu
 This data comes from this `GEO` record: <https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM8478586>, which is associated with [Reinecke et al. (2025)](https://aacrjournals.org/clincancerres/article/31/2/414/751106/Aberrant-Activation-of-Wound-Healing-Programs).
 This data needs to be filtered and normalized for input to workshop notebooks.
 
-In addition, the [OsteoCAR mouse metastasis reference](https://figshare.com/articles/dataset/OsteoCAR_A_multi-species_single-cell_atlas_of_primary_and_metastatic_osteosarcoma/31029559) also needs to be obtained and prepared for the workshop as the osteosarcoma deconvolution reference.
+In addition, the [`OsteoCAR` mouse metastasis reference](https://figshare.com/articles/dataset/OsteoCAR_A_multi-species_single-cell_atlas_of_primary_and_metastatic_osteosarcoma/31029559) also needs to be obtained and prepared for the workshop as the osteosarcoma deconvolution reference.
 
-This code requires the `qs` (not `qs2`) package to read in the raw osteo reference.
+This code requires the `qs` (not `qs2`) package to read in the raw `OsteoCAR` reference.
 As of January 2026, this package is not currently from CRAN (but it may be back one day), so you may need to install with `remotes::install_github("qsbase/qs")`.
 
 To download and prepare input data and the reference for the workshop, change directories to the `setup/osteo` directory and run:

--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -26,7 +26,7 @@ To obtain these files, use the script `wilms-tumor/download-wilms-tumor.R`.
 This script requires the [`ScPCAr` package](https://alexslemonade.github.io/ScPCAr/), which can be installed with `remotes::install_github("AlexsLemonade/ScPCAr")`.
 
 This will create a directory `../data/wilms-tumor/SCPCS00190/` with the following files:
-```markdown
+```console
 SCPCS000190
 └── spaceranger
     ├── raw_feature_bc_matrix
@@ -52,7 +52,7 @@ This data comes from this 10x Genomics dataset: <https://www.10xgenomics.com/dat
 This data, as well as its corresponding Visium probe set, can be downloaded with `ovarian-carcinoma/download-ovarian.R`.
 This will create a directory `../data/ovarian-carcinoma/spaceranger/` with the following files:
 
-```markdown
+```console
 spaceranger
 ├── filtered_feature_bc_matrix
 │   ├── barcodes.tsv.gz
@@ -89,5 +89,28 @@ To download and prepare input data and the reference for the workshop, change di
 snakemake -j2
 ```
 
-This will place the downloaded files from GEO and the normalized SPE object into `/shared/data/training-modules/scRNA-seq-advanced/data/osteo/GSM8478586/`, and it will place the osteo reference into `/shared/data/training-modules/scRNA-seq-advanced/data/osteo/reference/`.
+This will create both `../data/references/mm_mets_osteo_ref.rds` and a directory `../data/osteo/` with the following files:
 
+```console
+osteo
+└── GSM8478586
+    ├── normalized
+    │   └── osteo_normalized_spe.rds
+    └── spaceranger
+        ├── filtered_feature_bc_matrix
+        │   ├── barcodes.tsv.gz
+        │   ├── features.tsv.gz
+        │   └── matrix.mtx.gz
+        └── spatial
+            ├── aligned_fiducials.jpg
+            ├── aligned_tissue_image.jpg
+            ├── cytassist_image.tiff
+            ├── detected_tissue_image.jpg
+            ├── scalefactors_json.json
+            ├── spatial_enrichment.csv
+            ├── tissue_hires_image.png
+            ├── tissue_lowres_image.png
+            └── tissue_positions.csv
+```
+
+Then, `mm_mets_osteo_ref.rds` was copied to `/shared/data/training-modules/spatial/data/reference/`, and the `osteo` directory was copied to `/shared/data/training-modules/spatial/data/`. 

--- a/spatial/setup/osteo/Snakefile
+++ b/spatial/setup/osteo/Snakefile
@@ -26,7 +26,7 @@ rule download_spatial:
 
 rule download_osteo_ref:
     output:
-        temp("mm_mets_osteo_ref_raw.qs")
+        "mm_mets_osteo_ref_raw.qs"
     params:
         osteo_ref_url = config["osteo_ref_url"]
     shell:

--- a/spatial/setup/osteo/Snakefile
+++ b/spatial/setup/osteo/Snakefile
@@ -4,15 +4,16 @@ from pathlib import Path
 configfile: "config.yaml"
 
 base_dir        = Path(config["base_dir"])
+ref_dir         = Path(config["ref_dir"])
 sample_dir      = base_dir / config["sample_id"]
 spaceranger_dir = sample_dir / "spaceranger"
 normalized_dir  = sample_dir / "normalized"
-ref_dir         = base_dir / "reference"
+mito_genes_file = ref_dir / "mm_mitochondrial_genes.tsv"
 
 rule targets:
     input:
-        normalized_dir / config["output_rds"],
-        ref_dir / config["output_osteo_ref"]
+        normalized_dir / config["output_osteo_spe"],
+        ref_dir / config["output_osteo_ref"],
 
 rule download_spatial:
     output:
@@ -21,33 +22,7 @@ rule download_spatial:
     params:
         geo_url = config["geo_url"]
     shell:
-        "curl -L {params.geo_url} | tar xz --strip-components=1 -C {spaceranger_dir}"
-
-# import as SPE, filter, normalize, and export rds as preparation for the spatial clustering notebook
-rule prepare_sce:
-    input:
-        filtered_matrix = spaceranger_dir / "filtered_feature_bc_matrix",
-        spatial         = spaceranger_dir / "spatial",
-        mito_genes_file = config["mito_genes_file"],
-    output:
-        normalized_dir / config["output_rds"]
-    params:
-        notebook = "prepare-osteo-data.Rmd"
-    shell:
-        """
-        Rscript -e "
-          rmarkdown::render(
-            '{params.notebook}',
-            params = list(
-              filtered_matrix = '{input.filtered_matrix}',
-              spatial_dir     = '{input.spatial}',
-              mito_genes_file = '{input.mito_genes_file}',
-              output_rds      = '{output}'
-            ),
-            output_file = fs::file_temp()
-          )
-        "
-        """
+        "mkdir -p {spaceranger_dir} && curl -L {params.geo_url} | tar xz --strip-components=1 -C {spaceranger_dir}"
 
 rule download_osteo_ref:
     output:
@@ -57,10 +32,42 @@ rule download_osteo_ref:
     shell:
         "curl -Lo {output} {params.osteo_ref_url}"
 
+# import SPE, filter, normalize, and export rds as preparation for the 
+# spatial clustering notebook
+rule prepare_sce:
+    input:
+        filtered_matrix = spaceranger_dir / "filtered_feature_bc_matrix",
+        spatial         = spaceranger_dir / "spatial",
+        mito_genes_file = mito_genes_file,
+    output:
+        normalized_dir / config["output_osteo_spe"]
+    params:
+        notebook  = "prepare-osteo-data.Rmd",
+        sample_id = config["sample_id"],
+    shell:
+        """
+        Rscript -e "
+          rmarkdown::render(
+            '{params.notebook}',
+            params = list(
+              filtered_matrix = '{input.filtered_matrix}',
+              spatial_dir     = '{input.spatial}',
+              mito_genes_file = '{input.mito_genes_file}',
+              sample_id       = '{params.sample_id}',
+              output_rds      = '{output}'
+            ),
+            output_file = fs::file_temp()
+          )
+        "
+        """
+
+
+# Downsample and convert the osteo reference from Seurat -> SCE as preparation
+# for the deconvolution notebooks
 rule reformat_osteo_ref:
     input:
         osteo_ref = "mm_mets_osteo_ref_raw.qs", # doesn't need temp()
-        spe       = normalized_dir / config["output_rds"]
+        spe       = normalized_dir / config["output_osteo_spe"],
     output:
         ref_dir / config["output_osteo_ref"]
     params:
@@ -68,7 +75,7 @@ rule reformat_osteo_ref:
     shell:
         """
         Rscript {params.script} \
-            --input_osteo_ref {input.osteo_ref} \
-            --output_osteo_ref {output} \
+            -i {input.osteo_ref} \
+            -o {output} \
             --spe {input.spe}
         """

--- a/spatial/setup/osteo/Snakefile
+++ b/spatial/setup/osteo/Snakefile
@@ -1,4 +1,5 @@
-# Workflow for preparing the GSM8478586 osteosarcoma dataset
+# Workflow for preparing the GSM8478586 osteosarcoma dataset and OsteoCar mouse metastasis reference
+
 from pathlib import Path
 
 configfile: "config.yaml"
@@ -26,7 +27,7 @@ rule download_spatial:
 
 rule download_osteo_ref:
     output:
-        temp("mm_mets_osteo_ref_raw.qs")
+        config["output_osteo_ref_raw"]
     params:
         osteo_ref_url = config["osteo_ref_url"]
     shell:
@@ -66,7 +67,7 @@ rule prepare_sce:
 # for the deconvolution notebooks
 rule reformat_osteo_ref:
     input:
-        osteo_ref = "mm_mets_osteo_ref_raw.qs", # doesn't need temp()
+        osteo_ref = config["output_osteo_ref_raw"],
         spe       = normalized_dir / config["output_osteo_spe"],
     output:
         ref_dir / config["output_osteo_ref"]

--- a/spatial/setup/osteo/Snakefile
+++ b/spatial/setup/osteo/Snakefile
@@ -1,45 +1,74 @@
 # Workflow for preparing the GSM8478586 osteosarcoma dataset
+from pathlib import Path
+
 configfile: "config.yaml"
-sample_dir = os.path.join(config["base_dir"], config["sample_id"])
-spaceranger_dir = os.path.join(sample_dir, "spaceranger")
-normalized_dir = os.path.join(sample_dir, "normalized")
+
+base_dir        = Path(config["base_dir"])
+sample_dir      = base_dir / config["sample_id"]
+spaceranger_dir = sample_dir / "spaceranger"
+normalized_dir  = sample_dir / "normalized"
+ref_dir         = base_dir / "reference"
 
 rule targets:
-  input:
-    os.path.join(normalized_dir, config["output_rds"])
+    input:
+        normalized_dir / config["output_rds"],
+        ref_dir / config["output_osteo_ref"]
 
 rule download_spatial:
-  output:
-    directory(os.path.join(spaceranger_dir, "filtered_feature_bc_matrix")),
-    directory(os.path.join(spaceranger_dir, "spatial")),
-  params:
-    url = config["url"]
-  shell:
-    "curl -L {params.url} | tar xz --strip-components=1 -C {spaceranger_dir}"
-
+    output:
+        directory(spaceranger_dir / "filtered_feature_bc_matrix"),
+        directory(spaceranger_dir / "spatial"),
+    params:
+        geo_url = config["geo_url"]
+    shell:
+        "curl -L {params.geo_url} | tar xz --strip-components=1 -C {spaceranger_dir}"
 
 # import as SPE, filter, normalize, and export rds as preparation for the spatial clustering notebook
 rule prepare_sce:
-  input:
-    filtered_matrix = os.path.join(spaceranger_dir, "filtered_feature_bc_matrix"),
-    spatial         = os.path.join(spaceranger_dir, "spatial"),
-    mito_genes_file = config["mito_genes_file"],
-  output:
-    os.path.join(normalized_dir, config["output_rds"])
-  params:
-    notebook = "prepare-osteo-data.Rmd"
-  shell:
-    """
-    Rscript -e "
-      rmarkdown::render(
-        '{params.notebook}',
-        params = list(
-          filtered_matrix = '{input.filtered_matrix}',
-          spatial_dir     = '{input.spatial}',
-          mito_genes_file = '{input.mito_genes_file}',
-          output_rds      = '{output}'
-        ),
-        output_file = fs::file_temp()
-      )
-    "
-    """
+    input:
+        filtered_matrix = spaceranger_dir / "filtered_feature_bc_matrix",
+        spatial         = spaceranger_dir / "spatial",
+        mito_genes_file = config["mito_genes_file"],
+    output:
+        normalized_dir / config["output_rds"]
+    params:
+        notebook = "prepare-osteo-data.Rmd"
+    shell:
+        """
+        Rscript -e "
+          rmarkdown::render(
+            '{params.notebook}',
+            params = list(
+              filtered_matrix = '{input.filtered_matrix}',
+              spatial_dir     = '{input.spatial}',
+              mito_genes_file = '{input.mito_genes_file}',
+              output_rds      = '{output}'
+            ),
+            output_file = fs::file_temp()
+          )
+        "
+        """
+
+rule download_osteo_ref:
+    output:
+        temp("mm_mets_osteo_ref_raw.qs")
+    params:
+        osteo_ref_url = config["osteo_ref_url"]
+    shell:
+        "curl -Lo {output} {params.osteo_ref_url}"
+
+rule reformat_osteo_ref:
+    input:
+        osteo_ref = "mm_mets_osteo_ref_raw.qs", # doesn't need temp()
+        spe       = normalized_dir / config["output_rds"]
+    output:
+        ref_dir / config["output_osteo_ref"]
+    params:
+        script = "reformat-osteo-ref.R"
+    shell:
+        """
+        Rscript {params.script} \
+            --input_osteo_ref {input.osteo_ref} \
+            --output_osteo_ref {output} \
+            --spe {input.spe}
+        """

--- a/spatial/setup/osteo/config.yaml
+++ b/spatial/setup/osteo/config.yaml
@@ -17,3 +17,4 @@ osteo_ref_url: https://api.figshare.com/v2/file/download/60882436
 # Output files to create
 output_osteo_spe: osteo_normalized_spe.rds
 output_osteo_ref: mm_mets_osteo_ref.rds
+output_osteo_ref_raw: mm_mets_osteo_ref_raw.qs

--- a/spatial/setup/osteo/config.yaml
+++ b/spatial/setup/osteo/config.yaml
@@ -1,14 +1,18 @@
 # The main directory where files will be stored
 base_dir: /shared/data/training-modules/spatial/data/osteo
 
-# sample name for path creation:
+# sample name for path creation
 sample_id: GSM8478586
 
-# URL for downloading from GEO
-url: https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM8478nnn/GSM8478586/suppl/GSM8478586_SP0001.tar.gz
+# URL for downloading original dataset from GEO
+geo_url: https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM8478nnn/GSM8478586/suppl/GSM8478586_SP0001.tar.gz
+
+# URL for downloading OsteoCAR mouse mets reference
+osteo_ref_url: https://api.figshare.com/v2/file/download/60882436
 
 # Mito genes file used for processing
 mito_genes_file: /shared/data/training-modules/spatial/data/reference/hs_mitochondrial_genes.tsv
 
-# Output file to create
-output_rds: osteo_normalized_spe.rds
+# Output files to create
+output_osteo_spe: osteo_normalized_spe.rds
+output_osteo_ref: mm_mets_osteo_ref.rds

--- a/spatial/setup/osteo/config.yaml
+++ b/spatial/setup/osteo/config.yaml
@@ -1,5 +1,8 @@
 # The main directory where files will be stored
-base_dir: /shared/data/training-modules/spatial/data/osteo
+base_dir: ../../data/osteo/
+
+# Reference directory
+ref_dir: ../../data/reference/
 
 # sample name for path creation
 sample_id: GSM8478586
@@ -10,8 +13,6 @@ geo_url: https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM8478nnn/GSM8478586/suppl/GS
 # URL for downloading OsteoCAR mouse mets reference
 osteo_ref_url: https://api.figshare.com/v2/file/download/60882436
 
-# Mito genes file used for processing
-mito_genes_file: /shared/data/training-modules/spatial/data/reference/hs_mitochondrial_genes.tsv
 
 # Output files to create
 output_osteo_spe: osteo_normalized_spe.rds

--- a/spatial/setup/osteo/prepare-osteo-data.Rmd
+++ b/spatial/setup/osteo/prepare-osteo-data.Rmd
@@ -7,7 +7,7 @@ params:
   filtered_matrix: "../../data/osteo/GSM8478586/spaceranger/filtered_feature_bc_matrix"
   spatial_dir: "../../data/osteo/GSM8478586/spaceranger/spatial"
   output_rds: "../../data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds"
-  mito_genes_file: "../../data/reference/hs_mitochondrial_genes.tsv"
+  mito_genes_file: "../../data/reference/mm_mitochondrial_genes.tsv"
   sample_id: "GSM8478586"
 ---
 
@@ -87,15 +87,18 @@ Now, perform filtering:
 mito_genes <- readr::read_tsv(params$mito_genes_file) |>
   dplyr::filter(gene_id %in% rownames(spe)) |>
   dplyr::pull(gene_id)
+mito_genes
 ```
+
+Turns out there is no overlap, which is not actually unexpected.
+This data is from Visium and has 19465 genes, corresponding to the Mouse Visium v1 probe set which does not have mitochondrial genes.
+Therefore, we can skip filtering on mitochondrial percentage.
 
 
 ```{r}
 spe <- spe |>
   # calculate per-spot statistics
-  scuttle::addPerCellQC(
-    subsets = list(mito = mito_genes)
-  ) |> 
+  scuttle::addPerCellQC() |> 
   # Detect local outliers using defaults 
   SpotSweeper::localOutliers(
     metric = "sum",
@@ -104,12 +107,7 @@ spe <- spe |>
   SpotSweeper::localOutliers(
     metric = "detected",
     direction = "lower"
-  ) |> 
-  SpotSweeper::localOutliers(
-    metric = "subsets_mito_percent",
-    direction = "higher", # we want to remove HIGHER values
-    log = FALSE # don't log
-)
+  ) 
 ```
 
 There are this many outlier spots to remove:
@@ -117,9 +115,8 @@ There are this many outlier spots to remove:
 ```{r}
 # identify and remove local outliers
 spe$local_outliers <- spe$sum_outliers |
-  spe$detected_outliers |
-  spe$subsets_mito_percent_outliers
-print(sum(spe$local_outliers))
+  spe$detected_outliers
+print(sum(spe$local_outliers)) # 20 spots
 ```
 
 ```{r}

--- a/spatial/setup/osteo/prepare-osteo-data.Rmd
+++ b/spatial/setup/osteo/prepare-osteo-data.Rmd
@@ -4,16 +4,23 @@ author: Stephanie Spielman for CCDL
 date: 2026
 output: html_notebook
 params:
-  filtered_matrix: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/spaceranger/filtered_feature_bc_matrix"
-  spatial_dir: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/spaceranger/spatial"
-  output_rds: "/shared/data/training-modules/spatial/data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds"
-  mito_genes_file: "/shared/data/training-modules/spatial/data/reference/hs_mitochondrial_genes.tsv"
+  filtered_matrix: "../../data/osteo/GSM8478586/spaceranger/filtered_feature_bc_matrix"
+  spatial_dir: "../../data/osteo/GSM8478586/spaceranger/spatial"
+  output_rds: "../../data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds"
+  mito_genes_file: "../../data/reference/hs_mitochondrial_genes.tsv"
+  sample_id: "GSM8478586"
 ---
 
 This notebook prepares the osteosarcoma sample from [`GSM8478586`](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM8478586) for analysis in the workshop by performing filtering and normalization.
 It is meant to be run from the [snakemake workflow](Snakemake) in this directory.
 
-Note that this notebook runs only deterministic algorithms.
+Note that this notebook runs only deterministic algorithms, so no seed is set.
+
+```{r}
+suppressPackageStartupMessages({
+  library(SpatialExperiment)
+})
+```
 
 First, check paths:
 
@@ -26,16 +33,51 @@ stopifnot(
 )
 ```
 
-Begin by importing the SPE:
+Begin by importing the SPE.
+At this time of writing, `VisiumIO` does not support loading images into memory; it only stores the full path to the image resources.
+Therefore, we'll construct the SPE from scratch.
 
 ```{r}
-spe <- VisiumIO::import(
-  VisiumIO::TENxVisium(
-    resources = params$filtered_matrix,
-    spatialResource = params$spatial_dir,
-    images = c("hires", "cytassist")
-  )
+# first read in counts
+# don't include column names; those will come in from the coords_table
+sce <- DropletUtils::read10xCounts(
+  params$filtered_matrix
 )
+
+# read in image data with load = TRUE, which is default but we'll specify to be safe
+# this function can only accommodate: "lowres", "hires", "detected", "aligned"
+img_hires <- SpatialExperiment::readImgData(
+    path = params$spatial_dir,
+    sample_id = params$sample_id, 
+    imageSources = file.path(params$spatial_dir, "tissue_hires_image.png"),
+    scaleFactors = file.path(params$spatial_dir, "scalefactors_json.json"),
+    load = TRUE
+)
+
+# read in spatial coordinates
+coords_table <- readr::read_csv(
+  file.path(
+    params$spatial_dir,
+    "tissue_positions.csv"
+  )
+) |>
+  dplyr::filter(barcode %in% sce$Barcode)
+# confirm order matches
+coords_table <- coords_table[match(sce$Barcode, coords_table$barcode), ]
+stopifnot(
+  "Barcode mismatch when making SPE" = all(sce$Barcode == coords_table$barcode)
+)
+
+# combine
+spe <- SpatialExperiment(
+  assays = list(counts = assay(sce)),
+  rowData = rowData(sce),
+  colData = DataFrame(coords_table, row.names = coords_table$barcode),
+  spatialCoordsNames = c("pxl_col_in_fullres", "pxl_row_in_fullres"),
+  imgData = img_hires,
+  sample_id = params$sample_id
+)
+
 spe
 ```
 
@@ -98,7 +140,6 @@ Finally, we can export with compression.
 
 ```{r}
 readr::write_rds(spe, params$output_rds, compress = "gz")
-
 ```
 
 ## Session info

--- a/spatial/setup/osteo/reformat-osteo-ref.R
+++ b/spatial/setup/osteo/reformat-osteo-ref.R
@@ -5,29 +5,27 @@
 # - converts rownames to Ensembl, using a provided SPE
 # - converts to SCE
 
-library(optparse)
-library(Seurat)
-library(SpatialExperiment)
-
+suppressPackageStartupMessages({
+  library(optparse)
+  library(Seurat)
+  library(SpatialExperiment)
+})
 
 
 option_list <- list(
   make_option(
-    opt = c("-i", "--input_osteo_ref"),
+    opt = c("-i", "--input"),
     type = "character",
-    default = "setup/osteo/mm_mets_osteo_ref_raw.qs",
     help = "Path to the input osteo reference RDS file."
   ),
   make_option(
-    opt = c("-o", "--output_osteo_ref"),
+    opt = c("-o", "--output"),
     type = "character",
-    default = "setup/osteo/out.rds",
     help = "Path to the output formatted osteo reference RDS file."
   ),
   make_option(
     opt = c("--spe"),
     type = "character",
-    default = "data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds",
     help = "Path to SPE file to use for mapping IDs"
   )
 )
@@ -35,16 +33,16 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 stopifnot(
-  "Must provide the input osteo ref file with -i" = file.exists(opt$input_osteo_ref),
-  "Must provide the output osteo ref file with -o" = !is.null(opt$output_osteo_ref),
-  "Must provide an APE to use for mapping IDs with --spe" = file.exists(opt$spe)
+  "Must provide the input osteo ref file with -i" = file.exists(opt$input),
+  "Must provide the output osteo ref file with -o" = !is.null(opt$output),
+  "Must provide an SPE to use for mapping IDs with --spe" = file.exists(opt$spe)
 )
 
 # Read in SPE
-spe <- readRDS(opt$spe)
+spe <- readr::read_rds(opt$spe)
 
 ## Read in the original reference object with qs
-mm_mets <- qs::qread(opt$input_osteo_ref)
+mm_mets <- qs::qread(opt$input)
 
 # Downsample for reproducibility
 cells_keep <- mm_mets@meta.data |>
@@ -83,4 +81,4 @@ reducedDims(ref_sce_ensembl) <- NULL
 logcounts(ref_sce_ensembl) <- NULL
 
 # Export
-readr::write_rds(ref_sce_ensembl, opt$output_osteo_ref)
+readr::write_rds(ref_sce_ensembl, opt$output)

--- a/spatial/setup/osteo/reformat-osteo-ref.R
+++ b/spatial/setup/osteo/reformat-osteo-ref.R
@@ -1,0 +1,86 @@
+#!/usr/bin/env Rscript
+
+# This script reformats the osteo reference:
+# - downsamples to <= 10000 cells per L1 cell type
+# - converts rownames to Ensembl, using a provided SPE
+# - converts to SCE
+
+library(optparse)
+library(Seurat)
+library(SpatialExperiment)
+
+
+
+option_list <- list(
+  make_option(
+    opt = c("-i", "--input_osteo_ref"),
+    type = "character",
+    default = "setup/osteo/mm_mets_osteo_ref_raw.qs",
+    help = "Path to the input osteo reference RDS file."
+  ),
+  make_option(
+    opt = c("-o", "--output_osteo_ref"),
+    type = "character",
+    default = "setup/osteo/out.rds",
+    help = "Path to the output formatted osteo reference RDS file."
+  ),
+  make_option(
+    opt = c("--spe"),
+    type = "character",
+    default = "data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds",
+    help = "Path to SPE file to use for mapping IDs"
+  )
+)
+# parse arguments
+opt <- parse_args(OptionParser(option_list = option_list))
+
+stopifnot(
+  "Must provide the input osteo ref file with -i" = file.exists(opt$input_osteo_ref),
+  "Must provide the output osteo ref file with -o" = !is.null(opt$output_osteo_ref),
+  "Must provide an APE to use for mapping IDs with --spe" = file.exists(opt$spe)
+)
+
+# Read in SPE
+spe <- readRDS(opt$spe)
+
+## Read in the original reference object with qs
+mm_mets <- qs::qread(opt$input_osteo_ref)
+
+# Downsample for reproducibility
+cells_keep <- mm_mets@meta.data |>
+  tibble::rownames_to_column("barcode") |>
+  dplyr::group_by(Ann_Level1) |>
+  dplyr::slice_sample(n = 10000) |>
+  dplyr::pull(barcode)
+
+mm_mets <- mm_mets[, cells_keep]
+
+# Convert to SCE
+ref_sce <- Seurat::as.SingleCellExperiment(mm_mets)
+
+# Convert row names to Ensembl as close as we can
+map_df <- rowData(spe) |>
+  as.data.frame() |>
+  dplyr::select(gene_symbol = Symbol, ensembl  = ID)
+
+# Match gene symbols in reference to the map_df
+match_idx <- match(rownames(ref_sce), map_df$gene_symbol)
+
+# Track unmatched genes for posterity
+unmatched <- rownames(ref_sce)[is.na(match_idx)]
+cat(sprintf("Genes lost (no Ensembl match): %d / %d (%.1f%%)\n",
+            length(unmatched), nrow(ref_sce),
+            100 * length(unmatched) / nrow(ref_sce)))
+# ---> Genes lost (no Ensembl match): 3077 / 16807 (18.3%)
+
+# Subset reference to matched genes only and toggle in ensembl rownames
+matched_mask <- !is.na(match_idx)
+ref_sce_ensembl <- ref_sce[matched_mask, ]
+rownames(ref_sce_ensembl) <- map_df$ensembl[match_idx[matched_mask]]
+
+# Remove extra items in the object to save a bit of space
+reducedDims(ref_sce_ensembl) <- NULL
+logcounts(ref_sce_ensembl) <- NULL
+
+# Export
+readr::write_rds(ref_sce_ensembl, opt$output_osteo_ref)

--- a/spatial/setup/osteo/reformat-osteo-ref.R
+++ b/spatial/setup/osteo/reformat-osteo-ref.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-# This script reformats the osteo reference:
+# This script reformats the osteo reference Seurat object
 # - downsamples to <= 10000 cells per L1 cell type
 # - converts rownames to Ensembl, using a provided SPE
 # - converts to SCE
@@ -16,7 +16,7 @@ option_list <- list(
   make_option(
     opt = c("-i", "--input"),
     type = "character",
-    help = "Path to the input osteo reference RDS file."
+    help = "Path to the input osteo reference qs file."
   ),
   make_option(
     opt = c("-o", "--output"),

--- a/spatial/setup/osteo/reformat-osteo-ref.R
+++ b/spatial/setup/osteo/reformat-osteo-ref.R
@@ -38,6 +38,8 @@ stopifnot(
   "Must provide an SPE to use for mapping IDs with --spe" = file.exists(opt$spe)
 )
 
+set.seed(2026)
+
 # Read in SPE
 spe <- readr::read_rds(opt$spe)
 
@@ -56,7 +58,8 @@ mm_mets <- mm_mets[, cells_keep]
 # Convert to SCE
 ref_sce <- Seurat::as.SingleCellExperiment(mm_mets)
 
-# Convert row names to Ensembl as close as we can
+# Convert row names to Ensembl as close as we can, using gene symbols in the SPE
+# Note the SPE gene symbols are the mouse v1 Visium probe set, so less than a transcriptome
 map_df <- rowData(spe) |>
   as.data.frame() |>
   dplyr::select(gene_symbol = Symbol, ensembl  = ID)


### PR DESCRIPTION
Closes #987 
Partly addresses #988 

This PR updates the Snakemake workflow that prepares osteo data in several ways:

1. I updated how we read in the osteo SPE to ensure the image is actually preserved, and it seems to work. The code is more verbose but it is what it is!
2. I fixed a bug in the existing notebook/pipeline that was specifying the human mito genes file. This is in fact a mouse dataset, and also (as now explained) there are no mito genes anyways! I still think it's appropriate to read it in for posterity though, hence the added text in the notebook.
3. I added 2 additional steps to the Snakefile (and some config mods as well), to a) download and b) reformat the osteocar mouse metastasis reference (subset to 10000 cells per annotation, and convert rownames to symbols).
   - I want to note the `qs` situation - authors fell out of compliance with CRAN so the package got removed, and `qs2` doesn't work to read in files created with `qs`. This is a known annoyance for a lot of people! Now we too can be annoyed.
4. I updated paths in general to use local paths, for two reasons:
    - This more closely matches other setup code which prepares into local directories, not `/shared`
    - I am currently running/developing locally with the workshop coming up, juuust in case something needs to happen with the server. Relative paths are just better.
5. I updated the Snakefile to used pathlib, which is nicer to look at and work with.