### PR TITLE
Add deconvolution notebook text, part 1

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -24,6 +24,7 @@ AnnotationDbi
 AnnotationHub
 Aran
 ARI
+artifactual
 Ashburner
 AssayNames
 astrocyte

--- a/spatial/03-deconvolution.Rmd
+++ b/spatial/03-deconvolution.Rmd
@@ -10,41 +10,48 @@ output:
 
 ## Objectives
 
-- coming after the draft is complete.
+- Use RCTD to perform reference-based deconvolution of Visium spots in doublet and full modes
+- Visualize the spatial distribution of estimated cell type proportions across the osteosarcoma tissue
+- Explore patterns of cell type co-occurrence across spots
 
 ## Introduction
 
-We will be using the same mouse osteosarcoma lung metastases sample that we used in the `BANKSY` notebook.
+In this notebook, we'll continue working with the mouse osteosarcoma lung metastases sample from [Reinecke et al. (2025)](https://doi.org/10.1158/1078-0432.CCR-24-0049) that we explored in spatial clustering notebook.
 
-We'll be performing deconvolution to identify cell types present in each spot using the [OsteoCAR reference](https://www.biorxiv.org/content/10.64898/2026.01.13.698472v3), specifically the mouse metastasis reference. 
-Note the importance of having a well-matched reference to the data; you can't find cell types that your reference doesn't contain.
+As we have discussed, each Visium spot captures the combined expression of approximately 5--20 cells, not a single cell.
+While the clustering analysis from the previous notebook identified groups of spots with similar transcriptional profiles, clustering alone cannot tell us which specific cell types are contributing to each spot's expression.
+To move from spot-level expression to cell-type-level information, we can apply **deconvolution**, which decomposes each spot's bulk gene expression into contributions from different cell types and estimates their relative proportions.
 
-We'll use RCTD (Robust Cell Type Deconvolution) available in the `spacexr` package which uses MLE to estimate relative cell type weights which can be interpreted as proportions of cell types per spot. 
+Specifically, we'll perform deconvolution using RCTD (Robust Cell Type Deconvolution), which is available in the `spacexr` package ([Cable et al. 2022](https://doi.org/10.1038/s41587-021-00830-w)).
+RCTD uses maximum likelihood estimation to model each spot's expression as a weighted combination of reference cell type profiles, using a single-cell reference dataset.
+RCTD also accounts for "platform effects" between the reference dataset, which was sequenced with single-cell technology, and the query spatial transcriptomics dataset, as the differences in library preparation between these platforms can introduce artifactual differences between gene expression measurements.
+
+
+As with reference-based cell type annotation on single-cell data, it's critical for deconvolution to use a reference dataset that contains the cell types you expect to find in your data.
+Here, we'll use the [OsteoCAR reference](https://www.biorxiv.org/content/10.64898/2026.01.13.698472v3), a single-cell atlas for osteosarcoma that has been divided into "sub-references" for human and mouse samples, as well as for primary and metastatic samples.
+We'll specifically use the mouse metastasis-specific portion of this reference, which we expect will be a reasonably good match to our Visium sample which is also from a mouse osteosarcoma lung metastasis. 
 
 
 ## Set up
 
+To begin, we'll load the packages we'll use throughout this notebook and setting the random seed.
 
 ```{r libraries}
-# The main class we use for spatial transcriptomic data
 suppressPackageStartupMessages({
+  # The main class we use for spatial transcriptomic data
   library(SpatialExperiment)
+  # Packages to support plotting
+  library(ggspavis)
+  library(ggplot2)
+  library(patchwork)
 })
 
-
-# To support plotting
-library(ggspavis)
-library(ggplot2)
-library(patchwork)
-
-# Set ggplot2 theme
-theme_set(theme_bw())
+set.seed(2026)
 ```
-
 
 ### Directories and files
 
-We'll read in the file we exported in the clustering notebook. 
+Next, we'll define paths to the normalized SPE object prepared prior to this module, stored in a sample-specific subdirectory of `data/osteo`.
 
 ```{r inputs}
 # define sample id we'll be analyzing 
@@ -59,15 +66,16 @@ sample_dir <- file.path(data_dir, "osteo", sample_id, "normalized")
 normalized_rds <- file.path(sample_dir, "osteo_normalized_spe.rds")
 ```
 
