### PR TITLE
Setup code for Xenium dataset

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -59,6 +59,7 @@ blastemal
 BMC
 Bonferroni
 bp
+BRCA
 Bruning
 BSIDs
 Carpentries
@@ -540,6 +541,7 @@ Wickham's
 Wilms
 WIPO
 WNT
+xenium
 xenograft
 Yu
 zebrafish

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -541,7 +541,7 @@ Wickham's
 Wilms
 WIPO
 WNT
-xenium
+Xenium
 xenograft
 Yu
 zebrafish

--- a/scripts/link-data.sh
+++ b/scripts/link-data.sh
@@ -53,6 +53,7 @@ mkdir -p spatial/data/ovarian-carcinoma
 mkdir -p spatial/data/wilms-tumor/SCPCS000190
 mkdir -p spatial/data/osteo/GSM8478586
 mkdir -p spatial/data/crc-v1
+mkdir -p spatial/data/brca-xenium
 
 # Machine learning module directory
 mkdir -p machine-learning/data
@@ -119,6 +120,7 @@ link_locs=(
   spatial/data/wilms-tumor/SCPCS000190/spaceranger
   spatial/data/osteo/GSM8478586/normalized
   spatial/data/reference
+  spatial/data/brca-xenium/xenium
   machine-learning/data/open-pbta
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma

--- a/scripts/syncup-s3.sh
+++ b/scripts/syncup-s3.sh
@@ -59,6 +59,7 @@ sync_dirs=(
   spatial/data/ovarian-carcinoma/spaceranger
   spatial/data/osteo/GSM8478586/spaceranger
   spatial/data/reference
+  spatial/data/brca-xenium/xenium
   machine-learning/data/open-pbta/processed
   pathway-analysis/data/leukemia
   pathway-analysis/data/medulloblastoma
@@ -79,6 +80,7 @@ sync_files=(
   scRNA-seq-advanced/data/reference/hs_mitochondrial_genes.tsv
   spatial/data/osteo/GSM8478586/normalized/osteo_normalized_spe.rds
   spatial/data/crc-v1/normalized/crc_normalized_spe.rds
+  spatial/data/brca-xenium/Janesick_annotations.tsv
 )
 
 output_files=(

--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -158,3 +158,43 @@ This will create both a directory `../data/crc-v1/` with the following files:
 ```
 
 The `crc-v1/normalized/` directory was then copied to `/shared/data/training-modules/spatial/data/`.
+
+
+### BRCA Xenium
+
+This data comes from this 10x Genomics dataset: <https://www.10xgenomics.com/products/xenium-in-situ/preview-dataset-human-breast>
+
+Specifically, the Xenium outputs for `In Situ Sample 1, Replicate 1` are downloaded and saved to the `xenium` folder. 
+The cell type annotations for this sample can be found in sheet 4 of the supplemental Excel file saved here: <https://cdn.10xgenomics.com/raw/upload/v1695234604/Xenium%20Preview%20Data/Cell_Barcode_Type_Matrices.xlsx>
+
+To download and prepare input data for the workshop, change directories to the `setup/brca-xenium` directory and run the following.
+
+```sh
+snakemake -j2
+```
+
+This will create both a directory `../data/brca-xenium/` with the following files:
+
+```console
+├── Janesick_annotations.tsv
+└── xenium
+    ├── analysis
+    ├── analysis_summary.html
+    ├── analysis.zarr.zip
+    ├── cell_boundaries.csv.gz
+    ├── cell_boundaries.parquet
+    ├── cell_feature_matrix
+    ├── cell_feature_matrix.h5
+    ├── cell_feature_matrix.zarr.zip
+    ├── cells.csv.gz
+    ├── cells.parquet
+    ├── cells.zarr.zip
+    ├── experiment.xenium
+    ├── gene_panel.json
+    ├── metrics_summary.csv
+    ├── nucleus_boundaries.csv.gz
+    ├── nucleus_boundaries.parquet
+    ├── transcripts.csv.gz
+    ├── transcripts.parquet
+    └── transcripts.zarr.zip
+```

--- a/spatial/setup/README.md
+++ b/spatial/setup/README.md
@@ -173,7 +173,7 @@ To download and prepare input data for the workshop, change directories to the `
 snakemake -j2
 ```
 
-This will create both a directory `../data/brca-xenium/` with the following files:
+This will create a directory `../data/brca-xenium/` with the following files:
 
 ```console
 ├── Janesick_annotations.tsv

--- a/spatial/setup/brca-xenium/Snakefile
+++ b/spatial/setup/brca-xenium/Snakefile
@@ -1,0 +1,57 @@
+# Workflow for obtaining the Janesick breast cancer Xenium dataset from 10x
+# includes downloading and formatting annotations
+from pathlib import Path
+
+configfile: "config.yaml"
+
+base_dir = Path(config["base_dir"])
+xenium_dir = base_dir / "xenium"
+output_annotations_tsv = base_dir / config["output_annotations_tsv"]
+
+
+rule targets:
+    input:
+        xenium_dir,
+        output_annotations_tsv,
+
+
+# get the 10x dataset itself
+rule download_10x:
+    output:
+        directory(xenium_dir)
+    params:
+        url_xenium = config["url_xenium"],
+    shell:
+        """
+        curl -L --fail {params.url_xenium} -o temp_outs.zip
+        unzip temp_outs.zip
+        mv outs {xenium_dir}
+        
+        # TODO: Do we want to keep the tif images? They are ~5 GB in size and I don't plan on using them
+        find {output} -type f -name '*.tif' -delete
+        
+        # clean up 
+        rm temp_outs.zip
+        """
+
+
+# download and prepare the annotations TSV
+rule prepare_ref:
+    input:
+        xenium_dir
+    output:
+        output_annotations_tsv
+    params:
+        script = "format-annotations.R",
+        annotations = config["url_annotations"],
+    shell:
+        """
+        curl --output-dir {xenium_dir} -O {params.annotations}
+        Rscript {params.script} \
+          --input_file "{xenium_dir}/Cell_Barcode_Type_Matrices.xlsx" \
+          --output_file {output}
+          
+        # clean up 
+        rm {xenium_dir}/Cell_Barcode_Type_Matrices.xlsx
+        """
+        

--- a/spatial/setup/brca-xenium/Snakefile
+++ b/spatial/setup/brca-xenium/Snakefile
@@ -42,12 +42,11 @@ rule prepare_ref:
     output:
         output_annotations_tsv
     params:
-        script = "format-annotations.R",
         annotations = config["url_annotations"],
     shell:
         """
         curl --output-dir {xenium_dir} -O {params.annotations}
-        Rscript {params.script} \
+        Rscript format-annotations.R \
           --input_file "{xenium_dir}/Cell_Barcode_Type_Matrices.xlsx" \
           --output_file {output}
           

--- a/spatial/setup/brca-xenium/Snakefile
+++ b/spatial/setup/brca-xenium/Snakefile
@@ -27,7 +27,7 @@ rule download_10x:
         unzip temp_outs.zip
         mv outs {xenium_dir}
         
-        # TODO: Do we want to keep the tif images? They are ~5 GB in size and I don't plan on using them
+        # remove the morphology images since they are ~ 5 GB and we won't use them
         find {output} -type f -name '*.tif' -delete
         
         # clean up 

--- a/spatial/setup/brca-xenium/config.yaml
+++ b/spatial/setup/brca-xenium/config.yaml
@@ -1,0 +1,8 @@
+base_dir: ../../data/brca-xenium/
+
+# URLs for downloading original dataset and annotations from 10x
+url_xenium: https://cf.10xgenomics.com/samples/xenium/1.0.1/Xenium_FFPE_Human_Breast_Cancer_Rep1/Xenium_FFPE_Human_Breast_Cancer_Rep1_outs.zip
+url_annotations: https://cdn.10xgenomics.com/raw/upload/v1695234604/Xenium%20Preview%20Data/Cell_Barcode_Type_Matrices.xlsx
+
+# Output files
+output_annotations_tsv: Janesick_annotations.tsv

--- a/spatial/setup/brca-xenium/format-annotations.R
+++ b/spatial/setup/brca-xenium/format-annotations.R
@@ -1,0 +1,27 @@
+#!/usr/bin/env RScript
+
+# Script to format annotations file for Janesick Xenium data
+
+library(optparse)
+
+option_list <- list(
+  make_option("--input_file",
+              type = "character",
+              help = "Path to the 10x cell type annotations .xlsx"),
+  make_option("--output_file",
+              type = "character",
+              help = "Path to write the formatted annotations .tsv"),
+  make_option("--sheet",
+              type = "integer",
+              default = 4, # use annotations transferred from Flex data for rep1
+              help = "Worksheet to read [default %default = rep1]")
+)
+opts <- parse_args(OptionParser(option_list = option_list))
+
+# read in the appropriate sheet and rename columns for easier joining
+# also we should name the cell type annotation column appropriately
+cell_types_df <- openxlsx::read.xlsx(opts$input_file, sheet = opts$sheet) |>
+  dplyr::rename(cell_id = Barcode,
+                cell_type_annotation = Cluster)
+
+readr::write_tsv(cell_types_df, opts$output_file)


### PR DESCRIPTION
Closes #1037 
Closes #1036 

This PR adds a snakefile and appropriate setup code to grab the Xenium [BRCA dataset and cell type annotations from 10x](https://www.10xgenomics.com/products/xenium-in-situ/preview-dataset-human-breast). Originally, I was just going to grab the annotations from there, download them and then save them as a TSV file and not worry about the Xenium output, but then I realized that we actually could easily work with the Xenium outputs and start from there rather than using the `STexampleData`. I must have misread the folder size somewhere since it's only ~10 GB and definitely reasonable to download and read in using `SpatialExperimentIO::readXeniumSXE()`. We also don't need any additional prep once we read it in, so it seems like a better place to start. 

I modified the sync and linking scripts to add the new paths to this dataset, but have not actually run the syncup script yet. I will do that once this gets approved. 

- For the Xenium output, I chose to download everything but then remove the morphology images to save space. There isn't an easy way to plot these and I don't think they are worth spending time on in the workshop, so it made sense to me to delete them. The only reason to keep them would be to just show them as part of the output structure. Let me know if you think differently though and want me to keep them. (For reference here are the docs that describe expected outputs: https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs)
- I left the rest of the folder structure untouched so that we could walk through some of the typical outputs someone would see from 10x. I did change the name from `outs` to `xenium` though. I chose this name to be consistent with the way we store Space Ranger `outs` and name the folder `spaceranger`. 
- The annotations file is an Excel file with different sheets with annotations from different samples in the original paper. Sheet 4 corresponds to the "supervised" annotations for Xenium, Rep 1, which is the sample we're using here. I chose to save only the supervised annotations to the output TSV as those used label transfer from the annotations for a scFFPE sample. 

For some more context on the supervised vs unsupervised annotations, see the excerpt from the Methods below: 
> Supervised labeling & label transfer
We annotated the scFFPE-seq data by first conducting a differential gene expression (DGE) analysis across unsupervised clusters in Loupe. Annotations were built upon this DGE analysis, and literature review[4](https://www.nature.com/articles/s41467-023-43458-x#ref-CR4),[10](https://www.nature.com/articles/s41467-023-43458-x#ref-CR10), and pre-CytAssist H&E staining. We assigned labels DCIS #1 and DCIS #2 according to transcriptional similarity between the scFFPE-seq and Visium platforms. We performed a log-normalization step of the data, and then calculated a z-score across cells. A PCA was performed and the top 50 PCs were selected. From the in situ data, we determined the 30 nearest neighbors for each cell after normalization and projection into PC space, and if at least 50% were one cell type, then that is the cell type that was assigned. If that criteria was not met, then the cell was classified as “unlabeled”.

> Unsupervised labeling and subclustering
For Sample #2 (Fig. [6](https://www.nature.com/articles/s41467-023-43458-x#Fig6) and Supp. Fig. 13), we used the Seurat vignette (https://satijalab.org/seurat/articles/spatial_vignette_2.html) as guide to load and analyze the Xenium data with the development branch of Seurat 5 (https://github.com/satijalab/seurat/tree/develop). We identified 14 clusters (resolution = 0.3), and further subclustered the epithelial and macrophage clusters to increase resolution of the cell types within. Annotations were aided by single cell atlas data[4](https://www.nature.com/articles/s41467-023-43458-x#ref-CR4),[13](https://www.nature.com/articles/s41467-023-43458-x#ref-CR13),[14](https://www.nature.com/articles/s41467-023-43458-x#ref-CR14). Cropped FOV images with segmentation were generated with the ImageFeaturePlot function, and a custom ggplot2 script was used to plot individual transcripts on top of the segmented cells.