### PR TITLE
Export RDS from intro spatial notebook

### DIFF
--- a/scripts/link-data.sh
+++ b/scripts/link-data.sh
@@ -117,6 +117,7 @@ link_locs=(
   spatial/data/ovarian-carcinoma/spaceranger
   spatial/data/wilms-tumor/SCPCS000190/spaceranger
   spatial/data/osteo/GSM8478586/normalized
+  spatial/data/reference
   machine-learning/data/open-pbta
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma

--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -58,6 +58,7 @@ sync_dirs=(
   scRNA-seq-advanced/data/wilms-tumor/spaceranger
   spatial/data/ovarian-carcinoma/spaceranger
   spatial/data/osteo/GSM8478586/spaceranger
+  spatial/data/reference
   machine-learning/data/open-pbta/processed
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma
@@ -76,8 +77,7 @@ sync_files=(
   scRNA-seq-advanced/data/ewing-sarcoma/annotations/ewing_sarcoma_sample_metadata.tsv
   scRNA-seq-advanced/data/rms/annotations/rms_sample_metadata.tsv
   scRNA-seq-advanced/data/reference/hs_mitochondrial_genes.tsv
-  spatial/data/reference/hs_mitochondrial_genes.tsv
-  spatial/data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds  
+  spatial/data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds
 )
 
 output_files=(

--- a/spatial/01-spatial_intro.Rmd
+++ b/spatial/01-spatial_intro.Rmd
@@ -882,6 +882,24 @@ Did you expect this based on the H&E?
 Based on these (very few, very cursory, and highly exploratory!) plots, do you think there is evidence for blastemal and stromal compartments in this sample?
 
 
+## Export
+
+Finally, we'll export the SPE object to the RDS file `output_spe_file` we defined at the top of the notebook.
+
+Very importantly, the version of `VisiumIO` that we used to read in the SPE object earlier actually does not store the images themselves within the SPE object. 
+Instead, it stores the _full path_ to the image files to reload them if the exported SPE is read back into R.
+This works fine if the object is read back into R on exactly the same computer and files are in exactly the same places, but when this is not the case, the images will not properly be loaded when reading the object into R.
+
+The `VisiumIO` version included in the (forthcoming) Bioconductor 3.24 release has addressed this and allows you to fully load images rather than just their full paths when reading in Space Ranger output to create an SPE object.
+But for now, this is a limitation to be aware of. 
+
+```{r export spe}
+# export SPE with compression
+readr::write_rds(spe, output_spe_file, compress = "gz")
+```
+
+
+
 ## Session info
 
 To conclude, we'll run the `sessionInfo()` command to print out exactly what system setting and R package versions were used to run this code.


### PR DESCRIPTION
Closes #981 

Here, I'm adding a section to export the RDS from the first spatial notebook with an explanation about the image situation - edits welcome since I'm not 100% sure this is very clear to other readers who are not me!

I also updated the syncup script while I was here, since we have more files in spatial/data/references now (eg the mm mito genes and osteo reference), and I added the reference dir to the link data script too.