-We'll also need to define the file with the reference, which we have prepared for you by downsampling number of cells for RCTD compatibility, converting gene symbols to Ensembl (to match our object), and converting to `SCE` object; see here: <https://github.com/AlexsLemonade/training-modules/blob/master/spatial/setup/osteo/reformat-osteo-ref.R>.
+Next, we'll define the file with the OsteoCAR mouse metastasis reference.
+Note that we have prepared this object from its original form for use in this notebook by converting it from a Seurat to a `SingleCellExperment` object, converting row names from gene symbols to Ensembl ids (to match our object), and downsampling the number of cells for RCTD compatibility.
+You can see the code we use for this pre-processing here: <https://github.com/AlexsLemonade/training-modules/blob/master/spatial/setup/osteo/reformat-osteo-ref.R>.
 
 ```{r input reference}
 ref_dir <- file.path(data_dir, "reference")
 ref_rds <- file.path(ref_dir, "mm_mets_osteo_ref.rds")
 ```
 
-Also define the output file which we'll save in an `analysis` directory that we'll also create.
-We'll save space by exporting a TSV with deconvolution results.
+We'll conclude this notebook by exporting a TSV with deconvolution results to an `analysis` directory, so let's define this here.
 
 ```{r analysis dir}
 analysis_dir <- file.path("analysis/osteo")
@@ -79,14 +87,49 @@ rctd_tsv <- file.path(analysis_dir, "osteo_deconvolution.tsv")
 
 ## Import
 
+### Import the reference SCE
+
+We'll start by reading in the reference SCE object we'll use for deconvolution and define it as `osteo_ref`.
+
+```{r import ref, live = TRUE}
+# read in the reference object
+osteo_ref <- readr::read_rds(ref_rds)
+
+# show the object
+osteo_ref
+```
+
+This object contains about 32,000 cells annotated with several cell type labels, which are stored in its `colData` slot:
+
+```{r reference annotations}
+# show the different annotation levels
+colData(osteo_ref) |>
+  as.data.frame() |>
+  dplyr::select( starts_with("Ann_Level") )
+```
+
+For this notebook, we're going to focus on `Ann_Level1` which contains broad cell type categories, but a more fine-grained analysis might consider `Ann_Level2` or `Ann_Level3`.
+
+Let's see the distribution of cell types in our chosen reference:
+
+```{r count celltypes, live = TRUE}
+colData(osteo_ref) |>
+  as.data.frame() |>
+  dplyr::count(Ann_Level1)
+```
+RCTD expects (although this can be customized) a maximum of 10,000 cells per cell type in the reference, so we downsampled cells to match this expectation during our pre-processing step.
+The original version of this OsteoCAR reference dataset has even more cells. 
+
 ### Import the SPE object
+
+Next, we'll read in the normalized SPE object we'll be running deconvolution on.
 
 ```{r import spe, live = TRUE}
 spe <- readr::read_rds(normalized_rds)
 ```
 
-
-Again, plot the Visium to reorient ourselves:
+Before diving into deconvolution, let's plot the H&E image to reorient ourselves to the tissue.
+We'll refer back to this image throughout the notebook when interpreting the spatial cell type patterns we find.
 
 ```{r plot-visium}
 #| fig.width: 5
@@ -107,8 +150,8 @@ he_plot
 ```
 
 
-Before we dive in, let's look at some marker gene expression to develop a sense of what cell types we might expect in this data given this reference.
-These marker genes were taken from the OsteoCAR paper.
+Let's also look at some marker gene expression to develop a sense of what cell types we might expect in this data given this reference.
+We'll show expression of select marker genes, obtained taken from the OsteoCAR paper, for cell types in the reference.
 
 
 ```{r plot mouse markers}
