### PR TITLE
Update current-modules

### DIFF
--- a/current-modules.json
+++ b/current-modules.json
@@ -1,5 +1,5 @@
 {
-  "release-tag": "2026-may",
-  "modules": ["scRNA-seq", "intro-to-R-tidyverse"],
-  "reference-modules": []
+  "release-tag": "2026-june",
+  "modules": ["scRNA-seq-advanced"],
+  "reference-modules": ["scRNA-seq"]
 }


### PR DESCRIPTION
This PR updates `current-modules.json` for June 2026, where we teach scAdvanced but have the intro materials present as reference.