@@ -155,77 +198,44 @@ mouse_markers |>
   ) |> wrap_plots(ncol = 4)
 ```
 
-Based on these gene expression plots, what cell types do you think are likely common?
+Based on these gene expression plots, what cell types do you think are likely common in the dataset?
 Uncommon?
 Which cell types do you expect might co-occur?
-Any insights into the osteosarcoma tumor microenvironment and level of immune infiltration?
-
-
-### Import the reference SCE
-
-```{r import ref, live = TRUE}
-osteo_ref <- readr::read_rds(ref_rds)
-```
-
-Let's have a look at our reference, it's a `SingleCellExperiment` object.
-
-```{r show reference, live = TRUE}
-osteo_ref
-```
-
-We have about 32,000 cells across several cell types, which are in the `colData`:
-
-```{r reference annotations}
-# show the different annotation levels
-colData(osteo_ref) |>
-  as.data.frame() |>
-  dplyr::select( starts_with("Ann_Level") )
-```
-
-For this notebook, we're going to focus on `Ann_Level1` which contains broad cell type categories, but a more fine-grained analysis might consider `Ann_Level2`.
-Let's see the distribution of our chosen reference:
-
-```{r count celltypes, live = TRUE}
-colData(osteo_ref) |>
-  as.data.frame() |>
-  dplyr::count(Ann_Level1)
-```
-
-Again, when we prepared this reference, we downsampled to randomly select maximum 10000 cells per `Ann_Level1` label.
-
-
-Next, we'll use this reference to attempt to determine which cell types are present in each spot and their relative abundances in the osteosarcoma sample.
+Does this plot give you any insights about the osteosarcoma tumor microenvironment and the level of immune infiltration?
 
 ## Perform deconvolution
+Next, we'll use this reference to attempt to determine which cell types are present in each spot and their relative abundances in the osteosarcoma sample.
 
-RCTD introduction text; RCTD has three modes:
+RCTD models spot expression as a weighted combination of cell type-specific expression profiles from the single-cell reference.
+RCTD offers three different modes you can use to specify how many cell types to model for each spot:
 
-1. Doublet: Constrains the model to infer only two cell types per spot.
-May not be realistic for heterogeneous Visium data. 
-Importantly this is _not the same_ as doublets in single-cell which are multiple cells in a droplet (which we sometimes filter out); this means _two of cell types_ in spot, but we don't know the actual number of cells per spot just that there are likely between 5--20.
-2. Multi: Constrains the model to a given number of cell types per spot, controlled by a parameter `max_multi_types`
-3. Full: No constraints on the model; can have an arbitrary number of cell types per spot
+1. *Doublet mode:*
+This mode constrains the RCTD model to infer a maximum of two cell types per spot, which may or may not be realistic for heterogeneous Visium datasets.
+We have to note as well, this concept of "doublet" is not the same as doublets in single-cell analysis, in which multiple cells are sequenced together in a single droplet.
+Instead, this means at most two _cell types_ can be present in a spot; the exact number of cells per spot is not known, but we assume it's likely between 5--20.
+2. *Multi mode:*
+This mode allows the RCTD model to infer multiple cell types per spot, but no more than a specified maximum number of cell types (`max_multi_types`).
+This mode is an extension of doublet mode, where the maximum can be raised above 2.
+3. *Full mode:*
+This mode does not apply any constraints to the RCTD the model, which is allowed to infer an arbitrary number of cell types per spot
 
-With each, we'll ultimately end up with a per-cell weight which we can interpret as a proportion.
+With each mode, we'll ultimately end up with a per-cell weight which we can interpret as a proportion.
 
-We'll start off with doublet mode.
+We'll begin running deconvolution by running RCTD in doublet mode.
 
 ### Prepare the data for deconvolution
 
-First, we need to prepare the data with `spacexr::createRctd()`.
+Next, we'll prepare the data for deconvolution by running the function `spacexr::createRctd()`.
+This function sets various values and parameters that will be used for the deconvolution procedure, including:
 
-* A normalized expression matrix for the reference is calculated, as the mean-normalized expression of each gene within all cells of each cell type.
-* Platform effect genes are identified
-  * These are used to derive a scalar to account for technological differences between the reference (single-cell) and the query (Visium) data
-  * RCTD identifies these genes are those with some minimum expression level (`gene_cutoff` parameter) and some minimum level of differential expression (`fc_cutoff`).
-* DE genes to use for deconvolution are identified
-  * Uses more stringent thresholds than the scalar genes (`gene_cutoff_reg` and `fc_cutoff_ref`)
-* Estimates other parameters that RCTD will use
-
+* Identifying genes to use to correct for platform effects
+* Identifying differentially expressed genes across cell types in the reference
+* Using those differentially expressed genes, calculating a mean-normalized reference expression matrix that RCTD will use for the deconvolution process itself
 
 We'll leave parameters are their defaults and prepare the data to run deconvolution with `Ann_Level1` labels.
 
 ```{r create_rctd, live = TRUE}
+# prepare the data for deconvolution
 rctd_data <- spacexr::createRctd(
   spe, 
   osteo_ref, 
@@ -233,64 +243,85 @@ rctd_data <- spacexr::createRctd(
 )
 ```
 
-We got a list of several items organized into a structure that RCTD expects.
+We'll briefly look at the contents of `rctd_data`.
+It contains a list of several items organized into a structure that RCTD expects.
 
 ```{r rctd_data summary, live = TRUE}
 summary(rctd_data)
 ```
 
-We'll just look at the Visium data prepared for analysis:
+For example, here is the Visium data prepared for analysis:
 
 ```{r rctd_data SPE}
 rctd_data$spatial_experiment
 ```
 
-We can see genes have been downsampled from our original 19465 to only 3082 genes, which were identified for use by the model.
+We can see that it now only contains a small subset of genes which the model identified for use out of its original 19465 genes.
+
+Finally, we can also see the mean-normalized matrix that RCTD created for running deconvolution. 
+It's stored inside `rctd_data$cell_type_info$info`, and we'll show the first few rows below just for context:
+
+```{r show rctd matrix}
+rctd_data$cell_type_info$info[[1]] |>
+  head()
+```
 
 ### Perform deconvolution: doublet mode
 
-Now, we can perform deconvolution with this object as input.
-To begin, we'll run in doublet mode.
+We're ready to run deconvolution with the `rctd_data` object as input.
+We'll begin by running RCTD in doublet mode, which constrains the model to estimate at most two cell types per spot.
+This will take 1-2 minutes to run and reports model progress to the Console as it proceeds.
 
 ```{r run doublet mode, live = TRUE}
 rctd_doublet <- spacexr::runRctd(
+  # prepared data for RCTD
   rctd_data, 
+  # mode to run
   rctd_mode = "doublet",
+  # number of cores to use
   max_cores = 4
 ) 
 ```
 
-The function reports model progress to the Console so we can see it converges. 
+Now that results are ready, we'll have a look:
 
 ```{r show rctd_doublet, live = TRUE}
+# show rctd_doublet
 rctd_doublet
 ```
 
-We get a fresh SPE object with 5 features  (these are not genes, these are labels) across each of the 1632 spots.
+The resulting object is a new SPE object with only 5 features; these are not genes, but represent the cell type labels in the reference object. 
+This object also has several assays with the main deconvolution results:
 
-What's in the assays?
+* `weights`: Per-spot cell type proportions 
+* `weights_full`: Weights from the initial RCTD model fit, before constraining to two cell types
+  * Note that these values are not what precisely we would get from running RCTD "full" mode, as the model parameters here were optimized for "doublet" mode
+* `weighted_unconfident`: The same as `weights_full`, but including weights that the model is less confident in
 
-* `weights`: Cell type proportions 
-* `weights_full`: Initial step at estimating full weights before constraining them to proportions
-  * Note that this isn't exactly identical to what we'd get out of "full" mode because other model parameters were optimized for "doublet" mode
-* `weighted_unconfident`: Includes weights that the model is less confident in
-
-We'll focus on the `weights` assay here to look at the fitted proportions:
-
+The `weights` assay which contains the fitted proportions is of most interest to us:
 
 ```{r doublet weights}
-assay(rctd_doublet, "weights")[, 1:6]
+# print all rows across the first four columns of the matrix
+assay(rctd_doublet, "weights")[, 1:4]
 ```
 
-For example, this suggests that the spot barcoded `AACACCTAAGCATTGC-1` is roughly half and half epithelial/endothelial and mesenchymal. 
+This matrix tells us, for example, that the spot barcoded `AACACCTAAGCATTGC-1` is roughly split between epithelial/endothelial and mesenchymal cells.
 
-We also have some `colData` items:
+This result SPE object also contains some useful information in the `colData` slot:
 
 ```{r rctd coldata, live = TRUE}
 colData(rctd_doublet)
 ```
 
-Doublet mode works by comparing to a singlet mode so we have these classifications:
+There's a few columns of particular interest here that we'll point out:
+
+* `spot_class`: Whether each spot is more likely a doublet or singlet (i.e., containing a single cell type)
+_Importantly_, RCTD in doublet mode does not evaluate whether doublet is an accurate characterization in the first place.
+Doublet mode only assesses whether spots are more likely to be singlets or doublets but does not evaluate if enforcing a maximum of two cell types is a good fit to the data.
+* `first_type`: The cell type with the higher proportion in the spot
+* `second_type`: The cell type with the lower proportion in the spot
+
+Let's see how many doublets and singlets we have according to this model fit:
 
 ```{r count spot class, live = TRUE}
 colData(rctd_doublet) |>
@@ -298,16 +329,16 @@ colData(rctd_doublet) |>
   dplyr::count(spot_class)
 ```
 
-We have:
+We see the following labels in this column:
 
-* `reject` are spots that were filtered out because of either low quality or the reference was a poor fit in the first place
-* `singlet`: likely to have a single cell type
-* `doublet_certain`: under this constrained model, confidently a doublet _versus a singlet_. 
-_This does not mean that RCTD thinks it's more likely to be a doublet than have multiple cell types_.
-* `doublet_uncertain`: under this constrained model, doublet model is preferred but weaker difference from singlet
+* `reject`: Spots that were filtered out because of either low quality or the reference was a poor fit in the first place
+* `singlet`: Under the constrained doublet model, spots that are more likely to have a single cell type
+* `doublet_certain`: Under the constrained doublet model, spots that are more likely to have two cell types.
+Again, this does not mean that RCTD is entirely certain that the spot is a doublet, only that it is more certain to be a doublet than a singlet.
+* `doublet_uncertain`: Under the constrained doublet model, spots that are more likely to be doublets than singlets but with less confidence
 
-Let's go ahead and color by proportions using the provided function `spacexr::plotCellTypeWeight()`.
 
+We can also color the Visium coordinates by cell type proportions using the provided function `spacexr::plotCellTypeWeight()`.
 We'll do this using default settings for the `Tumor` cell type first:
 
 ```{r plot tumor proportions, live = TRUE}
@@ -317,14 +348,17 @@ spacexr::plotCellTypeWeight(
   rctd_doublet, 
   cell_type = "Tumor",
   assay_name = "weights", 
+  # minimally customize plot styling
   size = 2,
   stroke = 0.1
 )
 ```
 
+How does this plot compare to the regions we suspect are likely tumor-rich according to the H&E?
 
-Let's plot them all now, with more custom styling, including flipping the orientation to match the H&E.
-To facilitate this, we've written a function:
+We'll proceed to plot a grid of coordinate plots, each showing the proportion for a given cell type, and we'll also flip the plot orientation to match the H&E for easier comparison.
+
+To facilitate this, we've written a custom function; run this chunk to be able to use the function next.
 
 ```{r plot_all_props function}
 # Function to plot a grid of coordinate plots, each showing
@@ -363,7 +397,7 @@ plot_all_props <- function(rctd_result, assay = "weights") {
 
 ```
 
-Let's use it below to plot all the cell type proportions in `rctd_doublet`:
+Now, we can use `plot_all_props()` to plot all the cell type proportions in `rctd_doublet`:
 
 ```{r plot doublet proportions, live = TRUE}
 #| message: false
@@ -372,14 +406,17 @@ Let's use it below to plot all the cell type proportions in `rctd_doublet`:
 plot_all_props(rctd_doublet)
 ```
 
-What do we see?
-How does this compare to expectations from H&E and marker gene exploration?
-These results suggests that there are no lymphoid cells in the data, even though we did observe _limited_ expression. 
+What overall patterns do you see?
+Does the cell type distribution match your expectations from our earlier marker gene expression plots?
+
+One specific observation here is this model inferred very few, if any, immune lymphoid cells in the data.
+We did however observe limited expression of immune lymphoid cells, so it's possible that by using doublet mode, we have missed identifying rare cell type populations.
+
+Therefore, we'll run RCTD once more but this time in "full" mode, which does not impose any constraints on the number of cell types per spot.
 
 ### Perform deconvolution: full mode
 
-Let's run the model again, but unconstrained in "full" mode:
-
+We can use the same `rctd_data` object as input to full mode:
 
 ```{r run full mode}
 rctd_full <- spacexr::runRctd(

--- a/spatial/03-deconvolution.Rmd
+++ b/spatial/03-deconvolution.Rmd
@@ -16,9 +16,9 @@ output:
 
 ## Introduction
 
-In this notebook, we'll continue working with the mouse osteosarcoma lung metastases sample from [Reinecke et al. (2025)](https://doi.org/10.1158/1078-0432.CCR-24-0049) that we explored in spatial clustering notebook.
+In this notebook, we'll continue working with the mouse osteosarcoma lung metastases sample from [Reinecke et al. (2025)](https://doi.org/10.1158/1078-0432.CCR-24-0049) that we explored in the spatial clustering notebook.
 
-As we have discussed, each Visium spot captures the combined expression of approximately 5--20 cells, not a single cell.
+As we have discussed, each Visium spot captures the combined expression of approximately 5-20 cells, not a single cell.
 While the clustering analysis from the previous notebook identified groups of spots with similar transcriptional profiles, clustering alone cannot tell us which specific cell types are contributing to each spot's expression.
 To move from spot-level expression to cell-type-level information, we can apply **deconvolution**, which decomposes each spot's bulk gene expression into contributions from different cell types and estimates their relative proportions.
 
@@ -34,7 +34,7 @@ We'll specifically use the mouse metastasis-specific portion of this reference, 
 
 ## Set up
 
-To begin, we'll load the packages we'll use throughout this notebook and setting the random seed.
+To begin, we'll load the packages we'll use throughout this notebook and set the random seed.
 
 ```{r libraries}
 suppressPackageStartupMessages({
@@ -151,7 +151,7 @@ he_plot
 
 
 Let's also look at some marker gene expression to develop a sense of what cell types we might expect in this data given this reference.
-We'll show expression of select marker genes, obtained taken from the OsteoCAR paper, for cell types in the reference.
+We'll show the expression of select marker genes, taken from the OsteoCAR paper, for cell types in the reference.
 
 
 ```{r plot mouse markers}
@@ -211,17 +211,15 @@ RCTD offers three different modes you can use to specify how many cell types to 
 
 1. *Doublet mode:*
 This mode constrains the RCTD model to infer a maximum of two cell types per spot, which may or may not be realistic for heterogeneous Visium datasets.
-We have to note as well, this concept of "doublet" is not the same as doublets in single-cell analysis, in which multiple cells are sequenced together in a single droplet.
-Instead, this means at most two _cell types_ can be present in a spot; the exact number of cells per spot is not known, but we assume it's likely between 5--20.
 2. *Multi mode:*
 This mode allows the RCTD model to infer multiple cell types per spot, but no more than a specified maximum number of cell types (`max_multi_types`).
 This mode is an extension of doublet mode, where the maximum can be raised above 2.
 3. *Full mode:*
-This mode does not apply any constraints to the RCTD the model, which is allowed to infer an arbitrary number of cell types per spot
+This mode does not apply any constraints to the RCTD model, which is allowed to infer an arbitrary number of cell types per spot.
 
 With each mode, we'll ultimately end up with a per-cell weight which we can interpret as a proportion.
+This proportion indicates the estimated contribution of each cell type to each spot. 
 
-We'll begin running deconvolution by running RCTD in doublet mode.
 
 ### Prepare the data for deconvolution
 
@@ -232,7 +230,7 @@ This function sets various values and parameters that will be used for the decon
 * Identifying differentially expressed genes across cell types in the reference
 * Using those differentially expressed genes, calculating a mean-normalized reference expression matrix that RCTD will use for the deconvolution process itself
 
-We'll leave parameters are their defaults and prepare the data to run deconvolution with `Ann_Level1` labels.
+We'll leave the parameters at their defaults and prepare the data for deconvolution using `Ann_Level1` labels.
 
 ```{r create_rctd, live = TRUE}
 # prepare the data for deconvolution
@@ -307,7 +305,7 @@ assay(rctd_doublet, "weights")[, 1:4]
 
 This matrix tells us, for example, that the spot barcoded `AACACCTAAGCATTGC-1` is roughly split between epithelial/endothelial and mesenchymal cells.
 
-This result SPE object also contains some useful information in the `colData` slot:
+The resulting SPE object also contains some useful information in the `colData` slot:
 
 ```{r rctd coldata, live = TRUE}
 colData(rctd_doublet)
@@ -412,10 +410,10 @@ Does the cell type distribution match your expectations from our earlier marker 
 One specific observation here is this model inferred very few, if any, immune lymphoid cells in the data.
 We did however observe limited expression of immune lymphoid cells, so it's possible that by using doublet mode, we have missed identifying rare cell type populations.
 
-Therefore, we'll run RCTD once more but this time in "full" mode, which does not impose any constraints on the number of cell types per spot.
 
 ### Perform deconvolution: full mode
 
+We'll run RCTD once more but this time in "full" mode, which does not impose any constraints on the number of cell types per spot.
 We can use the same `rctd_data` object as input to full mode:
 
 ```{r run full mode}

--- a/spatial/03-deconvolution.Rmd
+++ b/spatial/03-deconvolution.Rmd
@@ -232,7 +232,7 @@ This function sets various values and parameters that will be used for the decon
 This includes identifying differentially expressed genes across cell types in the reference, which will be used to:
 
 * Calculate a mean-normalized reference expression matrix that RCTD will use for the deconvolution process itself
-* Estimate gene-specific platform effects from pseudobulked expression profiles of these differentially expressed genes 
+* Estimate gene-specific platform effects from pseudo-bulked expression profiles of these differentially expressed genes 
 
 
 We'll leave parameters at their defaults and prepare the data for deconvolution using `Ann_Level1` labels.

--- a/spatial/03-deconvolution.Rmd
+++ b/spatial/03-deconvolution.Rmd
@@ -22,9 +22,10 @@ As we have discussed, each Visium spot captures the combined expression of appro
 While the clustering analysis from the previous notebook identified groups of spots with similar transcriptional profiles, clustering alone cannot tell us which specific cell types are contributing to each spot's expression.
 To move from spot-level expression to cell-type-level information, we can apply **deconvolution**, which decomposes each spot's bulk gene expression into contributions from different cell types and estimates their relative proportions.
 
-Specifically, we'll perform deconvolution using RCTD (Robust Cell Type Deconvolution), which is available in the `spacexr` package ([Cable et al. 2022](https://doi.org/10.1038/s41587-021-00830-w)).
-RCTD uses maximum likelihood estimation to model each spot's expression as a weighted combination of reference cell type profiles, using a single-cell reference dataset.
-RCTD also accounts for "platform effects" between the reference dataset, which was sequenced with single-cell technology, and the query spatial transcriptomics dataset, as the differences in library preparation between these platforms can introduce artifactual differences between gene expression measurements.
+Specifically, we'll perform deconvolution using RCTD (Robust Cell Type Deconvolution), which is available in the `spacexr` package ([Cable et al. 2022](https://doi.org/10.1038/s41587-021-00830-w)):
+
+- RCTD uses maximum likelihood estimation to model each spot's expression as a weighted combination of reference cell type profiles, using a single-cell reference dataset.
+- RCTD also accounts for "platform effects" between the reference dataset, which was sequenced with single-cell technology, and the query spatial transcriptomics dataset, as the differences in library preparation between these platforms can introduce artifactual differences between gene expression measurements.
 
 
 As with reference-based cell type annotation on single-cell data, it's critical for deconvolution to use a reference dataset that contains the cell types you expect to find in your data.
@@ -45,6 +46,9 @@ suppressPackageStartupMessages({
   library(ggplot2)
   library(patchwork)
 })
+
+# Set theme for ggplot2 plotting
+theme_set(theme_bw())
 
 set.seed(2026)
 ```
@@ -224,13 +228,14 @@ This proportion indicates the estimated contribution of each cell type to each s
 ### Prepare the data for deconvolution
 
 Next, we'll prepare the data for deconvolution by running the function `spacexr::createRctd()`.
-This function sets various values and parameters that will be used for the deconvolution procedure, including:
+This function sets various values and parameters that will be used for the deconvolution procedure.
+This includes identifying differentially expressed genes across cell types in the reference, which will be used to:
 
-* Identifying genes to use to correct for platform effects
-* Identifying differentially expressed genes across cell types in the reference
-* Using those differentially expressed genes, calculating a mean-normalized reference expression matrix that RCTD will use for the deconvolution process itself
+* Calculate a mean-normalized reference expression matrix that RCTD will use for the deconvolution process itself
+* Estimate gene-specific platform effects from pseudobulked expression profiles of these differentially expressed genes 
 
-We'll leave the parameters at their defaults and prepare the data for deconvolution using `Ann_Level1` labels.
+
+We'll leave parameters at their defaults and prepare the data for deconvolution using `Ann_Level1` labels.
 
 ```{r create_rctd, live = TRUE}
 # prepare the data for deconvolution


### PR DESCRIPTION
Towards #1006 

This PR fleshes out text in the deconvolution notebook through doublet mode, stopping right when we run full mode.
I expect one more PR to wrap this up.

Let me know if we should add/remove/rearrange any details here.

I also did a bit of rearranging while I was here for flow - originally in the import section, we imported the SPE first and plotted marker gene expression for a set of cell types that are in the reference. I thought it would flow better to read in the reference first which help to contextualize why we're plotting those cell type marker genes on the SPE. So, I just swapped the import order, but no changes to code.