### PR TITLE
Clean up text in Xenium notebook

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -95,6 +95,7 @@ CPMs
 CRC
 csv
 Ctrl
+cuboidal
 curation
 customizable
 customization

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -39,6 +39,7 @@ Ballereau
 BAM
 Banksy
 BANKSY
+Banzi
 Baran
 barcode
 barcoded
@@ -63,6 +64,7 @@ bp
 BRCA
 Bruning
 BSIDs
+Cadherin
 Carpentries
 Castelo
 CBs
@@ -242,6 +244,7 @@ interpretable
 intra
 irectory
 isoforms
+isotropically
 isotype
 Jaccard
 Janesick
@@ -410,6 +413,7 @@ priori
 proliferative
 proteasome
 pseudocount
+punctum
 QCs
 QL
 quant
@@ -557,6 +561,7 @@ Xenium
 XOA
 xenograft
 Yu
+Zarr
 zebrafish
 Zhang
 Zheng

--- a/renv.lock
+++ b/renv.lock
@@ -1102,35 +1102,6 @@
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "d90821a3153a27b2a6b727df7188ea7a5b8929fd"
     },
-    "DEoptimR": {
-      "Package": "DEoptimR",
-      "Version": "1.2-0",
-      "Source": "Repository",
-      "Date": "2026-06-07",
-      "Title": "Differential Evolution Optimization in Pure R",
-      "Authors@R": "c( person(c(\"Eduardo\", \"L. T.\"), \"Conceicao\", role = c(\"aut\", \"cre\"), email = \"mail@eduardoconceicao.org\"), person(\"Martin\", \"Maechler\", role = \"ctb\", email = \"maechler@stat.math.ethz.ch\", comment = c(ORCID = \"0000-0002-8685-9910\")) )",
-      "URL": "svn://svn.r-forge.r-project.org/svnroot/robustbase/pkg/DEoptimR",
-      "Description": "Differential Evolution (DE) stochastic heuristic algorithms for global optimization of problems with and without general constraints. The aim is to curate a collection of its variants that (1) do not sacrifice simplicity of design, (2) are essentially tuning-free, and (3) can be efficiently implemented directly in the R language. Currently, it provides implementations of the algorithms 'jDE' by Brest et al. (2006) <doi:10.1109/TEVC.2006.872133> for single-objective optimization and 'NCDE' by Qu et al. (2012) <doi:10.1109/TEVC.2011.2161873> for multimodal optimization (single-objective problems with multiple solutions).",
-      "Imports": [
-        "stats",
-        "methods"
-      ],
-      "Suggests": [
-        "mirai (>= 2.7.1)"
-      ],
-      "Enhances": [
-        "robustbase"
-      ],
-      "License": "GPL (>= 2)",
-      "Author": "Eduardo L. T. Conceicao [aut, cre], Martin Maechler [ctb] (ORCID: <https://orcid.org/0000-0002-8685-9910>)",
-      "Maintainer": "Eduardo L. T. Conceicao <mail@eduardoconceicao.org>",
-      "Repository": "CRAN",
-      "Repository/R-Forge/Project": "robustbase",
-      "Repository/R-Forge/Revision": "1025",
-      "Repository/R-Forge/DateTimeStamp": "2026-06-07 16:58:58",
-      "NeedsCompilation": "no",
-      "Encoding": "UTF-8"
-    },
     "DOSE": {
       "Package": "DOSE",
       "Version": "4.4.0",
@@ -1321,30 +1292,6 @@
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "cbf7d75caf7c20af2ba47ef4c1f8346cccf55ab9"
     },
-    "Deriv": {
-      "Package": "Deriv",
-      "Version": "4.2.0",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Symbolic Differentiation",
-      "Date": "2025-06-20",
-      "Authors@R": "c(person(given=\"Andrew\", family=\"Clausen\", role=\"aut\"), person(given=\"Serguei\", family=\"Sokol\", role=c(\"aut\", \"cre\"), email=\"sokol@insa-toulouse.fr\", comment = c(ORCID = \"0000-0002-5674-3327\")), person(given=\"Andreas\", family=\"Rappold\", role=\"ctb\", email=\"arappold@gmx.at\"))",
-      "Description": "R-based solution for symbolic differentiation. It admits user-defined function as well as function substitution in arguments of functions to be differentiated. Some symbolic simplification is part of the work.",
-      "License": "GPL (>= 3)",
-      "Suggests": [
-        "testthat (>= 0.11.0)"
-      ],
-      "BugReports": "https://github.com/sgsokol/Deriv/issues",
-      "RoxygenNote": "7.3.1",
-      "Imports": [
-        "methods"
-      ],
-      "Encoding": "UTF-8",
-      "NeedsCompilation": "no",
-      "Author": "Andrew Clausen [aut], Serguei Sokol [aut, cre] (ORCID: <https://orcid.org/0000-0002-5674-3327>), Andreas Rappold [ctb]",
-      "Maintainer": "Serguei Sokol <sokol@insa-toulouse.fr>",
-      "Repository": "CRAN"
-    },
     "DropletUtils": {
       "Package": "DropletUtils",
       "Version": "1.30.0",
@@ -1525,25 +1472,6 @@
       "Repository": "CRAN",
       "Author": "Alina Beygelzimer [aut] (cover tree library), Sham Kakadet [aut] (cover tree library), John Langford [aut] (cover tree library), Sunil Arya [aut] (ANN library 1.1.2 for the kd-tree approach), David Mount [aut] (ANN library 1.1.2 for the kd-tree approach), Shengqiao Li [aut, cre]",
       "Maintainer": "Shengqiao Li <lishengqiao@yahoo.com>",
-      "Encoding": "UTF-8"
-    },
-    "Formula": {
-      "Package": "Formula",
-      "Version": "1.2-5",
-      "Source": "Repository",
-      "Date": "2023-02-23",
-      "Title": "Extended Model Formulas",
-      "Description": "Infrastructure for extended formulas with multiple parts on the right-hand side and/or multiple responses on the left-hand side (see <doi:10.18637/jss.v034.i01>).",
-      "Authors@R": "c(person(given = \"Achim\", family = \"Zeileis\", role = c(\"aut\", \"cre\"), email = \"Achim.Zeileis@R-project.org\", comment = c(ORCID = \"0000-0003-0918-3766\")), person(given = \"Yves\", family = \"Croissant\", role = \"aut\", email = \"Yves.Croissant@univ-reunion.fr\"))",
-      "Depends": [
-        "R (>= 2.0.0)",
-        "stats"
-      ],
-      "License": "GPL-2 | GPL-3",
-      "NeedsCompilation": "no",
-      "Author": "Achim Zeileis [aut, cre] (<https://orcid.org/0000-0003-0918-3766>), Yves Croissant [aut]",
-      "Maintainer": "Achim Zeileis <Achim.Zeileis@R-project.org>",
-      "Repository": "CRAN",
       "Encoding": "UTF-8"
     },
     "GEOquery": {
@@ -2567,36 +2495,6 @@
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "75d9a54ae570634c1c0d7f3c90958461ac8f6428"
     },
-    "MatrixModels": {
-      "Package": "MatrixModels",
-      "Version": "0.5-4",
-      "Source": "Repository",
-      "VersionNote": "Released 0.5-3 on 2023-11-06",
-      "Date": "2025-03-25",
-      "Title": "Modelling with Sparse and Dense Matrices",
-      "Contact": "Matrix-authors@R-project.org",
-      "Authors@R": "c( person(\"Douglas\", \"Bates\", role = \"aut\", email = \"bates@stat.wisc.edu\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"Martin\", \"Maechler\", role = c(\"aut\", \"cre\"), email = \"mmaechler+Matrix@gmail.com\", comment = c(ORCID = \"0000-0002-8685-9910\")))",
-      "Description": "Generalized Linear Modelling with sparse and dense 'Matrix' matrices, using modular prediction and response module classes.",
-      "Depends": [
-        "R (>= 3.6.0)"
-      ],
-      "Imports": [
-        "stats",
-        "methods",
-        "Matrix (>= 1.6-0)",
-        "Matrix(< 1.8-0)"
-      ],
-      "ImportsNote": "_not_yet_stats4",
-      "Encoding": "UTF-8",
-      "LazyLoad": "yes",
-      "License": "GPL (>= 2)",
-      "URL": "https://Matrix.R-forge.R-project.org/, https://r-forge.r-project.org/R/?group_id=61",
-      "BugReports": "https://R-forge.R-project.org/tracker/?func=add&atid=294&group_id=61",
-      "NeedsCompilation": "no",
-      "Author": "Douglas Bates [aut] (<https://orcid.org/0000-0001-8316-9503>), Martin Maechler [aut, cre] (<https://orcid.org/0000-0002-8685-9910>)",
-      "Maintainer": "Martin Maechler <mmaechler+Matrix@gmail.com>",
-      "Repository": "CRAN"
-    },
     "PLIER": {
       "Package": "PLIER",
       "Version": "0.99.0",
@@ -3332,41 +3230,6 @@
       "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
       "Repository": "CRAN",
       "Encoding": "UTF-8"
-    },
-    "Rdpack": {
-      "Package": "Rdpack",
-      "Version": "2.6.6",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Update and Manipulate Rd Documentation Objects",
-      "Authors@R": "c( person(given = c(\"Georgi\", \"N.\"), family = \"Boshnakov\",  role = c(\"aut\", \"cre\"),  email = \"georgi.boshnakov@manchester.ac.uk\", comment = c(ORCID = \"0000-0003-2839-346X\")), person(given = \"Duncan\",  family = \"Murdoch\",  role = \"ctb\", email = \"murdoch.duncan@gmail.com\") )",
-      "Description": "Functions for manipulation of R documentation objects, including functions reprompt() and ereprompt() for updating 'Rd' documentation for functions, methods and classes; 'Rd' macros for citations and import of references from 'bibtex' files for use in 'Rd' files and 'roxygen2' comments; 'Rd' macros for evaluating and inserting snippets of 'R' code and the results of its evaluation or creating graphics on the fly; and many functions for manipulation of references and Rd files.",
-      "URL": "https://geobosh.github.io/Rdpack/ (doc), https://CRAN.R-project.org/package=Rdpack",
-      "BugReports": "https://github.com/GeoBosh/Rdpack/issues",
-      "Depends": [
-        "R (>= 2.15.0)",
-        "methods"
-      ],
-      "Imports": [
-        "tools",
-        "utils",
-        "rbibutils (> 2.4)"
-      ],
-      "Suggests": [
-        "grDevices",
-        "testthat",
-        "rstudioapi",
-        "rprojroot",
-        "gbRd"
-      ],
-      "License": "GPL (>= 2)",
-      "LazyLoad": "yes",
-      "Encoding": "UTF-8",
-      "RoxygenNote": "7.1.1",
-      "NeedsCompilation": "no",
-      "Author": "Georgi N. Boshnakov [aut, cre] (ORCID: <https://orcid.org/0000-0003-2839-346X>), Duncan Murdoch [ctb]",
-      "Maintainer": "Georgi N. Boshnakov <georgi.boshnakov@manchester.ac.uk>",
-      "Repository": "CRAN"
     },
     "ResidualMatrix": {
       "Package": "ResidualMatrix",
@@ -4143,66 +4006,6 @@
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "39ca8d490be562462f4dfa9b7a159de0508c189c"
     },
-    "SpaceTrooper": {
-      "Package": "SpaceTrooper",
-      "Version": "1.0.1",
-      "Source": "Bioconductor",
-      "Type": "Package",
-      "Title": "SpaceTrooper performs Quality Control analysis of Image-Based spatial",
-      "Authors@R": "c(person(\"Dario\", \"Righelli\", email=\"dario.righelli@gmail.com\", role=c(\"aut\", \"cre\"), comment=c(ORCID=\"0000-0003-1504-3583\")), person(given=\"Benedetta\", family=\"Banzi\", role=\"aut\"), person(given=\"Oriana\", family=\"Romano\", role=\"ctb\"), person(given=\"Matteo\", family=\"Merchionni\", role=\"ctb\"), person(given=\"Mattia\", family=\"Forcato\", role=\"ctb\"), person(given=\"Silvio\", family=\"Bicciato\", role=\"aut\"), person(given=\"Davide\", family=\"Risso\", role=\"ctb\"))",
-      "Description": "SpaceTrooper performs Quality Control analysis using data driven GLM models of Image-Based spatial data, providing exploration plots, QC metrics computation, outlier detection. It implements a GLM strategy for the detection of low quality cells in imaging-based spatial data (Transcriptomics and Proteomics). It additionally implements several plots for the visualization of imaging based polygons through the ggplot2 package.",
-      "License": "MIT + file LICENSE",
-      "Encoding": "UTF-8",
-      "Depends": [
-        "R (>= 4.4.0)",
-        "SpatialExperiment"
-      ],
-      "Imports": [
-        "DropletUtils",
-        "S4Vectors",
-        "SummarizedExperiment",
-        "arrow",
-        "data.table",
-        "dplyr",
-        "e1071",
-        "ggplot2",
-        "ggpubr",
-        "robustbase",
-        "scater",
-        "scuttle",
-        "sf",
-        "sfheaders",
-        "cowplot",
-        "glmnet",
-        "rhdf5",
-        "methods",
-        "rlang",
-        "SpatialExperimentIO"
-      ],
-      "Suggests": [
-        "knitr",
-        "rmarkdown",
-        "BiocStyle",
-        "testthat (>= 3.0.0)",
-        "withr",
-        "viridis"
-      ],
-      "biocViews": "Software, Transcriptomics, GeneExpression, QualityControl, Spatial, SingleCell, DataImport, ImmunoOncology",
-      "RoxygenNote": "7.3.3",
-      "VignetteBuilder": "knitr",
-      "BugReports": "https://github.com/drighelli/SpaceTrooper/issues",
-      "URL": "https://github.com/drighelli/SpaceTrooper",
-      "Config/testthat/edition": "3",
-      "Config/pak/sysreqs": "libabsl-dev libcairo2-dev cmake libfontconfig1-dev libfreetype6-dev libfribidi-dev libgdal-dev gdal-bin libgeos-dev make libharfbuzz-dev libmagick++-dev gsfonts libicu-dev libjpeg-dev libpng-dev libtiff-dev libwebp-dev libssl-dev libproj-dev libsqlite3-dev libudunits2-dev zlib1g-dev",
-      "Repository": "https://bioc-release.r-universe.dev",
-      "NeedsCompilation": "no",
-      "Author": "Dario Righelli [aut, cre] (ORCID: <https://orcid.org/0000-0003-1504-3583>), Benedetta Banzi [aut], Oriana Romano [ctb], Matteo Merchionni [ctb], Mattia Forcato [ctb], Silvio Bicciato [aut], Davide Risso [ctb]",
-      "Maintainer": "Dario Righelli <dario.righelli@gmail.com>",
-      "RemoteType": "repository",
-      "RemoteUrl": "https://github.com/bioc/SpaceTrooper",
-      "RemoteRef": "RELEASE_3_22",
-      "RemoteSha": "098bd1e56e303a11f083a2027ecc4b81e64e3f25"
-    },
     "SparseArray": {
       "Package": "SparseArray",
       "Version": "1.10.10",
@@ -4255,34 +4058,6 @@
       "RemoteUrl": "https://github.com/bioc/SparseArray",
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "ae957c5c70aacacb712d2449d9edeab2362c7904"
-    },
-    "SparseM": {
-      "Package": "SparseM",
-      "Version": "1.84-2",
-      "Source": "Repository",
-      "Authors@R": "c( person(\"Roger\", \"Koenker\",  role = c(\"cre\",\"aut\"), email =  \"rkoenker@uiuc.edu\"), person(c(\"Pin\", \"Tian\"), \"Ng\",  role = c(\"ctb\"), comment = \"Contributions to Sparse QR code\", email =  \"pin.ng@nau.edu\") , person(\"Yousef\", \"Saad\",  role = c(\"ctb\"), comment = \"author of sparskit2\") , person(\"Ben\", \"Shaby\", role = c(\"ctb\"), comment = \"author of chol2csr\") , person(\"Martin\", \"Maechler\", role = \"ctb\", comment = c(\"chol() tweaks; S4\", ORCID = \"0000-0002-8685-9910\")) )",
-      "Maintainer": "Roger Koenker <rkoenker@uiuc.edu>",
-      "Depends": [
-        "R (>= 2.15)",
-        "methods"
-      ],
-      "Imports": [
-        "graphics",
-        "stats",
-        "utils"
-      ],
-      "VignetteBuilder": "knitr",
-      "Suggests": [
-        "knitr"
-      ],
-      "Description": "Some basic linear algebra functionality for sparse matrices is provided:  including Cholesky decomposition and backsolving as well as standard R subsetting and Kronecker products.",
-      "License": "GPL (>= 2)",
-      "Title": "Sparse Linear Algebra",
-      "URL": "http://www.econ.uiuc.edu/~roger/research/sparse/sparse.html",
-      "NeedsCompilation": "yes",
-      "Author": "Roger Koenker [cre, aut], Pin Tian Ng [ctb] (Contributions to Sparse QR code), Yousef Saad [ctb] (author of sparskit2), Ben Shaby [ctb] (author of chol2csr), Martin Maechler [ctb] (chol() tweaks; S4, <https://orcid.org/0000-0002-8685-9910>)",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
     },
     "SpatialExperiment": {
       "Package": "SpatialExperiment",
@@ -6082,33 +5857,6 @@
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "b47a2df6c8993c280830578fc0bb5d712d8e7f7b"
     },
-    "boot": {
-      "Package": "boot",
-      "Version": "1.3-32",
-      "Source": "Repository",
-      "Priority": "recommended",
-      "Date": "2025-08-29",
-      "Authors@R": "c(person(\"Angelo\", \"Canty\", role = \"aut\", email = \"cantya@mcmaster.ca\",  comment = \"author of original code for S\"), person(\"Brian\", \"Ripley\", role = c(\"aut\", \"trl\"), email = \"Brian.Ripley@R-project.org\", comment = \"conversion to R, maintainer 1999--2022, author of parallel support\"), person(\"Alessandra R.\", \"Brazzale\", role = c(\"ctb\", \"cre\"), email = \"brazzale@stat.unipd.it\", comment = \"minor bug fixes\"))",
-      "Maintainer": "Alessandra R. Brazzale <brazzale@stat.unipd.it>",
-      "Note": "Maintainers are not available to give advice on using a package they did not author.",
-      "Description": "Functions and datasets for bootstrapping from the book \"Bootstrap Methods and Their Application\" by A. C. Davison and  D. V. Hinkley (1997, CUP), originally written by Angelo Canty for S.",
-      "Title": "Bootstrap Functions",
-      "Depends": [
-        "R (>= 3.0.0)",
-        "graphics",
-        "stats"
-      ],
-      "Suggests": [
-        "MASS",
-        "survival"
-      ],
-      "LazyData": "yes",
-      "ByteCompile": "yes",
-      "License": "Unlimited",
-      "NeedsCompilation": "no",
-      "Author": "Angelo Canty [aut] (author of original code for S), Brian Ripley [aut, trl] (conversion to R, maintainer 1999--2022, author of parallel support), Alessandra R. Brazzale [ctb, cre] (minor bug fixes)",
-      "Repository": "CRAN"
-    },
     "broom": {
       "Package": "broom",
       "Version": "1.0.13",
@@ -6385,89 +6133,6 @@
       "Author": "Gábor Csárdi [aut, cre, cph] (ORCID: <https://orcid.org/0000-0001-7098-9676>), Winston Chang [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>), Ascent Digital Services [cph, fnd]",
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
       "Repository": "CRAN"
-    },
-    "car": {
-      "Package": "car",
-      "Version": "3.1-5",
-      "Source": "Repository",
-      "Date": "2026-01-05",
-      "Title": "Companion to Applied Regression",
-      "Authors@R": "c(person(\"John\", \"Fox\", role =\"aut\" , email = \"jfox@mcmaster.ca\"), person(\"Sanford\", \"Weisberg\", role = \"aut\", email = \"sandy@umn.edu\"), person(\"Brad\", \"Price\", role = c(\"aut\", \"cre\"), email = \"brad.price@mail.wvu.edu\"), person(\"Daniel\", \"Adler\", role=\"ctb\"), person(\"Douglas\", \"Bates\", role = \"ctb\"), person(\"Gabriel\", \"Baud-Bovy\", role = \"ctb\"), person(\"Ben\", \"Bolker\", role=\"ctb\"), person(\"Steve\", \"Ellison\", role=\"ctb\"), person(\"David\", \"Firth\", role = \"ctb\"), person(\"Michael\", \"Friendly\", role = \"ctb\"), person(\"Gregor\", \"Gorjanc\", role = \"ctb\"), person(\"Spencer\", \"Graves\", role = \"ctb\"), person(\"Richard\", \"Heiberger\", role = \"ctb\"), person(\"Pavel\", \"Krivitsky\", role = \"ctb\"), person(\"Rafael\", \"Laboissiere\", role = \"ctb\"), person(\"Martin\", \"Maechler\", role=\"ctb\"), person(\"Georges\", \"Monette\", role = \"ctb\"), person(\"Duncan\", \"Murdoch\", role=\"ctb\"), person(\"Henric\", \"Nilsson\", role = \"ctb\"), person(\"Derek\", \"Ogle\", role = \"ctb\"), person(\"Iain\", \"Proctor\", role = \"ctb\"), person(\"Brian\", \"Ripley\", role = \"ctb\"), person(\"Tom\", \"Short\", role=\"ctb\"), person(\"William\", \"Venables\", role = \"ctb\"), person(\"Steve\", \"Walker\", role=\"ctb\"), person(\"David\", \"Winsemius\", role=\"ctb\"), person(\"Achim\", \"Zeileis\", role = \"ctb\"), person(\"R-Core\", role=\"ctb\"))",
-      "Depends": [
-        "R (>= 3.5.0)",
-        "carData (>= 3.0-0)"
-      ],
-      "Imports": [
-        "abind",
-        "Formula",
-        "MASS",
-        "mgcv",
-        "nnet",
-        "pbkrtest (>= 0.4-4)",
-        "quantreg",
-        "grDevices",
-        "utils",
-        "stats",
-        "graphics",
-        "lme4 (>= 1.1-27.1)",
-        "nlme",
-        "scales"
-      ],
-      "Suggests": [
-        "alr4",
-        "boot",
-        "coxme",
-        "effects",
-        "knitr",
-        "leaps",
-        "lmtest",
-        "Matrix",
-        "MatrixModels",
-        "ordinal",
-        "plotrix",
-        "mvtnorm",
-        "rgl (>= 0.111.3)",
-        "rio",
-        "sandwich",
-        "SparseM",
-        "survival",
-        "survey"
-      ],
-      "ByteCompile": "yes",
-      "LazyLoad": "yes",
-      "Description": "Functions to Accompany J. Fox and S. Weisberg,  An R Companion to Applied Regression, Third Edition, Sage, 2019.",
-      "License": "GPL (>= 2)",
-      "URL": "https://github.com/bprice2652/car_repo, https://CRAN.R-project.org/package=car, https://z.umn.edu/carbook",
-      "VignetteBuilder": "knitr",
-      "NeedsCompilation": "no",
-      "Author": "John Fox [aut], Sanford Weisberg [aut], Brad Price [aut, cre], Daniel Adler [ctb], Douglas Bates [ctb], Gabriel Baud-Bovy [ctb], Ben Bolker [ctb], Steve Ellison [ctb], David Firth [ctb], Michael Friendly [ctb], Gregor Gorjanc [ctb], Spencer Graves [ctb], Richard Heiberger [ctb], Pavel Krivitsky [ctb], Rafael Laboissiere [ctb], Martin Maechler [ctb], Georges Monette [ctb], Duncan Murdoch [ctb], Henric Nilsson [ctb], Derek Ogle [ctb], Iain Proctor [ctb], Brian Ripley [ctb], Tom Short [ctb], William Venables [ctb], Steve Walker [ctb], David Winsemius [ctb], Achim Zeileis [ctb], R-Core [ctb]",
-      "Maintainer": "Brad Price <brad.price@mail.wvu.edu>",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
-    },
-    "carData": {
-      "Package": "carData",
-      "Version": "3.0-6",
-      "Source": "Repository",
-      "Date": "2026-01-30",
-      "Title": "Companion to Applied Regression Data Sets",
-      "Authors@R": "c(person(\"John\", \"Fox\", role = \"aut\", email = \"jfox@mcmaster.ca\"), person(\"Sanford\", \"Weisberg\", role = \"aut\", email = \"sandy@umn.edu\"), person(\"Brad\", \"Price\", role = c(\"aut\", \"cre\"), email = \"brad.price@mail.wvu.edu\"))",
-      "Depends": [
-        "R (>= 3.5.0)"
-      ],
-      "Suggests": [
-        "car (>= 3.0-0)"
-      ],
-      "LazyLoad": "yes",
-      "LazyData": "yes",
-      "Description": "Datasets to Accompany J. Fox and S. Weisberg,  An R Companion to Applied Regression, Third Edition, Sage (2019).",
-      "License": "GPL (>= 2)",
-      "URL": "https://r-forge.r-project.org/projects/car/, https://CRAN.R-project.org/package=carData, https://z.umn.edu/carbook",
-      "NeedsCompilation": "no",
-      "Author": "John Fox [aut], Sanford Weisberg [aut], Brad Price [aut, cre]",
-      "Maintainer": "Brad Price <brad.price@mail.wvu.edu>",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
     },
     "celldex": {
       "Package": "celldex",
@@ -7082,35 +6747,6 @@
       "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
       "Repository": "CRAN"
     },
-    "corrplot": {
-      "Package": "corrplot",
-      "Version": "0.95",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Visualization of a Correlation Matrix",
-      "Date": "2024-10-14",
-      "Authors@R": "c( person('Taiyun', 'Wei', email = 'weitaiyun@gmail.com', role = c('cre', 'aut')), person('Viliam', 'Simko', email = 'viliam.simko@gmail.com', role = 'aut'), person('Michael', 'Levy', email = 'michael.levy@healthcatalyst.com', role = 'ctb'), person('Yihui', 'Xie', email = 'xie@yihui.name', role = 'ctb'), person('Yan', 'Jin', email = 'jyfeather@gmail.com', role = 'ctb'), person('Jeff', 'Zemla', email = 'zemla@wisc.edu', role = 'ctb'), person('Moritz', 'Freidank', email = 'freidankm@googlemail.com', role = 'ctb'), person('Jun', 'Cai', email = 'cai-j12@mails.tsinghua.edu.cn', role = 'ctb'), person('Tomas', 'Protivinsky', email = 'tomas.protivinsky@gmail.com', role = 'ctb') )",
-      "Maintainer": "Taiyun Wei <weitaiyun@gmail.com>",
-      "Suggests": [
-        "seriation",
-        "knitr",
-        "RColorBrewer",
-        "rmarkdown",
-        "magrittr",
-        "prettydoc",
-        "testthat"
-      ],
-      "Description": "Provides a visual exploratory tool on correlation matrix that supports automatic variable reordering to help detect hidden patterns among variables.",
-      "License": "MIT + file LICENSE",
-      "URL": "https://github.com/taiyun/corrplot",
-      "BugReports": "https://github.com/taiyun/corrplot/issues",
-      "VignetteBuilder": "knitr",
-      "RoxygenNote": "7.2.1",
-      "NeedsCompilation": "no",
-      "Author": "Taiyun Wei [cre, aut], Viliam Simko [aut], Michael Levy [ctb], Yihui Xie [ctb], Yan Jin [ctb], Jeff Zemla [ctb], Moritz Freidank [ctb], Jun Cai [ctb], Tomas Protivinsky [ctb]",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
-    },
     "cowplot": {
       "Package": "cowplot",
       "Version": "1.2.0",
@@ -7532,57 +7168,6 @@
       "RemoteUrl": "https://github.com/bioc/dir.expiry",
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "6d768b34100713a2e1f24c88d1a87fbea2cad758"
-    },
-    "doBy": {
-      "Package": "doBy",
-      "Version": "4.7.2",
-      "Source": "Repository",
-      "Title": "Groupwise Statistics, LSmeans, Linear Estimates, Utilities",
-      "Authors@R": "c( person(given = \"Ulrich\", family = \"Halekoh\", email = \"uhalekoh@health.sdu.dk\", role = c(\"aut\", \"cph\")), person(given = \"Søren\", family = \"Højsgaard\", email = \"sorenh@math.aau.dk\", role = c(\"aut\", \"cre\", \"cph\")) )",
-      "Description": "Utility package containing: Main categories: Working with grouped data: 'do' something to data when  stratified 'by' some variables.  General linear estimates. Data handling utilities. Functional programming, in particular restrict functions to a smaller domain. Miscellaneous functions for data handling. Model stability in connection with model selection. Miscellaneous other tools.",
-      "Encoding": "UTF-8",
-      "VignetteBuilder": "knitr",
-      "LazyData": "true",
-      "LazyDataCompression": "xz",
-      "URL": "https://github.com/hojsgaard/doBy",
-      "License": "GPL (>= 2)",
-      "Depends": [
-        "R (>= 4.2.0)",
-        "methods"
-      ],
-      "Imports": [
-        "boot",
-        "broom",
-        "cowplot",
-        "Deriv",
-        "dplyr",
-        "forecast",
-        "ggplot2",
-        "MASS",
-        "Matrix",
-        "modelr",
-        "rlang",
-        "purrr",
-        "tibble",
-        "tidyr"
-      ],
-      "Suggests": [
-        "geepack",
-        "knitr",
-        "lme4",
-        "markdown",
-        "rmarkdown",
-        "multcomp",
-        "microbenchmark",
-        "pbkrtest (>= 0.5.2)",
-        "survival",
-        "testthat (>= 2.1.0)"
-      ],
-      "Config/roxygen2/version": "8.0.0",
-      "NeedsCompilation": "no",
-      "Author": "Ulrich Halekoh [aut, cph], Søren Højsgaard [aut, cre, cph]",
-      "Maintainer": "Søren Højsgaard <sorenh@math.aau.dk>",
-      "Repository": "CRAN"
     },
     "doParallel": {
       "Package": "doParallel",
@@ -8881,62 +8466,6 @@
       "Maintainer": "Folashade Daniel <fdaniel@microsoft.com>",
       "Repository": "CRAN"
     },
-    "forecast": {
-      "Package": "forecast",
-      "Version": "9.0.2",
-      "Source": "Repository",
-      "Title": "Forecasting Functions for Time Series and Linear Models",
-      "Description": "Methods and tools for displaying and analysing univariate time series forecasts including exponential smoothing via state space models and automatic ARIMA modelling.",
-      "Depends": [
-        "R (>= 4.1.0)"
-      ],
-      "Imports": [
-        "colorspace",
-        "fracdiff",
-        "generics (>= 0.1.2)",
-        "ggplot2 (>= 3.4.0)",
-        "graphics",
-        "lmtest",
-        "magrittr",
-        "nnet",
-        "parallel",
-        "Rcpp (>= 0.12.4)",
-        "stats",
-        "timeDate",
-        "urca",
-        "withr",
-        "zoo"
-      ],
-      "Suggests": [
-        "forecTheta",
-        "knitr",
-        "methods",
-        "rmarkdown",
-        "rticles",
-        "scales",
-        "seasonal",
-        "testthat (>= 3.3.0)",
-        "uroot"
-      ],
-      "LinkingTo": [
-        "Rcpp (>= 0.12.4)",
-        "RcppArmadillo (>= 0.2.35)"
-      ],
-      "LazyData": "yes",
-      "ByteCompile": "TRUE",
-      "Authors@R": "c( person(\"Rob\", \"Hyndman\", email = \"Rob.Hyndman@monash.edu\", role = c(\"aut\", \"cre\", \"cph\"), comment = c(ORCID = \"0000-0002-2140-5352\")), person(\"George\", \"Athanasopoulos\", role = \"aut\", comment = c(ORCID = \"0000-0002-5389-2802\")), person(\"Christoph\", \"Bergmeir\", role = \"aut\", comment = c(ORCID = \"0000-0002-3665-9021\")), person(\"Gabriel\", \"Caceres\", role = \"aut\", comment = c(ORCID = \"0000-0002-2947-2023\")), person(\"Leanne\", \"Chhay\", role = \"aut\"), person(\"Kirill\", \"Kuroptev\", role = \"aut\"), person(\"Maximilian\", \"Mücke\", role = \"aut\", comment = c(ORCID = \"0009-0000-9432-9795\")), person(\"Mitchell\", \"O'Hara-Wild\", role = \"aut\", comment = c(ORCID = \"0000-0001-6729-7695\")), person(\"Fotios\", \"Petropoulos\", role = \"aut\", comment = c(ORCID = \"0000-0003-3039-4955\")), person(\"Slava\", \"Razbash\", role = \"aut\"), person(\"Earo\", \"Wang\", role = \"aut\", comment = c(ORCID = \"0000-0001-6448-5260\")), person(\"Farah\", \"Yasmeen\", role = \"aut\", comment = c(ORCID = \"0000-0002-1479-5401\")), person(\"Federico\", \"Garza\", role = \"ctb\"), person(\"Daniele\", \"Girolimetto\", role = \"ctb\"), person(\"Ross\", \"Ihaka\", role = c(\"ctb\", \"cph\")), person(\"R Core Team\", role = c(\"ctb\", \"cph\")), person(\"Daniel\", \"Reid\", role = \"ctb\"), person(\"David\", \"Shaub\", role = \"ctb\"), person(\"Yuan\", \"Tang\", role = \"ctb\", comment = c(ORCID = \"0000-0001-5243-233X\")), person(\"Xiaoqian\", \"Wang\", role = \"ctb\"), person(\"Zhenyu\", \"Zhou\", role = \"ctb\") )",
-      "BugReports": "https://github.com/robjhyndman/forecast/issues",
-      "License": "GPL-3",
-      "URL": "https://pkg.robjhyndman.com/forecast/, https://github.com/robjhyndman/forecast",
-      "VignetteBuilder": "knitr",
-      "RoxygenNote": "7.3.3",
-      "Encoding": "UTF-8",
-      "Config/testthat/edition": "3",
-      "NeedsCompilation": "yes",
-      "Author": "Rob Hyndman [aut, cre, cph] (ORCID: <https://orcid.org/0000-0002-2140-5352>), George Athanasopoulos [aut] (ORCID: <https://orcid.org/0000-0002-5389-2802>), Christoph Bergmeir [aut] (ORCID: <https://orcid.org/0000-0002-3665-9021>), Gabriel Caceres [aut] (ORCID: <https://orcid.org/0000-0002-2947-2023>), Leanne Chhay [aut], Kirill Kuroptev [aut], Maximilian Mücke [aut] (ORCID: <https://orcid.org/0009-0000-9432-9795>), Mitchell O'Hara-Wild [aut] (ORCID: <https://orcid.org/0000-0001-6729-7695>), Fotios Petropoulos [aut] (ORCID: <https://orcid.org/0000-0003-3039-4955>), Slava Razbash [aut], Earo Wang [aut] (ORCID: <https://orcid.org/0000-0001-6448-5260>), Farah Yasmeen [aut] (ORCID: <https://orcid.org/0000-0002-1479-5401>), Federico Garza [ctb], Daniele Girolimetto [ctb], Ross Ihaka [ctb, cph], R Core Team [ctb, cph], Daniel Reid [ctb], David Shaub [ctb], Yuan Tang [ctb] (ORCID: <https://orcid.org/0000-0001-5243-233X>), Xiaoqian Wang [ctb], Zhenyu Zhou [ctb]",
-      "Maintainer": "Rob Hyndman <Rob.Hyndman@monash.edu>",
-      "Repository": "CRAN"
-    },
     "formatR": {
       "Package": "formatR",
       "Version": "1.14",
@@ -8964,32 +8493,6 @@
       "NeedsCompilation": "no",
       "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>), Ed Lee [ctb], Eugene Ha [ctb], Kohske Takahashi [ctb], Pavel Krivitsky [ctb]",
       "Maintainer": "Yihui Xie <xie@yihui.name>",
-      "Repository": "CRAN"
-    },
-    "fracdiff": {
-      "Package": "fracdiff",
-      "Version": "1.5-4",
-      "Source": "Repository",
-      "VersionNote": "Released 1.5-3 on 2024-02-01, 1.5-2 on 2022-10-31, 1.5-1 on 2020-01-20",
-      "Date": "2026-04-27",
-      "Title": "Fractionally Differenced ARIMA aka ARFIMA(P,d,q) Models",
-      "Authors@R": "c(person(\"Martin\",\"Maechler\", role=c(\"aut\",\"cre\"), email=\"maechler@stat.math.ethz.ch\", comment = c(ORCID = \"0000-0002-8685-9910\")) , person(\"Chris\", \"Fraley\", role=c(\"ctb\",\"cph\"), comment = \"S original; Fortran code\") , person(\"Friedrich\", \"Leisch\", role = \"ctb\", comment = c(\"R port\", ORCID = \"0000-0001-7278-1983\")) , person(\"Valderio\", \"Reisen\", role=\"ctb\", comment = \"fdGPH() & fdSperio()\") , person(\"Artur\",  \"Lemonte\",  role=\"ctb\", comment = \"fdGPH() & fdSperio()\") , person(\"Rob\", \"Hyndman\", email=\"Rob.Hyndman@monash.edu\", role=\"ctb\", comment = c(\"residuals() & fitted()\", ORCID = \"0000-0002-2140-5352\")) )",
-      "Description": "Maximum likelihood estimation of the parameters of a fractionally differenced ARIMA(p,d,q) model (Haslett and Raftery, Appl.Statistics, 1989); including inference and basic methods.  Some alternative algorithms to estimate \"H\".",
-      "Imports": [
-        "stats"
-      ],
-      "Suggests": [
-        "longmemo",
-        "forecast",
-        "urca"
-      ],
-      "License": "GPL (>= 2)",
-      "URL": "https://github.com/mmaechler/fracdiff",
-      "BugReports": "https://github.com/mmaechler/fracdiff/issues",
-      "Encoding": "UTF-8",
-      "NeedsCompilation": "yes",
-      "Author": "Martin Maechler [aut, cre] (ORCID: <https://orcid.org/0000-0002-8685-9910>), Chris Fraley [ctb, cph] (S original; Fortran code), Friedrich Leisch [ctb] (R port, ORCID: <https://orcid.org/0000-0001-7278-1983>), Valderio Reisen [ctb] (fdGPH() & fdSperio()), Artur Lemonte [ctb] (fdGPH() & fdSperio()), Rob Hyndman [ctb] (residuals() & fitted(), ORCID: <https://orcid.org/0000-0002-2140-5352>)",
-      "Maintainer": "Martin Maechler <maechler@stat.math.ethz.ch>",
       "Repository": "CRAN"
     },
     "fs": {
@@ -9283,38 +8786,6 @@
       "NeedsCompilation": "no",
       "Author": "Hadley Wickham [aut, cre] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Max Kuhn [aut], Davis Vaughan [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Hadley Wickham <hadley@posit.co>",
-      "Repository": "CRAN"
-    },
-    "geometries": {
-      "Package": "geometries",
-      "Version": "0.2.5",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Convert Between R Objects and Geometric Structures",
-      "Date": "2025-11-23",
-      "Authors@R": "c( person(\"David\", \"Cooley\", ,\"david.cooley.au@gmail.com\", role = c(\"aut\", \"cre\")) )",
-      "Description": "Geometry shapes in 'R' are typically represented by matrices (points, lines), with more complex  shapes being lists of matrices (polygons). 'Geometries' will convert various 'R' objects into these shapes.  Conversion functions are available at both the 'R' level, and through 'Rcpp'.",
-      "License": "MIT + file LICENSE",
-      "URL": "https://dcooley.github.io/geometries/",
-      "BugReports": "https://github.com/dcooley/geometries/issues",
-      "Encoding": "UTF-8",
-      "RoxygenNote": "7.2.3",
-      "LinkingTo": [
-        "Rcpp"
-      ],
-      "Imports": [
-        "Rcpp (>= 1.1.0)"
-      ],
-      "Suggests": [
-        "covr",
-        "knitr",
-        "rmarkdown",
-        "tinytest"
-      ],
-      "VignetteBuilder": "knitr",
-      "NeedsCompilation": "yes",
-      "Author": "David Cooley [aut, cre]",
-      "Maintainer": "David Cooley <david.cooley.au@gmail.com>",
       "Repository": "CRAN"
     },
     "ggbeeswarm": {
@@ -9641,58 +9112,6 @@
       "Maintainer": "Guangchuang Yu <guangchuangyu@gmail.com>",
       "Repository": "CRAN"
     },
-    "ggpubr": {
-      "Package": "ggpubr",
-      "Version": "1.0.0",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "'ggplot2' Based Publication Ready Plots",
-      "Date": "2026-07-06",
-      "Authors@R": "c( person(\"Alboukadel\", \"Kassambara\", role = c(\"aut\", \"cre\"), email = \"alboukadel.kassambara@gmail.com\"), person(\"Laszlo\", \"Erdey\", role = \"ctb\", email = \"erdey.laszlo@econ.unideb.hu\", comment = \"Faculty of Economics and Business, University of Debrecen, Hungary\"))",
-      "Author": "Alboukadel Kassambara [aut, cre], Laszlo Erdey [ctb] (Faculty of Economics and Business, University of Debrecen, Hungary)",
-      "Maintainer": "Alboukadel Kassambara <alboukadel.kassambara@gmail.com>",
-      "Description": "The 'ggplot2' package is excellent and flexible for elegant data visualization in R. However the default generated plots require some formatting before we can send them for publication. Furthermore, to customize a 'ggplot', the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills. 'ggpubr' provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots. This version includes modern R ecosystem compatibility updates and customizable p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad, and scientific notation) for publication workflows, plus robust sparse-subset handling in statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group skip diagnostics for non-comparable subsets.",
-      "License": "GPL (>= 2)",
-      "LazyData": "TRUE",
-      "Encoding": "UTF-8",
-      "Depends": [
-        "R (>= 4.1.0)",
-        "ggplot2 (>= 3.5.2)"
-      ],
-      "Imports": [
-        "ggrepel (>= 0.9.2)",
-        "grid",
-        "ggsci",
-        "stats",
-        "utils",
-        "tidyr (>= 1.3.2)",
-        "purrr",
-        "dplyr (>= 1.2.0)",
-        "cowplot (>= 1.2.0)",
-        "ggsignif",
-        "scales",
-        "gridExtra",
-        "glue",
-        "polynom",
-        "rlang (>= 1.1.7)",
-        "rstatix (>= 1.0.0)",
-        "tibble",
-        "magrittr"
-      ],
-      "Suggests": [
-        "grDevices",
-        "knitr",
-        "RColorBrewer",
-        "gtable",
-        "testthat"
-      ],
-      "URL": "https://rpkgs.datanovia.com/ggpubr/, https://github.com/kassambara/ggpubr",
-      "BugReports": "https://github.com/kassambara/ggpubr/issues",
-      "RoxygenNote": "7.3.3",
-      "Collate": "'utilities_color.R' 'utilities_base.R' 'desc_statby.R' 'utilities.R' 'add_summary.R' 'annotate_figure.R' 'as_ggplot.R' 'as_npc.R' 'axis_scale.R' 'background_image.R' 'bgcolor.R' 'border.R' 'p_format_utils.R' 'compare_means.R' 'create_aes.R' 'diff_express.R' 'facet.R' 'font.R' 'gene_citation.R' 'gene_expression.R' 'geom_bracket.R' 'geom_exec.R' 'utils-aes.R' 'utils_stat_test_label.R' 'geom_pwc.R' 'get_breaks.R' 'get_coord.R' 'get_legend.R' 'get_palette.R' 'ggadd.R' 'ggadjust_pvalue.R' 'ggarrange.R' 'ggballoonplot.R' 'ggpar.R' 'ggbarplot.R' 'ggboxplot.R' 'ggdensity.R' 'ggpie.R' 'ggdonutchart.R' 'stat_conf_ellipse.R' 'stat_chull.R' 'ggdotchart.R' 'ggdotplot.R' 'ggecdf.R' 'ggerrorplot.R' 'ggexport.R' 'gghistogram.R' 'ggline.R' 'ggmaplot.R' 'ggpaired.R' 'ggparagraph.R' 'ggpubr-package.R' 'ggpubr_args.R' 'ggpubr_options.R' 'ggqqplot.R' 'utilities_label.R' 'stat_cor.R' 'stat_stars.R' 'ggscatter.R' 'ggscatterhist.R' 'ggstripchart.R' 'ggsummarystats.R' 'ggtext.R' 'ggtexttable.R' 'ggviolin.R' 'gradient_color.R' 'grids.R' 'npc_to_data_coord.R' 'reexports.R' 'rotate.R' 'rotate_axis_text.R' 'rremove.R' 'set_palette.R' 'shared_docs.R' 'show_line_types.R' 'show_point_shapes.R' 'stat_anova_test.R' 'stat_central_tendency.R' 'stat_compare_means.R' 'stat_friedman_test.R' 'stat_kruskal_test.R' 'stat_mean.R' 'stat_overlay_normal_density.R' 'stat_pvalue_manual.R' 'stat_regline_equation.R' 'stat_welch_anova_test.R' 'text_grob.R' 'theme_pubr.R' 'theme_transparent.R' 'utils-geom-signif.R' 'utils-pipe.R' 'utils-tidyr.R' 'zzz.R'",
-      "NeedsCompilation": "no",
-      "Repository": "CRAN"
-    },
     "ggrastr": {
       "Package": "ggrastr",
       "Version": "1.0.2",
@@ -9821,40 +9240,6 @@
       "NeedsCompilation": "no",
       "Author": "Claus O. Wilke [aut, cre] (ORCID: <https://orcid.org/0000-0002-7470-9261>)",
       "Maintainer": "Claus O. Wilke <wilke@austin.utexas.edu>",
-      "Repository": "CRAN"
-    },
-    "ggsci": {
-      "Package": "ggsci",
-      "Version": "5.1.0",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Scientific Journal and Sci-Fi Themed Color Palettes for 'ggplot2'",
-      "Authors@R": "c( person(\"Nan\", \"Xiao\", email = \"me@nanx.me\", role = c(\"aut\", \"cre\", \"cph\"), comment = c(ORCID = \"0000-0002-0250-5673\")), person(\"Joshua\", \"Cook\", email = \"joshuacook0023@gmail.com\", role = \"ctb\"), person(\"Clara\", \"Jégousse\", email = \"cat3@hi.is\", role = \"ctb\"), person(\"Hui\", \"Chen\", email = \"huichen@zju.edu.cn\", role = \"ctb\"), person(\"Miaozhu\", \"Li\", email = \"miaozhu.li@duke.edu\", role = \"ctb\"), person(\"iTerm2-Color-Schemes contributors\", role = c(\"ctb\", \"cph\"), comment = \"iTerm2-Color-Schemes project\"), person(\"Winston\", \"Chang\", role = c(\"ctb\", \"cph\"), comment = \"staticimports.R\") )",
-      "Maintainer": "Nan Xiao <me@nanx.me>",
-      "Description": "A collection of 'ggplot2' color palettes inspired by plots in scientific journals, data visualization libraries, science fiction movies, and TV shows.",
-      "License": "GPL (>= 3)",
-      "URL": "https://nanx.me/ggsci/, https://github.com/nanxstats/ggsci",
-      "BugReports": "https://github.com/nanxstats/ggsci/issues",
-      "Depends": [
-        "R (>= 3.5.0)"
-      ],
-      "Imports": [
-        "ggplot2 (>= 2.0.0)",
-        "grDevices",
-        "rlang",
-        "scales"
-      ],
-      "Suggests": [
-        "gridExtra",
-        "knitr",
-        "ragg",
-        "rmarkdown"
-      ],
-      "VignetteBuilder": "knitr",
-      "Encoding": "UTF-8",
-      "Config/roxygen2/version": "8.0.0",
-      "NeedsCompilation": "no",
-      "Author": "Nan Xiao [aut, cre, cph] (ORCID: <https://orcid.org/0000-0002-0250-5673>), Joshua Cook [ctb], Clara Jégousse [ctb], Hui Chen [ctb], Miaozhu Li [ctb], iTerm2-Color-Schemes contributors [ctb, cph] (iTerm2-Color-Schemes project), Winston Chang [ctb, cph] (staticimports.R)",
       "Repository": "CRAN"
     },
     "ggside": {
@@ -12056,79 +11441,6 @@
       "Maintainer": "Yihui Xie <xie@yihui.name>",
       "Repository": "CRAN"
     },
-    "lme4": {
-      "Package": "lme4",
-      "Version": "2.0-1",
-      "Source": "Repository",
-      "Title": "Linear Mixed-Effects Models using 'Eigen' and S4",
-      "Authors@R": "c(person(\"Douglas\", \"Bates\", role = \"aut\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"Martin\", \"Maechler\", role = \"aut\", comment = c(ORCID = \"0000-0002-8685-9910\")), person(\"Ben\", \"Bolker\", role = c(\"cre\", \"aut\"), email = \"bbolker+lme4@gmail.com\", comment = c(ORCID = \"0000-0002-2127-0443\")), person(\"Steven\", \"Walker\", role = \"aut\", comment = c(ORCID = \"0000-0002-4394-9078\")), person(\"Rune Haubo Bojesen\", \"Christensen\", role = \"ctb\", comment = c(ORCID = \"0000-0002-4494-3399\")), person(\"Henrik\", \"Singmann\", role = \"ctb\", comment = c(ORCID = \"0000-0002-4842-3657\")), person(\"Bin\", \"Dai\", role = \"ctb\"), person(\"Fabian\", \"Scheipl\", role = \"ctb\", comment = c(ORCID = \"0000-0001-8172-3603\")), person(\"Gabor\", \"Grothendieck\", role = \"ctb\"), person(\"Peter\", \"Green\", role = \"ctb\", comment = c(ORCID = \"0000-0002-0238-9852\")), person(\"John\", \"Fox\", role = \"ctb\"), person(\"Alexander\", \"Bauer\", role = \"ctb\"), person(\"Pavel N.\", \"Krivitsky\", role = c(\"ctb\", \"cph\"), comment = c(ORCID = \"0000-0002-9101-3362\", \"shared copyright on simulate.formula\")), person(\"Emi\", \"Tanaka\", role = \"ctb\", comment = c(ORCID = \"0000-0002-1455-259X\")), person(\"Mikael\", \"Jagan\", role = \"aut\", comment = c(ORCID = \"0000-0002-3542-2938\")), person(\"Ross D.\", \"Boylan\", role = \"ctb\", comment = c(ORCID = \"0009-0003-4123-8090\")), person(\"Anna\", \"Ly\", role = \"aut\", comment = c(ORCID = \"0000-0002-0210-0342\")))",
-      "Description": "Fit linear and generalized linear mixed-effects models.  The models and their components are represented using S4 classes and methods.  The core computational algorithms are implemented using the 'Eigen' C++ library for numerical linear algebra and 'RcppEigen' \"glue\".",
-      "Depends": [
-        "R (>= 3.6)",
-        "Matrix",
-        "methods",
-        "stats"
-      ],
-      "LinkingTo": [
-        "Matrix (>= 1.5-0)",
-        "Rcpp (>= 0.10.5)",
-        "RcppEigen (>= 0.3.3.9.4)"
-      ],
-      "Imports": [
-        "MASS",
-        "Rdpack",
-        "boot",
-        "graphics",
-        "grid",
-        "lattice",
-        "minqa (>= 1.1.15)",
-        "nlme (>= 3.1-123)",
-        "nloptr (>= 1.0.4)",
-        "parallel",
-        "reformulas (>= 0.4.3.1)",
-        "rlang",
-        "splines",
-        "utils"
-      ],
-      "Suggests": [
-        "HSAUR3",
-        "MEMSS",
-        "car",
-        "dfoptim",
-        "gamm4",
-        "ggplot2",
-        "glmmTMB",
-        "knitr",
-        "merDeriv",
-        "mgcv",
-        "mlmRev",
-        "numDeriv",
-        "optimx (>= 2013.8.6)",
-        "pbkrtest",
-        "rmarkdown",
-        "rr2",
-        "semEff",
-        "statmod",
-        "testthat (>= 0.8.1)",
-        "tibble"
-      ],
-      "Enhances": [
-        "DHARMa",
-        "performance"
-      ],
-      "RdMacros": "Rdpack",
-      "VignetteBuilder": "knitr",
-      "LazyData": "yes",
-      "License": "GPL (>= 2)",
-      "URL": "https://github.com/lme4/lme4/",
-      "BugReports": "https://github.com/lme4/lme4/issues",
-      "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.3",
-      "NeedsCompilation": "yes",
-      "Author": "Douglas Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>), Martin Maechler [aut] (ORCID: <https://orcid.org/0000-0002-8685-9910>), Ben Bolker [cre, aut] (ORCID: <https://orcid.org/0000-0002-2127-0443>), Steven Walker [aut] (ORCID: <https://orcid.org/0000-0002-4394-9078>), Rune Haubo Bojesen Christensen [ctb] (ORCID: <https://orcid.org/0000-0002-4494-3399>), Henrik Singmann [ctb] (ORCID: <https://orcid.org/0000-0002-4842-3657>), Bin Dai [ctb], Fabian Scheipl [ctb] (ORCID: <https://orcid.org/0000-0001-8172-3603>), Gabor Grothendieck [ctb], Peter Green [ctb] (ORCID: <https://orcid.org/0000-0002-0238-9852>), John Fox [ctb], Alexander Bauer [ctb], Pavel N. Krivitsky [ctb, cph] (ORCID: <https://orcid.org/0000-0002-9101-3362>, shared copyright on simulate.formula), Emi Tanaka [ctb] (ORCID: <https://orcid.org/0000-0002-1455-259X>), Mikael Jagan [aut] (ORCID: <https://orcid.org/0000-0002-3542-2938>), Ross D. Boylan [ctb] (ORCID: <https://orcid.org/0009-0003-4123-8090>), Anna Ly [aut] (ORCID: <https://orcid.org/0000-0002-0210-0342>)",
-      "Maintainer": "Ben Bolker <bbolker+lme4@gmail.com>",
-      "Repository": "CRAN"
-    },
     "lmtest": {
       "Package": "lmtest",
       "Version": "0.9-40",
@@ -12502,39 +11814,6 @@
       "RemoteRef": "RELEASE_3_22",
       "RemoteSha": "6552a64cd51a5b6abf7cd199fbcea69e2a9c5b2d"
     },
-    "mgcv": {
-      "Package": "mgcv",
-      "Version": "1.9-3",
-      "Source": "Repository",
-      "Authors@R": "person(given = \"Simon\", family = \"Wood\", role = c(\"aut\", \"cre\"), email = \"simon.wood@r-project.org\")",
-      "Title": "Mixed GAM Computation Vehicle with Automatic Smoothness Estimation",
-      "Description": "Generalized additive (mixed) models, some of their extensions and  other generalized ridge regression with multiple smoothing  parameter estimation by (Restricted) Marginal Likelihood,  Generalized Cross Validation and similar, or using iterated  nested Laplace approximation for fully Bayesian inference. See  Wood (2017) <doi:10.1201/9781315370279> for an overview.  Includes a gam() function, a wide variety of smoothers, 'JAGS'  support and distributions beyond the exponential family.",
-      "Priority": "recommended",
-      "Depends": [
-        "R (>= 3.6.0)",
-        "nlme (>= 3.1-64)"
-      ],
-      "Imports": [
-        "methods",
-        "stats",
-        "graphics",
-        "Matrix",
-        "splines",
-        "utils"
-      ],
-      "Suggests": [
-        "parallel",
-        "survival",
-        "MASS"
-      ],
-      "LazyLoad": "yes",
-      "ByteCompile": "yes",
-      "License": "GPL (>= 2)",
-      "NeedsCompilation": "yes",
-      "Author": "Simon Wood [aut, cre]",
-      "Maintainer": "Simon Wood <simon.wood@r-project.org>",
-      "Repository": "CRAN"
-    },
     "miQC": {
       "Package": "miQC",
       "Version": "1.18.0",
@@ -12620,29 +11899,6 @@
       "Author": "Joe Cheng [cre, aut], Posit Software, PBC [cph, fnd] (03wc8by49)",
       "Maintainer": "Joe Cheng <joe@posit.co>",
       "Repository": "CRAN"
-    },
-    "minqa": {
-      "Package": "minqa",
-      "Version": "1.2.8",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Derivative-Free Optimization Algorithms by Quadratic Approximation",
-      "Authors@R": "c(person(given = \"Douglas\", family = \"Bates\", role = \"aut\"), person(given = c(\"Katharine\", \"M.\"), family = \"Mullen\", role = c(\"aut\", \"cre\"), email = \"katharine.mullen@stat.ucla.edu\"), person(given = c(\"John\", \"C.\"), family = \"Nash\", role = \"aut\"), person(given = \"Ravi\", family = \"Varadhan\", role = \"aut\"))",
-      "Maintainer": "Katharine M. Mullen <katharine.mullen@stat.ucla.edu>",
-      "Description": "Derivative-free optimization by quadratic approximation based on an interface to Fortran implementations by M. J. D. Powell.",
-      "License": "GPL-2",
-      "URL": "http://optimizer.r-forge.r-project.org",
-      "Imports": [
-        "Rcpp (>= 0.9.10)"
-      ],
-      "LinkingTo": [
-        "Rcpp"
-      ],
-      "SystemRequirements": "GNU make",
-      "NeedsCompilation": "yes",
-      "Repository": "CRAN",
-      "Author": "Douglas Bates [aut], Katharine M. Mullen [aut, cre], John C. Nash [aut], Ravi Varadhan [aut]",
-      "Encoding": "UTF-8"
     },
     "mixsqp": {
       "Package": "mixsqp",
@@ -12872,33 +12128,6 @@
       "NeedsCompilation": "yes",
       "Author": "José Pinheiro [aut] (S version), Douglas Bates [aut] (up to 2007), Saikat DebRoy [ctb] (up to 2002), Deepayan Sarkar [ctb] (up to 2005), EISPACK authors [ctb] (src/rs.f), Siem Heisterkamp [ctb] (Author fixed sigma), Bert Van Willigen [ctb] (Programmer fixed sigma), Johannes Ranke [ctb] (varConstProp()), R Core Team [aut, cre] (02zz1nj61)",
       "Maintainer": "R Core Team <R-core@R-project.org>",
-      "Repository": "CRAN"
-    },
-    "nloptr": {
-      "Package": "nloptr",
-      "Version": "2.2.1",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "R Interface to NLopt",
-      "Authors@R": "c(person(\"Jelmer\", \"Ypma\", role = \"aut\", email = \"uctpjyy@ucl.ac.uk\"), person(c(\"Steven\", \"G.\"), \"Johnson\", role = \"aut\", comment = \"author of the NLopt C library\"), person(\"Aymeric\", \"Stamm\", role = c(\"ctb\", \"cre\"), email = \"aymeric.stamm@cnrs.fr\", comment = c(ORCID = \"0000-0002-8725-3654\")), person(c(\"Hans\", \"W.\"), \"Borchers\", role = \"ctb\", email = \"hwborchers@googlemail.com\"), person(\"Dirk\", \"Eddelbuettel\", role = \"ctb\", email = \"edd@debian.org\"), person(\"Brian\", \"Ripley\", role = \"ctb\", comment = \"build process on multiple OS\"), person(\"Kurt\", \"Hornik\", role = \"ctb\", comment = \"build process on multiple OS\"), person(\"Julien\", \"Chiquet\", role = \"ctb\"), person(\"Avraham\", \"Adler\", role = \"ctb\",  email = \"Avraham.Adler@gmail.com\", comment = c(ORCID = \"0000-0002-3039-0703\")), person(\"Xiongtao\", \"Dai\", role = \"ctb\"), person(\"Jeroen\", \"Ooms\", role = \"ctb\", email = \"jeroen@berkeley.edu\"), person(\"Tomas\", \"Kalibera\", role = \"ctb\"), person(\"Mikael\", \"Jagan\", role = \"ctb\"))",
-      "Description": "Solve optimization problems using an R interface to NLopt. NLopt is a  free/open-source library for nonlinear optimization, providing a common interface for a number of different free optimization routines available online as well as original implementations of various other algorithms. See <https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/> for more information on the available algorithms. Building from included sources  requires 'CMake'. On Linux and 'macOS', if a suitable system build of  NLopt (2.7.0 or later) is found, it is used; otherwise, it is built  from included sources via 'CMake'. On Windows, NLopt is obtained through  'rwinlib' for 'R <= 4.1.x' or grabbed from the appropriate toolchain for 'R >= 4.2.0'.",
-      "License": "LGPL (>= 3)",
-      "SystemRequirements": "cmake (>= 3.2.0) which is used only on Linux or macOS systems when no system build of nlopt (>= 2.7.0) can be found.",
-      "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2",
-      "Suggests": [
-        "knitr",
-        "rmarkdown",
-        "covr",
-        "tinytest"
-      ],
-      "VignetteBuilder": "knitr",
-      "URL": "https://github.com/astamm/nloptr, https://astamm.github.io/nloptr/",
-      "BugReports": "https://github.com/astamm/nloptr/issues",
-      "NeedsCompilation": "yes",
-      "UseLTO": "yes",
-      "Author": "Jelmer Ypma [aut], Steven G. Johnson [aut] (author of the NLopt C library), Aymeric Stamm [ctb, cre] (<https://orcid.org/0000-0002-8725-3654>), Hans W. Borchers [ctb], Dirk Eddelbuettel [ctb], Brian Ripley [ctb] (build process on multiple OS), Kurt Hornik [ctb] (build process on multiple OS), Julien Chiquet [ctb], Avraham Adler [ctb] (<https://orcid.org/0000-0002-3039-0703>), Xiongtao Dai [ctb], Jeroen Ooms [ctb], Tomas Kalibera [ctb], Mikael Jagan [ctb]",
-      "Maintainer": "Aymeric Stamm <aymeric.stamm@cnrs.fr>",
       "Repository": "CRAN"
     },
     "nnet": {
@@ -13332,43 +12561,6 @@
       "Repository": "CRAN",
       "Encoding": "UTF-8"
     },
-    "pbkrtest": {
-      "Package": "pbkrtest",
-      "Version": "0.5.5",
-      "Source": "Repository",
-      "Title": "Parametric Bootstrap, Kenward-Roger and Satterthwaite Based Methods for Test in Mixed Models",
-      "Authors@R": "c( person(given = \"Ulrich\", family = \"Halekoh\", email = \"uhalekoh@health.sdu.dk\", role = c(\"aut\", \"cph\")), person(given = \"Søren\", family = \"Højsgaard\", email = \"sorenh@math.aau.dk\", role = c(\"aut\", \"cre\", \"cph\")) )",
-      "Maintainer": "Søren Højsgaard <sorenh@math.aau.dk>",
-      "Description": "Computes p-values based on (a) Satterthwaite or Kenward-Rogers degree of freedom methods and (b) parametric bootstrap for mixed effects models as implemented in the 'lme4' package. Implements parametric bootstrap test for generalized linear mixed models as implemented in 'lme4' and generalized linear models. The package is documented in the paper by Halekoh and Højsgaard, (2012, <doi:10.18637/jss.v059.i09>).  Please see 'citation(\"pbkrtest\")' for citation details.",
-      "URL": "https://people.math.aau.dk/~sorenh/software/pbkrtest/",
-      "Depends": [
-        "R (>= 4.2.0)",
-        "lme4 (>= 1.1.31)"
-      ],
-      "Imports": [
-        "broom",
-        "dplyr",
-        "MASS",
-        "methods",
-        "numDeriv",
-        "Matrix (>= 1.2.3)",
-        "doBy (>= 4.6.22)"
-      ],
-      "Suggests": [
-        "nlme",
-        "markdown",
-        "knitr"
-      ],
-      "Encoding": "UTF-8",
-      "VignetteBuilder": "knitr",
-      "License": "GPL (>= 2)",
-      "ByteCompile": "Yes",
-      "RoxygenNote": "7.3.2",
-      "LazyData": "true",
-      "NeedsCompilation": "no",
-      "Author": "Ulrich Halekoh [aut, cph], Søren Højsgaard [aut, cre, cph]",
-      "Repository": "CRAN"
-    },
     "pbmcapply": {
       "Package": "pbmcapply",
       "Version": "1.5.1",
@@ -13654,29 +12846,6 @@
       "Note": "built from Clipper C++ version 6.4.0",
       "NeedsCompilation": "yes",
       "Author": "Angus Johnson [aut] (C++ original, http://www.angusj.com/delphi/clipper.php), Adrian Baddeley [aut, trl, cre], Kurt Hornik [ctb], Brian D. Ripley [ctb], Elliott Sales de Andrade [ctb], Paul Murrell [ctb], Ege Rubak [ctb], Mark Padgham [ctb]",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
-    },
-    "polynom": {
-      "Package": "polynom",
-      "Version": "1.4-1",
-      "Source": "Repository",
-      "Title": "A Collection of Functions to Implement a Class for Univariate Polynomial Manipulations",
-      "Authors@R": "c(person(\"Bill\", \"Venables\", role = c(\"aut\", \"cre\"), email = \"Bill.Venables@gmail.com\", comment = \"S original\"), person(\"Kurt\", \"Hornik\", role = \"aut\", email = \"Kurt.Hornik@R-project.org\", comment = \"R port\"), person(\"Martin\", \"Maechler\", role = \"aut\", email = \"maechler@stat.math.ethz.ch\", comment = \"R port\"))",
-      "Description": "A collection of functions to implement a class for univariate polynomial manipulations.",
-      "Imports": [
-        "stats",
-        "graphics"
-      ],
-      "License": "GPL-2",
-      "NeedsCompilation": "no",
-      "Author": "Bill Venables [aut, cre] (S original), Kurt Hornik [aut] (R port), Martin Maechler [aut] (R port)",
-      "Maintainer": "Bill Venables <Bill.Venables@gmail.com>",
-      "Suggests": [
-        "knitr",
-        "rmarkdown"
-      ],
-      "VignetteBuilder": "knitr",
       "Repository": "CRAN",
       "Encoding": "UTF-8"
     },
@@ -14075,45 +13244,6 @@
       "Repository": "RSPM",
       "Encoding": "UTF-8"
     },
-    "quantreg": {
-      "Package": "quantreg",
-      "Version": "6.1",
-      "Source": "Repository",
-      "Title": "Quantile Regression",
-      "Description": "Estimation and inference methods for models for conditional quantile functions:  Linear and nonlinear parametric and non-parametric (total variation penalized) models  for conditional quantiles of a univariate response and several methods for handling censored survival data.  Portfolio selection methods based on expected shortfall risk are also now included. See Koenker, R. (2005) Quantile Regression, Cambridge U. Press, <doi:10.1017/CBO9780511754098> and Koenker, R. et al. (2017) Handbook of Quantile Regression,  CRC Press, <doi:10.1201/9781315120256>.",
-      "Authors@R": "c( person(\"Roger\", \"Koenker\",  role = c(\"cre\",\"aut\"), email =  \"rkoenker@illinois.edu\"), person(\"Stephen\", \"Portnoy\",  role = c(\"ctb\"),  comment = \"Contributions to Censored QR code\", email =  \"sportnoy@illinois.edu\"), person(c(\"Pin\", \"Tian\"), \"Ng\",  role = c(\"ctb\"),  comment = \"Contributions to Sparse QR code\", email =  \"pin.ng@nau.edu\"), person(\"Blaise\", \"Melly\",  role = c(\"ctb\"),  comment = \"Contributions to preprocessing code\", email =  \"mellyblaise@gmail.com\"), person(\"Achim\", \"Zeileis\",  role = c(\"ctb\"),  comment = \"Contributions to dynrq code essentially identical to his dynlm code\",  email =  \"Achim.Zeileis@uibk.ac.at\"), person(\"Philip\", \"Grosjean\",  role = c(\"ctb\"),  comment = \"Contributions to nlrq code\", email =  \"phgrosjean@sciviews.org\"), person(\"Cleve\", \"Moler\",  role = c(\"ctb\"),  comment = \"author of several linpack routines\"), person(\"Yousef\", \"Saad\",  role = c(\"ctb\"),  comment = \"author of sparskit2\"), person(\"Victor\", \"Chernozhukov\",  role = c(\"ctb\"),  comment = \"contributions to extreme value inference code\"), person(\"Ivan\", \"Fernandez-Val\",  role = c(\"ctb\"),  comment = \"contributions to extreme value inference code\"), person(\"Martin\", \"Maechler\", role = \"ctb\", comment = c(\"tweaks (src/chlfct.f, 'tiny','Large')\", ORCID = \"0000-0002-8685-9910\")), person(c(\"Brian\", \"D\"), \"Ripley\",  role = c(\"trl\",\"ctb\"),  comment = \"Initial (2001) R port from S (to my everlasting shame --  how could I have been so slow to adopt R!) and for numerous other  suggestions and useful advice\", email =  \"ripley@stats.ox.ac.uk\"))",
-      "Maintainer": "Roger Koenker <rkoenker@illinois.edu>",
-      "Repository": "CRAN",
-      "Depends": [
-        "R (>= 3.5)",
-        "stats",
-        "SparseM"
-      ],
-      "Imports": [
-        "methods",
-        "graphics",
-        "Matrix",
-        "MatrixModels",
-        "survival",
-        "MASS"
-      ],
-      "Suggests": [
-        "interp",
-        "rgl",
-        "logspline",
-        "nor1mix",
-        "Formula",
-        "zoo",
-        "R.rsp",
-        "conquer"
-      ],
-      "License": "GPL (>= 2)",
-      "URL": "https://www.r-project.org",
-      "NeedsCompilation": "yes",
-      "VignetteBuilder": "R.rsp",
-      "Author": "Roger Koenker [cre, aut], Stephen Portnoy [ctb] (Contributions to Censored QR code), Pin Tian Ng [ctb] (Contributions to Sparse QR code), Blaise Melly [ctb] (Contributions to preprocessing code), Achim Zeileis [ctb] (Contributions to dynrq code essentially identical to his dynlm code), Philip Grosjean [ctb] (Contributions to nlrq code), Cleve Moler [ctb] (author of several linpack routines), Yousef Saad [ctb] (author of sparskit2), Victor Chernozhukov [ctb] (contributions to extreme value inference code), Ivan Fernandez-Val [ctb] (contributions to extreme value inference code), Martin Maechler [ctb] (tweaks (src/chlfct.f, 'tiny','Large'), <https://orcid.org/0000-0002-8685-9910>), Brian D Ripley [trl, ctb] (Initial (2001) R port from S (to my everlasting shame -- how could I have been so slow to adopt R!) and for numerous other suggestions and useful advice)",
-      "Encoding": "UTF-8"
-    },
     "qusage": {
       "Package": "qusage",
       "Version": "2.44.0",
@@ -14250,34 +13380,6 @@
       "Maintainer": "Hadley Wickham <hadley@posit.co>",
       "Repository": "CRAN"
     },
-    "rbibutils": {
-      "Package": "rbibutils",
-      "Version": "2.4.1",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Read 'Bibtex' Files and Convert Between Bibliography Formats",
-      "Authors@R": "c( person(given = c(\"Georgi\", \"N.\"), family = \"Boshnakov\",  role = c(\"aut\", \"cre\"), \t email = \"georgi.boshnakov@manchester.ac.uk\", comment = c(ORCID = \"0000-0003-2839-346X\", \"R port, R code, new C code and modifications to bibutils' C code, conversion to Bibentry (R and C code)\") ), person(given = \"Chris\", family = \"Putman\", role = \"aut\", comment = \"src/*, author of the bibutils libraries, https://sourceforge.net/projects/bibutils/\"), person(given = \"Richard\", family = \"Mathar\", role = \"ctb\", comment = \"src/addsout.c\"), person(given = \"Johannes\", family = \"Wilm\", role = \"ctb\", comment = \"src/biblatexin.c, src/bltypes.c\"), person(\"R Core Team\", role = \"ctb\", comment = \"base R's bibentry and bibstyle implementation\") )",
-      "Description": "Read and write 'Bibtex' files. Convert between bibliography formats, including 'Bibtex', 'Biblatex', 'PubMed', 'Endnote', and 'Bibentry'.  Includes a port of the 'bibutils' utilities by Chris Putnam <https://sourceforge.net/projects/bibutils/>. Supports all bibliography formats and character encodings implemented in 'bibutils'.",
-      "License": "GPL-2",
-      "URL": "https://geobosh.github.io/rbibutils/ (doc), https://CRAN.R-project.org/package=rbibutils",
-      "BugReports": "https://github.com/GeoBosh/rbibutils/issues",
-      "Depends": [
-        "R (>= 2.10)"
-      ],
-      "Imports": [
-        "utils",
-        "tools"
-      ],
-      "Suggests": [
-        "testthat"
-      ],
-      "Encoding": "UTF-8",
-      "NeedsCompilation": "yes",
-      "Config/Needs/memcheck": "devtools, rcmdcheck",
-      "Author": "Georgi N. Boshnakov [aut, cre] (ORCID: <https://orcid.org/0000-0003-2839-346X>, R port, R code, new C code and modifications to bibutils' C code, conversion to Bibentry (R and C code)), Chris Putman [aut] (src/*, author of the bibutils libraries, https://sourceforge.net/projects/bibutils/), Richard Mathar [ctb] (src/addsout.c), Johannes Wilm [ctb] (src/biblatexin.c, src/bltypes.c), R Core Team [ctb] (base R's bibentry and bibstyle implementation)",
-      "Maintainer": "Georgi N. Boshnakov <georgi.boshnakov@manchester.ac.uk>",
-      "Repository": "CRAN"
-    },
     "readr": {
       "Package": "readr",
       "Version": "2.2.0",
@@ -14375,36 +13477,6 @@
       "NeedsCompilation": "yes",
       "Author": "Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Jennifer Bryan [aut, cre] (ORCID: <https://orcid.org/0000-0002-6983-2759>), Posit, PBC [cph, fnd] (Copyright holder of all R code and all C/C++ code without explicit copyright attribution), Marcin Kalicinski [ctb, cph] (Author of included RapidXML code), Komarov Valery [ctb, cph] (Author of included libxls code), Christophe Leitienne [ctb, cph] (Author of included libxls code), Bob Colbert [ctb, cph] (Author of included libxls code), David Hoerl [ctb, cph] (Author of included libxls code), Evan Miller [ctb, cph] (Author of included libxls code)",
       "Maintainer": "Jennifer Bryan <jenny@posit.co>",
-      "Repository": "CRAN"
-    },
-    "reformulas": {
-      "Package": "reformulas",
-      "Version": "0.4.4",
-      "Source": "Repository",
-      "Title": "Machinery for Processing Random Effect Formulas",
-      "Authors@R": "c( person(given = \"Ben\", family = \"Bolker\", role = c(\"aut\", \"cre\"), email = \"bolker@mcmaster.ca\", comment=c(ORCID=\"0000-0002-2127-0443\")), person(\"Anna\", \"Ly\", role = \"ctb\", comment = c(ORCID = \"0000-0002-0210-0342\")) )",
-      "Description": "Takes formulas including random-effects components (formatted as in 'lme4', 'glmmTMB', etc.) and processes them. Includes various helper functions.",
-      "URL": "https://github.com/bbolker/reformulas",
-      "License": "GPL-3",
-      "Encoding": "UTF-8",
-      "Imports": [
-        "stats",
-        "methods",
-        "Matrix",
-        "Rdpack"
-      ],
-      "RdMacros": "Rdpack",
-      "Suggests": [
-        "lme4",
-        "tinytest",
-        "glmmTMB",
-        "Formula"
-      ],
-      "RoxygenNote": "7.3.3",
-      "Config/testthat/edition": "3",
-      "NeedsCompilation": "no",
-      "Author": "Ben Bolker [aut, cre] (ORCID: <https://orcid.org/0000-0002-2127-0443>), Anna Ly [ctb] (ORCID: <https://orcid.org/0000-0002-0210-0342>)",
-      "Maintainer": "Ben Bolker <bolker@mcmaster.ca>",
       "Repository": "CRAN"
     },
     "rematch": {
@@ -14969,65 +14041,6 @@
       "Maintainer": "Yihui Xie <xie@yihui.name>",
       "Repository": "CRAN"
     },
-    "robustbase": {
-      "Package": "robustbase",
-      "Version": "0.99-7",
-      "Source": "Repository",
-      "VersionNote": "Released 0.99-6 on 2025-09-03, 0.99-5 on 2024-11-01, 0.99-4-1 on 2024-09-24, 0.99-4 on 2024-08-19 to CRAN",
-      "Date": "2026-02-03",
-      "Title": "Basic Robust Statistics",
-      "Authors@R": "c(person(\"Martin\",\"Maechler\", role=c(\"aut\",\"cre\"), email=\"maechler@stat.math.ethz.ch\", comment = c(ORCID = \"0000-0002-8685-9910\")) , person(\"Peter\", \"Rousseeuw\", role=\"ctb\", comment = \"Qn and Sn\") , person(\"Christophe\", \"Croux\", role=\"ctb\", comment = \"Qn and Sn\") , person(\"Valentin\", \"Todorov\", role = \"aut\", email = \"valentin.todorov@chello.at\", comment = \"most robust Cov\") , person(\"Andreas\", \"Ruckstuhl\", role = \"aut\", email = \"andreas.ruckstuhl@zhaw.ch\", comment = \"nlrob, anova, glmrob\") , person(\"Matias\", \"Salibian-Barrera\", role = \"aut\", email = \"matias@stat.ubc.ca\", comment = \"lmrob orig.\") , person(\"Tobias\", \"Verbeke\", role = c(\"ctb\",\"fnd\"), email = \"tobias.verbeke@openanalytics.eu\", comment = \"mc, adjbox\") , person(\"Manuel\", \"Koller\", role = \"aut\", email = \"koller.manuel@gmail.com\", comment = \"mc, lmrob, psi-func.\") , person(c(\"Eduardo\", \"L. T.\"), \"Conceicao\", role = \"aut\", email = \"mail@eduardoconceicao.org\", comment = \"MM-, tau-, CM-, and MTL- nlrob\") , person(\"Maria\", \"Anna di Palma\", role = \"ctb\", comment = \"initial version of Comedian\") )",
-      "URL": "https://robustbase.R-forge.R-project.org/, https://R-forge.R-project.org/R/?group_id=59, https://R-forge.R-project.org/scm/viewvc.php/pkg/robustbase/?root=robustbase, svn://svn.r-forge.r-project.org/svnroot/robustbase/pkg/robustbase",
-      "BugReports": "https://R-forge.R-project.org/tracker/?atid=302&group_id=59",
-      "Description": "\"Essential\" Robust Statistics. Tools allowing to analyze data with robust methods.  This includes regression methodology including model selections and multivariate statistics where we strive to cover the book \"Robust Statistics, Theory and Methods\" by 'Maronna, Martin and Yohai'; Wiley 2006.",
-      "Depends": [
-        "R (>= 3.5.0)"
-      ],
-      "Imports": [
-        "stats",
-        "graphics",
-        "utils",
-        "methods",
-        "DEoptimR"
-      ],
-      "Suggests": [
-        "grid",
-        "MASS",
-        "lattice",
-        "boot",
-        "cluster",
-        "Matrix",
-        "robust",
-        "fit.models",
-        "MPV",
-        "xtable",
-        "ggplot2",
-        "GGally",
-        "RColorBrewer",
-        "reshape2",
-        "sfsmisc",
-        "catdata",
-        "doParallel",
-        "foreach",
-        "skewt"
-      ],
-      "SuggestsNote": "mostly only because of vignette graphics and simulation",
-      "Enhances": [
-        "robustX",
-        "rrcov",
-        "matrixStats",
-        "quantreg",
-        "Hmisc"
-      ],
-      "EnhancesNote": "linked to in man/*.Rd",
-      "LazyData": "yes",
-      "NeedsCompilation": "yes",
-      "License": "GPL (>= 2)",
-      "Author": "Martin Maechler [aut, cre] (ORCID: <https://orcid.org/0000-0002-8685-9910>), Peter Rousseeuw [ctb] (Qn and Sn), Christophe Croux [ctb] (Qn and Sn), Valentin Todorov [aut] (most robust Cov), Andreas Ruckstuhl [aut] (nlrob, anova, glmrob), Matias Salibian-Barrera [aut] (lmrob orig.), Tobias Verbeke [ctb, fnd] (mc, adjbox), Manuel Koller [aut] (mc, lmrob, psi-func.), Eduardo L. T. Conceicao [aut] (MM-, tau-, CM-, and MTL- nlrob), Maria Anna di Palma [ctb] (initial version of Comedian)",
-      "Maintainer": "Martin Maechler <maechler@stat.math.ethz.ch>",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
-    },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.1.1",
@@ -15060,56 +14073,6 @@
       "NeedsCompilation": "no",
       "Author": "Kirill Müller [aut, cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>)",
       "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-      "Repository": "CRAN"
-    },
-    "rstatix": {
-      "Package": "rstatix",
-      "Version": "1.0.0",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Pipe-Friendly Framework for Basic Statistical Tests",
-      "Date": "2026-07-03",
-      "Authors@R": "c( person(\"Alboukadel\", \"Kassambara\", role = c(\"aut\", \"cre\"), email = \"alboukadel.kassambara@gmail.com\"))",
-      "Description": "Provides a simple and intuitive pipe-friendly framework, coherent with the 'tidyverse' design philosophy,  for performing basic statistical tests, including t-test, Wilcoxon test, ANOVA, Kruskal-Wallis and correlation analyses.  The output of each test is automatically transformed into a tidy data frame to facilitate visualization.  Additional functions are available for reshaping, reordering, manipulating and visualizing correlation matrix.   Functions are also included to facilitate the analysis of factorial experiments, including purely 'within-Ss' designs  (repeated measures), purely 'between-Ss' designs, and mixed 'within-and-between-Ss' designs.  It's also possible to compute several effect size metrics, including \"eta squared\" for ANOVA, \"Cohen's d\" for t-test and  'Cramer V' for the association between categorical variables.  The package contains helper functions for identifying univariate and multivariate outliers, assessing normality and homogeneity of variances.",
-      "License": "GPL-2",
-      "Encoding": "UTF-8",
-      "Depends": [
-        "R (>= 3.3.0)"
-      ],
-      "Imports": [
-        "stats",
-        "utils",
-        "tidyr (>= 1.0.0)",
-        "purrr",
-        "broom (>= 0.7.4)",
-        "rlang (>= 0.3.1)",
-        "tibble (>= 2.1.3)",
-        "dplyr (>= 0.7.1)",
-        "magrittr",
-        "corrplot",
-        "tidyselect (>= 1.2.0)",
-        "car",
-        "generics (>= 0.0.2)"
-      ],
-      "Suggests": [
-        "knitr",
-        "rmarkdown",
-        "ggpubr",
-        "graphics",
-        "emmeans",
-        "coin",
-        "boot",
-        "testthat",
-        "spelling"
-      ],
-      "URL": "https://rpkgs.datanovia.com/rstatix/",
-      "BugReports": "https://github.com/kassambara/rstatix/issues",
-      "RoxygenNote": "7.3.3",
-      "Collate": "'utilities.R' 'add_cld.R' 'add_significance.R' 'adjust_pvalue.R' 'factorial_design.R' 'utilities_two_sample_test.R' 'anova_summary.R' 'anova_test.R' 'as_cor_mat.R' 'binom_test.R' 'box_m.R' 'chisq_test.R' 'cochran_qtest.R' 'cohens_d.R' 't_test.R' 'dunn_test.R' 'conover_test.R' 'cor_as_symbols.R' 'replace_triangle.R' 'pull_triangle.R' 'cor_mark_significant.R' 'cor_mat.R' 'cor_plot.R' 'cor_reorder.R' 'cor_reshape.R' 'cor_select.R' 'cor_test.R' 'counts_to_cases.R' 'cramer_v.R' 'df.R' 'doo.R' 'emmeans_test.R' 'dunnett_test.R' 'eta_squared.R' 'factors.R' 'fisher_test.R' 'fligner_test.R' 'freq_table.R' 'friedman_test.R' 'friedman_conover_test.R' 'friedman_effsize.R' 'friedman_nemenyi_test.R' 'games_howell_test.R' 'get_comparisons.R' 'get_manova_table.R' 'get_mode.R' 'get_pvalue_position.R' 'get_summary_stats.R' 'get_test_label.R' 'kruskal_effesize.R' 'kruskal_test.R' 'ks_test.R' 'levene_test.R' 'mahalanobis_distance.R' 'make_clean_names.R' 'mcnemar_test.R' 'multinom_test.R' 'outliers.R' 'p_value.R' 'prop_test.R' 'prop_trend_test.R' 'reexports.R' 'remove_ns.R' 'rstatix-programming.R' 'sample_n_by.R' 'shapiro_test.R' 'sign_test.R' 'tukey_hsd.R' 'utils-manova.R' 'utils-pipe.R' 'welch_anova_test.R' 'wilcox_effsize.R' 'wilcox_test.R'",
-      "Language": "en-US",
-      "NeedsCompilation": "no",
-      "Author": "Alboukadel Kassambara [aut, cre]",
-      "Maintainer": "Alboukadel Kassambara <alboukadel.kassambara@gmail.com>",
       "Repository": "CRAN"
     },
     "rstudioapi": {
@@ -16112,40 +15075,6 @@
       "NeedsCompilation": "yes",
       "Author": "Edzer Pebesma [aut, cre] (ORCID: <https://orcid.org/0000-0001-8049-7069>), Roger Bivand [ctb] (ORCID: <https://orcid.org/0000-0003-2392-6140>), Etienne Racine [ctb], Michael Sumner [ctb], Ian Cook [ctb], Tim Keitt [ctb], Robin Lovelace [ctb], Hadley Wickham [ctb], Jeroen Ooms [ctb] (ORCID: <https://orcid.org/0000-0002-4035-0289>), Kirill Müller [ctb], Thomas Lin Pedersen [ctb], Dan Baston [ctb], Dewey Dunnington [ctb] (ORCID: <https://orcid.org/0000-0002-9415-4582>), Alexandre Courtiol [ctb] (ORCID: <https://orcid.org/0000-0003-0637-2959>)",
       "Maintainer": "Edzer Pebesma <edzer.pebesma@uni-muenster.de>",
-      "Repository": "CRAN"
-    },
-    "sfheaders": {
-      "Package": "sfheaders",
-      "Version": "0.4.5",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "Converts Between R Objects and Simple Feature Objects",
-      "Date": "2025-11-24",
-      "Authors@R": "c( person(\"David\", \"Cooley\", ,\"david.cooley.au@gmail.com\", role = c(\"aut\", \"cre\")), person(given = \"Michael\", family = \"Sumner\", role = \"ctb\") )",
-      "Description": "Converts between R and Simple Feature 'sf' objects, without depending on the Simple Feature library. Conversion functions are available at both the R level,  and through 'Rcpp'.",
-      "License": "MIT + file LICENSE",
-      "URL": "https://dcooley.github.io/sfheaders/",
-      "BugReports": "https://github.com/dcooley/sfheaders/issues",
-      "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2",
-      "Depends": [
-        "R (>= 3.0.2)"
-      ],
-      "LinkingTo": [
-        "geometries (>= 0.2.5)",
-        "Rcpp"
-      ],
-      "Imports": [
-        "Rcpp (>= 1.1.0)"
-      ],
-      "Suggests": [
-        "covr",
-        "knitr",
-        "testthat"
-      ],
-      "NeedsCompilation": "yes",
-      "Author": "David Cooley [aut, cre], Michael Sumner [ctb]",
-      "Maintainer": "David Cooley <david.cooley.au@gmail.com>",
       "Repository": "CRAN"
     },
     "shape": {
@@ -17492,34 +16421,6 @@
       "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
       "Repository": "CRAN"
     },
-    "timeDate": {
-      "Package": "timeDate",
-      "Version": "4052.112",
-      "Source": "Repository",
-      "Title": "Rmetrics - Chronological and Calendar Objects",
-      "Authors@R": "c(person(\"Diethelm\", \"Wuertz\", role=\"aut\", comment = \"original code\") , person(\"Tobias\", \"Setz\", role = c(\"aut\"), email = \"tobias.setz@live.com\") , person(\"Yohan\", \"Chalabi\", role = \"aut\") , person(\"Martin\",\"Maechler\", role = \"ctb\", email = \"maechler@stat.math.ethz.ch\", comment = c(ORCID = \"0000-0002-8685-9910\")) , person(given = c(\"Joe\", \"W.\"), family = \"Byers\", role = \"ctb\") , person(given = c(\"Georgi\", \"N.\"), family = \"Boshnakov\",  role = c(\"cre\", \"aut\"), email = \"georgi.boshnakov@manchester.ac.uk\", comment = c(ORCID = \"0000-0003-2839-346X\")) )",
-      "Description": "The 'timeDate' class fulfils the conventions of the ISO 8601  standard as well as of the ANSI C and POSIX standards. Beyond these standards it provides the \"Financial Center\" concept which allows to handle data records collected in different time  zones and mix them up to have always the proper time stamps with  respect to your personal financial center, or alternatively to the GMT reference time. It can thus also handle time stamps from historical  data records from the same time zone, even if the financial  centers changed day light saving times at different calendar dates.",
-      "Depends": [
-        "R (>= 3.6.0)",
-        "methods"
-      ],
-      "Imports": [
-        "graphics",
-        "utils",
-        "stats"
-      ],
-      "Suggests": [
-        "RUnit"
-      ],
-      "License": "GPL (>= 2)",
-      "Encoding": "UTF-8",
-      "URL": "https://geobosh.github.io/timeDateDoc/ (doc), https://CRAN.R-project.org/package=timeDate, https://www.rmetrics.org",
-      "BugReports": "https://r-forge.r-project.org/tracker/?atid=633&group_id=156&func=browse",
-      "NeedsCompilation": "no",
-      "Author": "Diethelm Wuertz [aut] (original code), Tobias Setz [aut], Yohan Chalabi [aut], Martin Maechler [ctb] (ORCID: <https://orcid.org/0000-0002-8685-9910>), Joe W. Byers [ctb], Georgi N. Boshnakov [cre, aut] (ORCID: <https://orcid.org/0000-0003-2839-346X>)",
-      "Maintainer": "Georgi N. Boshnakov <georgi.boshnakov@manchester.ac.uk>",
-      "Repository": "CRAN"
-    },
     "timechange": {
       "Package": "timechange",
       "Version": "0.4.0",
@@ -17957,31 +16858,6 @@
       "Author": "Edzer Pebesma [aut, cre] (ORCID: <https://orcid.org/0000-0001-8049-7069>), Thomas Mailund [aut], Tomasz Kalinowski [aut], James Hiebert [ctb], Iñaki Ucar [aut] (ORCID: <https://orcid.org/0000-0001-6403-5550>), Thomas Lin Pedersen [ctb]",
       "Maintainer": "Edzer Pebesma <edzer.pebesma@uni-muenster.de>",
       "Repository": "CRAN"
-    },
-    "urca": {
-      "Package": "urca",
-      "Version": "1.3-4",
-      "Source": "Repository",
-      "Date": "2024-05-25",
-      "Title": "Unit Root and Cointegration Tests for Time Series Data",
-      "Authors@R": "c(person(\"Bernhard\", \"Pfaff\", email = \"bernhard@pfaffikus.de\", role = c(\"aut\", \"cre\")), person(\"Eric\", \"Zivot\",email = \"ezivot@u.washington.edu\", role = \"ctb\"), person(\"Matthieu\", \"Stigler\", role = \"ctb\"))",
-      "Depends": [
-        "R (>= 2.0.0)",
-        "methods"
-      ],
-      "Imports": [
-        "nlme",
-        "graphics",
-        "stats"
-      ],
-      "LazyLoad": "yes",
-      "Description": "Unit root and cointegration tests encountered in applied  econometric analysis are implemented.",
-      "License": "GPL (>= 2)",
-      "NeedsCompilation": "yes",
-      "Author": "Bernhard Pfaff [aut, cre], Eric Zivot [ctb], Matthieu Stigler [ctb]",
-      "Maintainer": "Bernhard Pfaff <bernhard@pfaffikus.de>",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
     },
     "utf8": {
       "Package": "utf8",

--- a/spatial/05-xenium_processing.Rmd
+++ b/spatial/05-xenium_processing.Rmd
@@ -236,7 +236,7 @@ The codebook deliberately reserves some codewords and probes as controls, which 
 - **Negative control codewords** are valid codewords that are deliberately left unassigned to any real gene. 
 Counts on these reflect optical or decoding errors, so they measure decoding specificity.
 - **Antisense** are probes targeting the antisense strand. 
-Counts on these reflect nonspecific probe binding and measure assay backgound. 
+Counts on these reflect nonspecific probe binding and measure assay background. 
 - **BLANK** codewords are empty codewords that map to nothing. 
 These are also used to identify decoding specificity. 
 Note that this category does not appear in newer versions and has been replaced with Unassigned codewords.
@@ -395,7 +395,7 @@ The ones we will use for QC include `total` and `Area_um`:
 **Note:** For this particular experiment, these metrics were already stored in the columns `total_counts` and `cell_area` found in the `colData`, but this will not be the case for all imaging-based experiments. 
 This is why we will use the columns calculated by `SpaceTrooper` and not the original columns. 
 
-We will ultimately combine this information with the existing control-feature counts stored in `control_probe_counts` and `control_codeword_counts`, which quanity the total counts falling on the negative control probe and negative control codeword categories. 
+We will ultimately combine this information with the existing control-feature counts stored in `control_probe_counts` and `control_codeword_counts`, which quantity the total counts falling on the negative control probe and negative control codeword categories. 
 This information serves as a direct read-out of background and decoding error.
 
 It also writes the centroid coordinates into `colData` as `x_centroid`/`y_centroid`.
@@ -498,7 +498,7 @@ ggspavis::plotCoords(spe, annotate = "exclude") +
   scale_color_manual(values = c("grey90", "#00274C"))
 ```
 
-It looks like theres a group of cells at the top that are flagged, likely due to an issue with tissue placement on the slide. 
+It looks like there's a group of cells at the top that are flagged, likely due to an issue with tissue placement on the slide. 
 We also see random cells that are low-quality scattered throughout the slide, which is typical of Xenium data.
 
 Let's go ahead and filter our cells and remove them from the SPE object.

--- a/spatial/05-xenium_processing.Rmd
+++ b/spatial/05-xenium_processing.Rmd
@@ -143,14 +143,15 @@ It is somewhat similar to `tissue_positions_list.csv` in Visium, but at far high
 
 ##### `cell_boundaries.parquet` and `nucleus_boundaries.parquet` (plus `.csv.gz` versions)
 
-The polygon vertices defining each cell's and each nucleus's segmentation outline which is useful for plotting and for any polygon-based QC metrics like cell area and shape.
+These files describe the polygons that define each cell's and each nucleus's segmentation outline.
+These polygons are useful for plotting and for calculating QC metrics like cell area and shape.
 Nucleus boundaries come from segmenting the DAPI image and cell boundaries come from expanding or otherwise extending those nuclei (see the segmentation note below).
 The count matrix is summarized at the **cell** level so that transcripts are assigned to the cell polygons. 
 This means that `cell_boundaries` correspond to the columns of our object (or `spots` in Visium), while `nucleus_boundaries` is supplementary information about the nuclear compartment.
 
 ##### `analysis/` and `analysis.zarr.zip`
 
-The instrument's automated secondary analysis (e.g., dimensionality reduction and clustering) produced on-instrument.
+These files contain automated secondary analysis (e.g., dimensionality reduction and clustering) that are produced on-instrument.
 
 ##### `metrics_summary.csv` and `analysis_summary.html`
 
@@ -167,7 +168,7 @@ We'll import the counts and spatial information into a `SpatialExperiment` (SPE)
 Note that here we are not using `VisiumIO` as our dataset is from Xenium, which is distinct from the previous Visium data sets we have been working with.
 
 The only argument the function strictly requires is the path to the output bundle directory.
-Below we also pass a few arguments explicitly, like the count matrix and per-cell metadata, just so we can see what files are required, but we are still using the defaults.
+In the code below, we set a few arguments explicitly, like the count matrix and per-cell metadata, just so we can see what files are required, but we are still using the defaults.
 
 By default, the function also moves the Xenium control features (negative control probes, negative control codewords, unassigned codewords, etc.) out of the main gene matrix and into `altExps`, and adds the `experiment.xenium` metadata and the transcript/boundary parquet paths to `metadata()`.
 
@@ -210,7 +211,8 @@ ggspavis::plotCoords(spe)
 
 ### A note on segmentation 
 
-Because Xenium reports data per cell, every count depends on cell segmentation which is a computational approach that draws a boundary around each cell and decides which transcripts belong to each cell.
+Because Xenium reports data per cell, every count depends on the cell segmentation step.
+Segmentation employs a computational algorithm to identify a boundary for each cell and decides which transcripts belong to each cell.
 Segmentation quality therefore directly affects downstream results, and it remains an active area of research as no method handles every tissue perfectly.
 
 The Xenium Onboard Analysis pipeline segments cells in two broad ways depending on the assay ([10x Genomics segmentation algorithms](https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/algorithms-overview/segmentation)):
@@ -233,7 +235,7 @@ Decoding is the process of reading the observed signal at each detected fluoresc
 The codebook deliberately reserves some codewords and probes as controls, which let us estimate background and error rates:
 
 - **Negative control probes** are physical probes included in the panel that target sequences _not_ present in the transcriptome. Counts on these reflect nonspecific probe binding, so they measure assay background.
-- **Negative control codewords** are valid codewords that are deliberately left unassigned to any real gene. 
+- **Negative control codewords** are valid codewords that are deliberately left unassigned to any real probe in the panel. 
 Counts on these reflect optical or decoding errors, so they measure decoding specificity.
 - **Antisense** are probes targeting the antisense strand. 
 Counts on these reflect nonspecific probe binding and measure assay background. 
@@ -242,7 +244,7 @@ These are also used to identify decoding specificity.
 Note that this category does not appear in newer versions and has been replaced with Unassigned codewords.
 
 Because a high-quality cell should have essentially no control counts, these features are a powerful QC signal and we will use them below.
-To keep them from being mistaken for real gene counts, `readXeniumSXE()` moves them out of the main matrix and into alternative experiments (`altExps`) stored alongside the main object.
+To keep control counts from being mistaken for real gene counts, `readXeniumSXE()` moves them out of the main matrix and into alternative experiments (`altExps`) stored alongside the main object.
 These can be accessed with `altExp()`.
 
 We can see which control experiments were separated out here:
@@ -295,7 +297,7 @@ cell_types_df |>
 
 
 Now we join the annotations onto the object's `colData` by `cell_id`.
-Cells that are not present in the annotation file will get `NA`.
+Cells that are not present in the annotation file will be assigned as `NA`.
 
 ```{r add-annotations}
 coldata_df <- colData(spe) |>
@@ -422,7 +424,7 @@ p1 <- ggspavis::plotCoords(spe, annotate = "total") +
 
 p2 <- ggspavis::plotCoords(spe, annotate = "Area_um") +
   scale_color_viridis_c() +
-  ggplot2::scale_color_distiller(palette = "YlOrRd", direction = 1)
+ ggplot2::scale_color_distiller(palette = "YlOrRd", direction = 1)
 
 p1 + p2
 ```
@@ -431,7 +433,7 @@ To flag these cells, we summarize each cell by its counts-per-area ratio and loo
 Specifically, we use `scater::isOutlier()` to flag cells whose ratio falls more than three median absolute deviations (MADs) below the median.
 
 * The MAD is a robust measure of spread and is less sensitive to extreme values than the standard deviation. 
-* We will use the common cutoff of three MADs. 
+* We will use the common cutoff of 3 * MAD. 
 * We only flag the low side, since it is unusually _few_ counts for a cell's area that signals debris or a failed segmentation.
 * We work on the log scale because the ratio is strictly positive and right-skewed, which makes a symmetric MAD rule more appropriate.
 

--- a/spatial/05-xenium_processing.Rmd
+++ b/spatial/05-xenium_processing.Rmd
@@ -256,7 +256,9 @@ We can see which control experiments were separated out here:
 ```{r inspect-altexps}
 # control features are stored separately from the gene panel, as altExps
 altExpNames(spe) |> 
-  purrr::map(\(name) altExp(spe, name))
+altExpNames(spe) |> 
+ purrr::set_names() |>
+ purrr::map(\(name) altExp(spe, name))
 ```
 
 ## Add in cell type annotations 
@@ -368,7 +370,7 @@ For Xenium, this information is stored in `control_probe_counts` and `control_co
 For Xenium, this information is stored in `total_counts` and `cell_area` in the `colData`. 
 
 **Note:** For other imaging based methods, this information may not be pre-calculated. 
-In this case the [`SpaceTrooper`](https://bioconductor.org/packages/SpaceTrooper) ([Banzi _et al.,_ 2025](https://doi.org/10.64898/2025.12.24.696336)) package can be used to compute per-cell quality-control metrics that are tailored to imaging-based spatial data. 
+In this case the [`SpaceTrooper` package](https://bioconductor.org/packages/SpaceTrooper) ([Banzi _et al.,_ 2025](https://doi.org/10.64898/2025.12.24.696336)) can be used to compute per-cell quality-control metrics that are tailored to imaging-based spatial data. 
 Additionally, the exact filtering steps shown here may not be applicable for all imaging based platforms. 
 Please consult [OSTA section on quality control for imaging-based platforms](https://bioconductor.org/books/release/OSTA/pages/img-quality-control.html) for more details. 
 

--- a/spatial/05-xenium_processing.Rmd
+++ b/spatial/05-xenium_processing.Rmd
@@ -353,14 +353,15 @@ ggspavis::plotCoords(spe, annotate = "cell_types_lumped") +
 
 ## Identifying low quality cells 
 
-Cells from imaging based methods can be considered low-quality because of two different reason: 
+Cells from imaging based methods can be considered low-quality for one of two reasons: 
 
 1. The cell has a high level of background noise or has had issues decoding the codewords, as indicated by high per-cell counts for the negative control probes or negative codewords. 
+For Xenium, this information is stored in `control_probe_counts` and `control_codeword_counts` in the `colData`. 
 2. The cell has a low number of gene expression counts compared to other cells of the same size, indicating the cells may be debris or segmentation artifacts. 
+This information should be calculated for each cell. 
 
-We will use [`SpaceTrooper`](https://bioconductor.org/packages/SpaceTrooper) ([Banzi _et al.,_ 2025](https://doi.org/10.64898/2025.12.24.696336)) to compute per-cell quality-control metrics that are tailored to imaging-based spatial data.
-This includes cell area, total counts, and control-feature counts. 
-Cell area and total counts are calculated from the main experiment while each of the alternative experiments are used to calculate control-feature counts.
+We will use [`SpaceTrooper`](https://bioconductor.org/packages/SpaceTrooper) ([Banzi _et al.,_ 2025](https://doi.org/10.64898/2025.12.24.696336)) to compute per-cell quality-control metrics that are tailored to imaging-based spatial data. 
+This includes cell area and total counts which is calculated from the `counts` assay in the main experiment. 
 
 `SpaceTrooper` supports many imaging-based spatial transcriptomics platforms (e.g., CosMx, MERFISH, Xenium).
 Because some of its metrics are platform-specific, we tell it which technology produced the data by setting it in the object's `metadata()` first.
@@ -379,7 +380,7 @@ metadata(spe)$technology <- "10X_Xenium"
 # note that some of this may have been pre-calculated for this experiment but we'll re-do that here
 spe <- SpaceTrooper::spatialPerCellQC(
   spe,
-  use_altexps = TRUE # calculate total counts for each control probe
+  use_altexps = FALSE # don't calculate metrics for altexperiments
 )
 
 head(colData(spe))
@@ -390,10 +391,12 @@ The ones we will use for QC include `total` and `Area_um`:
 
 - `total`: total transcript counts per cell summed over all panel genes.
 - `Area_um`: the cell's area in square microns, derived from its segmentation polygon.
-- `altexps_NegControlProbe_sum` and `altexps_NegControlCodeword_sum`: per-cell counts falling on the negative control probe and negative control codeword categories, which serve as our direct read-out of background and decoding error.
 
-**Note:** For this particular experiment, these metrics were already stored in the columns `total_counts`, `cell_area`, `control_probe_counts`, and `control_codeword_counts`, but this will not be the case for all imaging-based experiments. 
+**Note:** For this particular experiment, these metrics were already stored in the columns `total_counts` and `cell_area` found in the `colData`, but this will not be the case for all imaging-based experiments. 
 This is why we will use the columns calculated by `SpaceTrooper` and not the original columns. 
+
+We will ultimately combine this information with the existing control-feature counts stored in `control_probe_counts` and `control_codeword_counts`, which quanity the total counts falling on the negative control probe and negative control codeword categories. 
+This information serves as a direct read-out of background and decoding error.
 
 It also writes the centroid coordinates into `colData` as `x_centroid`/`y_centroid`.
 Because `spatialCoords()` already holds columns with those exact names, `ggspavis` errors on the duplicated names when it assembles its plotting data frame.

--- a/spatial/05-xenium_processing.Rmd
+++ b/spatial/05-xenium_processing.Rmd
@@ -21,7 +21,7 @@ output:
 Unlike sequencing-based methods such as single-cell RNA-seq or Visium, Xenium does not sequence anything.
 Instead, it measures a targeted panel of a few hundred genes directly inside intact tissue by repeated rounds of fluorescence imaging, then computationally decodes those images into individual transcript molecules.
 
-There are two big differences to be aware of when processing Xenium data:
+There are two big differences between Xenium and Visium data to be aware of:
 
 - Resolution is subcellular.
 Each detected transcript has an `(x, y, z)` location in the tissue, and transcripts are assigned to individual cells identified by image segmentation. 
@@ -30,8 +30,9 @@ So the columns of our data are _cells_, not the multi-cell _spots_ you get with 
 - The gene set is fixed and small.
 We only measure the genes on the panel (here, 313 genes), so we can't discover expression of genes that weren't targeted, but we get very high sensitivity and spatial precision for the ones we do measure.
 
-<!--TODO: Add in appropriate links-->
-In this notebook we read in a Xenium human breast cancer dataset (the Janesick et al. dataset), compute quality-control metrics, remove low-quality cells, and normalize the expression values.
+In this notebook we will be working with a Xenium human breast cancer dataset.
+The data come from [Janesick _et al._ (2023)](https://doi.org/10.1038/s41467-023-43458-x), a widely used, publicly available benchmark study that profiled serial formalin-fixed paraffin-embedded (FFPE) human breast cancer sections with matched single-cell RNA-seq, Visium, and Xenium.
+The Xenium run used the 313-gene human breast panel, which encompasses a 280-gene pre-designed panel plus 33 custom add-on genes. 
 
 ## Set up
 
@@ -55,9 +56,12 @@ Xenium data comes as an output bundle produced by the Xenium Onboard Analysis (X
 The specific files present will depend on the Xenium software version and assay, but they are all described in detail in the [10x Genomics documentation](https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs).
 
 We've placed the Xenium output bundle for this breast cancer sample in the directory `data/brca-xenium/xenium`, organized as XOA returns it.
+Note that we have removed the morphology images since we will not use those here and they take up a lot of space.
 
-<!--TODO: Describe how cell typing was done-->
-We also have an annotations file containing cell type annotations from the original publication. 
+We also have an annotations file containing cell type annotations from the original publication.
+In [Janesick _et al._ (2023)](https://doi.org/10.1038/s41467-023-43458-x), cell types were first annotated using a single-cell RNA-seq dataset from the same tissue. 
+In particular, cells were clustered and clusters were annotated using canonical marker genes.
+The labels from the single-cell RNA-seq experiment were used as a reference for transferring annotations onto the Xenium cells, giving each segmented cell a cell type call.
 
 We'll define the path to both the Xenium output and the annotations file here. 
 
@@ -101,7 +105,7 @@ The instrument:
 - decoded transcripts from the images
 - segmented cells 
 - assigned transcripts to cells 
-- built the count matrix
+- and built the count matrix
 
 Let's look at what's in the bundle:
 
@@ -112,42 +116,50 @@ dir(xenium_outs_dir)
 
 Below are brief descriptions of the core files in a Xenium output bundle.
 Not every file is always present since it depends on the software version and the exact assay used.
+The [10x Genomics documentation](https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs) is the authoritative reference for the full list.
 
-<!--TODO: Fill in file specific information -->
 ##### `experiment.xenium`
 
-A JSON file of run-level metadata: the gene panel, pixel size, software versions, and file paths.
-This is the entry-point file that most loaders (including the one we use below) read first.
+A JSON file of run-level metadata including the gene panel, pixel size, software versions, and file paths.
+This is the entry-point file that most loaders read first.
 
 ##### `cell_feature_matrix.h5` (and `cell_feature_matrix/`, `cell_feature_matrix.zarr.zip`)
 
-Analogous to the feature barcode matrix output from Cell Ranger/Space Ranger. 
+The cell-by-feature count matrix, analogous to the feature-barcode matrix from Cell Ranger/Space Ranger.
+Rows are features (panel genes plus control categories) and columns are segmented cells.
+It contains only transcripts that passed the default quality threshold (Q-Score ≥ 20).
+The same data are provided in HDF5 (`.h5`), a Matrix Market directory, and Zarr formats, but we will we use the `.h5` version.
 
 ##### `cells.parquet` / `cells.csv.gz` (and `cells.zarr.zip`)
 
-This is the file that provides our spatial coordinates and column (cell) metadata.
+This file provides our spatial coordinates and column (cell) metadata.
+It includes each cell's ID, centroid coordinates (`x_centroid`, `y_centroid`) in microns, cell and nucleus area, transcript counts, and the segmentation method used.
 
 ##### `transcripts.parquet` / `transcripts.csv.gz`
 
-This is the subcellular data that distinguishes Xenium from spot-based methods.
-This is analogous to the `tissue_positions_list.csv` for Visium.
+This file contains the individual decoded transcript molecules, each with an `(x, y, z)` location, the gene it decoded to, a quality score, and the cell it was assigned to (if any).
+This subcellular, molecule-level table is what distinguishes Xenium from spot-based methods. 
+It is somewhat similar to `tissue_positions_list.csv` in Visium, but at far higher resolution.
 
 ##### `cell_boundaries.parquet` and `nucleus_boundaries.parquet` (plus `.csv.gz` versions)
 
-The polygon vertices defining each cell's and each nucleus's segmentation outline.
-<!--TODO: Clarify how these relate to the count matrix which has a cell (not nucleus) dimension -->
+The polygon vertices defining each cell's and each nucleus's segmentation outline which is useful for plotting and for any polygon-based QC metrics like cell area and shape.
+Nucleus boundaries come from segmenting the DAPI image and cell boundaries come from expanding or otherwise extending those nuclei (see the segmentation note below).
+The count matrix is summarized at the **cell** level so that transcripts are assigned to the cell polygons. 
+This means that `cell_boundaries` correspond to the columns of our object (or `spots` in Visium), while `nucleus_boundaries` is supplementary information about the nuclear compartment.
 
 ##### `analysis/` and `analysis.zarr.zip`
 
-The instrument's automated secondary analysis.
+The instrument's automated secondary analysis (e.g., dimensionality reduction and clustering) produced on-instrument.
 
 ##### `metrics_summary.csv` and `analysis_summary.html`
 
-Summary information as CSV and HTML 
+Run-level QC summaries as a CSV and a HTML report which includes transcript quality, segmentation method breakdown, control rates, and similar diagnostics.
 
 ##### Morphology images (`morphology.ome.tif`, `morphology_mip.ome.tif`, `morphology_focus.ome.tif` / `morphology_focus/`)
 
-We don't have these to save space (as of right now), but these are the tissue morphology/DAPI images
+The tissue morphology images, including the DAPI nuclear stain and any additional stains that might be present for multi-modal assays.
+We don't include these here to save space, but they are what you would use to visually inspect or re-run segmentation.
 
 ### Import with `SpatialExperimentIO`
 
@@ -155,9 +167,9 @@ We'll import the counts and spatial information into a `SpatialExperiment` (SPE)
 Note that here we are not using `VisiumIO` as our dataset is from Xenium, which is distinct from the previous Visium data sets we have been working with.
 
 The only argument the function strictly requires is the path to the output bundle directory.
-Below we also pass a few arguments explicitly (count matrix and per-cell metadata) just so we can see what files are required, but we are still using the defaults.
+Below we also pass a few arguments explicitly, like the count matrix and per-cell metadata, just so we can see what files are required, but we are still using the defaults.
 
-By default the function also moves the Xenium control features (negative control probes, negative control codewords, unassigned codewords, etc.) out of the main gene matrix and into `altExps`, and adds the `experiment.xenium` metadata and the transcript/boundary parquet paths to `metadata()`.
+By default, the function also moves the Xenium control features (negative control probes, negative control codewords, unassigned codewords, etc.) out of the main gene matrix and into `altExps`, and adds the `experiment.xenium` metadata and the transcript/boundary parquet paths to `metadata()`.
 
 ```{r import-xenium, live = TRUE}
 spe <- SpatialExperimentIO::readXeniumSXE(
@@ -177,7 +189,7 @@ spe
 
 A few things to notice about this object:
 
-- The dimensions show only 313 genes but roughly 167,000 cells.
+- The dimensions show only 313 genes and roughly 167,000 cells.
   The gene count is small because Xenium measures a targeted panel, and because the control features have been split off into `altExps` (so the main matrix is genes only).
 - Each column corresponds to one cell.
 There are no barcodes, or spot barcodes, just cell ids.
@@ -198,20 +210,40 @@ ggspavis::plotCoords(spe)
 
 ### A note on segmentation 
 
-TODO: Fill in with text talking about segmentation 
+Because Xenium reports data per cell, every count depends on cell segmentation which is a computational approach that draws a boundary around each cell and decides which transcripts belong to each cell.
+Segmentation quality therefore directly affects downstream results, and it remains an active area of research as no method handles every tissue perfectly.
+
+The Xenium Onboard Analysis pipeline segments cells in two broad ways depending on the assay ([10x Genomics segmentation algorithms](https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/algorithms-overview/segmentation)):
+
+- **Nuclear expansion:** Nuclei are detected from the DAPI stain, then each nucleus boundary is expanded outward (isotropically, up to ~5 µm by default) to approximate the cell body. 
+- **Multimodal cell segmentation:** When the multi-tissue stain mix is used, a cell boundary stain (identified through membrane markers such as ATP1A1/CD45/E-Cadherin) is used to identify the true cell membrane, and an interior stain (18S rRNA) is used alongside the DAPI stain to identify the nuclei. 
+In this scenario, nuclear expansion is used as a fallback.
+
+This particular dataset only included a DAPI stain so cell segmentation was done using nuclear expansion. 
 
 ### A note on control features and `altExps`
 
-A Xenium panel does not only include genes.
-<!--TODO: Explain what codebook and codewords are-->
-The codebook also contains several categories of control features that let us estimate background and error rates:
+A Xenium panel includes probes for both targeted genes and control probes. 
 
-- Negative control probes target sequences that are _not_ present in the transcriptome, so any counts reflect nonspecific probe binding (background).
-- Negative control codewords are valid codewords deliberately left unassigned to any gene, so counts reflect optical/decoding errors.
-- Other categories (unassigned/deprecated codewords, and, for some panels, genomic or antisense controls) exist too.
+To understand the control categories, it helps to know how Xenium turns images into counts.
+Each targeted gene is detected not by sequencing but by a characteristic pattern of fluorescent signals across imaging channels and cycles.
+That pattern is called a **codeword**, and the full lookup table mapping codewords to genes is the **codebook** ([10x Genomics Xenium panel design concepts and terms](https://www.10xgenomics.com/support/software/xenium-panel-designer/latest/tutorials/xenium-panel-design-concepts-terms)).
+Decoding is the process of reading the observed signal at each detected fluorescent punctum and matching it to a codeword (and therefore a gene), with a quality score attached to each call.
 
-So we don't mix these with real gene counts, `readXeniumSXE()` moves them into alternative experiments stored alongside the main object.
-These can be accessed with `altExp`. 
+The codebook deliberately reserves some codewords and probes as controls, which let us estimate background and error rates:
+
+- **Negative control probes** are physical probes included in the panel that target sequences _not_ present in the transcriptome. Counts on these reflect nonspecific probe binding, so they measure assay background.
+- **Negative control codewords** are valid codewords that are deliberately left unassigned to any real gene. 
+Counts on these reflect optical or decoding errors, so they measure decoding specificity.
+- **Antisense** are probes targeting the antisense strand. 
+Counts on these reflect nonspecific probe binding and measure assay backgound. 
+- **BLANK** codewords are empty codewords that map to nothing. 
+These are also used to identify decoding specificity. 
+Note that this category does not appear in newer versions and has been replaced with Unassigned codewords.
+
+Because a high-quality cell should have essentially no control counts, these features are a powerful QC signal and we will use them below.
+To keep them from being mistaken for real gene counts, `readXeniumSXE()` moves them out of the main matrix and into alternative experiments (`altExps`) stored alongside the main object.
+These can be accessed with `altExp()`.
 
 We can see which control experiments were separated out here:
 
@@ -299,11 +331,15 @@ cell_type_palette <- list(
 cell_type_palette$Unlabeled <- "grey90"
 ```
 
+Finally, we'll use factors to define the order of the cell types so that they appear in the legend in the same order that we have defined above rather than in alphabetical order. 
+
 ```{r set-celltype-levels}
 # re-order celltypes for plotting by setting them as a factor
 spe$cell_types_lumped <- as.factor(spe$cell_types_lumped) |> 
   forcats::fct_relevel(names(cell_type_palette))
 ```
+
+Now that we have prepared our data, we can create our plot showing the lumped cell type annotations across the slide. 
 
 
 ```{r plot-celltypes, live = TRUE}
@@ -315,14 +351,25 @@ ggspavis::plotCoords(spe, annotate = "cell_types_lumped") +
 ```
 
 
-## Identifying low quality spots 
+## Identifying low quality cells 
 
-We use `SpaceTrooper` to compute per-cell quality-control metrics that are tailored to imaging-based spatial data (e.g., cell area, total counts, and control-feature counts).
-`SpaceTrooper` can be used with many different imaging based spatial transcriptomics platforms (e.g., CosMx, MERFISH). 
-Therefore we need to specify which technology produced the data, which we set in the object's `metadata()` first.
+Cells from imaging based methods can be considered low-quality because of two different reason: 
 
-<!--TODO: Note about the warning being expected for Xenium data since that metric is not calculated upon input. 
-Ultimately the metric is used for generating a QC score that is specifically useful for CosMx data and other data that have stitching artifacts within their FOV border-->
+1. The cell has a high level of background noise or has had issues decoding the codewords, as indicated by high per-cell counts for the negative control probes or negative codewords. 
+2. The cell has a low number of gene expression counts compared to other cells of the same size, indicating the cells may be debris or segmentation artifacts. 
+
+We will use [`SpaceTrooper`](https://bioconductor.org/packages/SpaceTrooper) ([Banzi _et al.,_ 2025](https://doi.org/10.64898/2025.12.24.696336)) to compute per-cell quality-control metrics that are tailored to imaging-based spatial data.
+This includes cell area, total counts, and control-feature counts. 
+Cell area and total counts are calculated from the main experiment while each of the alternative experiments are used to calculate control-feature counts.
+
+`SpaceTrooper` supports many imaging-based spatial transcriptomics platforms (e.g., CosMx, MERFISH, Xenium).
+Because some of its metrics are platform-specific, we tell it which technology produced the data by setting it in the object's `metadata()` first.
+
+**Note** that you may see a warning when running the step below.
+This is expected for Xenium data.
+`SpaceTrooper` can compute a border-related metric based on cell aspect ratio and distance to the nearest field-of-view border that feeds its combined quality score.
+That metric exists to capture stitching artifacts seen at field-of-view borders. 
+Although you can calculate these metrics for Xenium, the Xenium output is not expected to have field-of-view border artifacts, so the metric is not calculated here and the warning simply notes its absence.
 
 ```{r spatial-qc}
 # tell SpaceTrooper which platform this is
@@ -332,17 +379,25 @@ metadata(spe)$technology <- "10X_Xenium"
 # note that some of this may have been pre-calculated for this experiment but we'll re-do that here
 spe <- SpaceTrooper::spatialPerCellQC(
   spe,
-  use_altexps = FALSE # ignore altexps as we won't use these
+  use_altexps = TRUE # calculate total counts for each control probe
 )
 
 head(colData(spe))
 ```
 
-<!--TODO: Add in some text about the new columns that are added-->
+`spatialPerCellQC()` adds several per-cell QC columns to `colData()`. 
+The ones we will use for QC include `total` and `Area_um`: 
 
-`spatialPerCellQC()` writes the centroid coordinates into `colData` as `x_centroid`/`y_centroid`.
+- `total`: total transcript counts per cell summed over all panel genes.
+- `Area_um`: the cell's area in square microns, derived from its segmentation polygon.
+- `altexps_NegControlProbe_sum` and `altexps_NegControlCodeword_sum`: per-cell counts falling on the negative control probe and negative control codeword categories, which serve as our direct read-out of background and decoding error.
+
+**Note:** For this particular experiment, these metrics were already stored in the columns `total_counts`, `cell_area`, `control_probe_counts`, and `control_codeword_counts`, but this will not be the case for all imaging-based experiments. 
+This is why we will use the columns calculated by `SpaceTrooper` and not the original columns. 
+
+It also writes the centroid coordinates into `colData` as `x_centroid`/`y_centroid`.
 Because `spatialCoords()` already holds columns with those exact names, `ggspavis` errors on the duplicated names when it assembles its plotting data frame.
-We drop the `colData` copies (the coordinates still live safely in `spatialCoords`):
+We drop the `colData` copies in the code below, but note that the coordinates still live safely in `spatialCoords`:
 
 ```{r dedupe-coords}
 # remove the duplicated coordinate columns from colData to avoid a name
@@ -359,7 +414,6 @@ Below we can color the cells by these QC metrics.
 
 ```{r plot-qc}
 #| fig.width: 8
-
 p1 <- ggspavis::plotCoords(spe, annotate = "total") +
   ggplot2::scale_color_distiller(palette = "Blues", direction = 1)
 
@@ -370,7 +424,13 @@ p2 <- ggspavis::plotCoords(spe, annotate = "Area_um") +
 p1 + p2
 ```
 
-We'll then calculate outliers by finding the ratio between total counts and area and getting the threshold for three median absolute deviations (MADs) below the median. 
+To flag these cells, we summarize each cell by its counts-per-area ratio and look for cells that sit far below the bulk of the distribution.
+Specifically, we use `scater::isOutlier()` to flag cells whose ratio falls more than three median absolute deviations (MADs) below the median.
+
+* The MAD is a robust measure of spread and is less sensitive to extreme values than the standard deviation. 
+* We will use the common cutoff of three MADs. 
+* We only flag the low side, since it is unusually _few_ counts for a cell's area that signals debris or a failed segmentation.
+* We work on the log scale because the ratio is strictly positive and right-skewed, which makes a symmetric MAD rule more appropriate.
 
 ```{r count-area-outliers}
 # counts-per-area ratio for each cell
@@ -384,29 +444,34 @@ outliers <- scater::isOutlier(count_area_ratio, log = TRUE, type = "lower", nmad
 outliers
 ```
 
+Now we can pull out the specific threshold corresponding to 3 MADs below the median from the `outliers` object. 
 
 ```{r define-threshold, live=TRUE}
 # pull out the numeric threshold for plotting
 threshold <- attr(outliers, "threshold")[1]
 ```
 
+We'll also plot the distribution of the ratio and the chosen cutoff. 
+
 ```{r plot-threshold}
 # visualize the distribution and the chosen threshold
 ggplot(mapping = aes(log(count_area_ratio))) +
   geom_histogram(bins = 100, fill = "grey90", color = "black") +
   theme_bw() +
-  geom_vline(xintercept = log(threshold))
+  geom_vline(xintercept = log(threshold)) +
+  labs(
+    x = "Log (total counts/area)"
+  )
 ```
 
 
 
 ## Filtering low quality spots
 
-Now we can filter. 
-
-In addition to the counts-per-area outliers, we use the control features as a quality signal.
+Now we can filter by combining the counts-per-area QC metric with information from the control features as a secondary quality signal. 
 A high-quality cell should have essentially no control counts. 
-Any counts in these categories indicate background or errors in that cell, so we exclude cells with a nonzero count in either control category.
+Any counts in these categories indicate background or errors in that cell. 
+Therefore we exclude cells with a nonzero count in either control category or with a counts-per-area ratio below the cutoff. 
 
 ```{r flag-exclude}
 # a cell is excluded if it is a counts-per-area outlier OR has any control counts
@@ -418,6 +483,8 @@ exclude <- outliers |
 sum(exclude) / length(exclude)
 ```
 
+Now we can add a new column to the SPE indicating which cells to exclude and use that to visualize what cells will be excluded during filtering. 
+
 ```{r plot-exclude}
 # store the flag and visualize which cells will be excluded
 spe$exclude <- exclude
@@ -427,6 +494,11 @@ ggspavis::plotCoords(spe, annotate = "exclude") +
   # add custom colors so excluded cells are easy to see
   scale_color_manual(values = c("grey90", "#00274C"))
 ```
+
+It looks like theres a group of cells at the top that are flagged, likely due to an issue with tissue placement on the slide. 
+We also see random cells that are low-quality scattered throughout the slide, which is typical of Xenium data.
+
+Let's go ahead and filter our cells and remove them from the SPE object.
 
 ```{r filter-cells, live = TRUE}
 # keep only the cells not flagged for removal
@@ -438,8 +510,14 @@ dim(filtered_spe)
 
 ## Normalization 
 
-Following the recommendations in [OSTA](https://bioconductor.org/books/release/OSTA/pages/img-intermediate-processing.html#normalization), we'll use a simple library-size normalization. 
-This is the same normalization we would use for Visium data. 
+Following the recommendations in [OSTA](https://bioconductor.org/books/release/OSTA/pages/img-intermediate-processing.html#normalization) (Orchestrating Spatial Transcriptomics Analysis with Bioconductor), we'll use a simple library-size normalization.
+This is the same normalization we would use for Visium data and will ensure that the differences in total counts across cells don't dominate downstream analyses. 
+
+This includes: 
+
+* Computing a per-cell size factor proportional to each cell's total counts
+* Dividing the expression counts by that size factor for each cell 
+* Log-transforming the data
 
 ```{r normalize, live = TRUE}
 # calculate per-spot size factors
@@ -451,6 +529,8 @@ normalized_spe <- scuttle::logNormCounts(normalized_spe)
 
 
 ## Export
+
+Finally, we save the filtered, normalized `SpatialExperiment` object as an `.rds` file so it can be loaded directly into later notebooks without repeating the steps above.
 
 ```{r}
 readr::write_rds(normalized_spe, output_spe_file)

--- a/spatial/05-xenium_processing.Rmd
+++ b/spatial/05-xenium_processing.Rmd
@@ -214,8 +214,8 @@ ggspavis::plotCoords(spe)
 Because Xenium reports data per cell, every count depends on the cell segmentation step.
 Segmentation employs a computational algorithm to identify a boundary for each cell and decides which transcripts belong to each cell.
 Segmentation quality therefore directly affects downstream results, but no current method handles every tissue perfectly. 
-Different cell types, such as neurons and muscle cells have non-cuboidal shapes so segmentation approaches for tisseus with those cell types maybe more difficult than others. 
-Improving sementation remains an active area of research. 
+Different cell types, such as neurons and muscle cells have non-cuboidal shapes so segmentation approaches for tissues with those cell types maybe more difficult than others. 
+Improving segmentation remains an active area of research. 
 
 The Xenium Onboard Analysis pipeline segments cells in two broad ways depending on the assay ([10x Genomics segmentation algorithms](https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/algorithms-overview/segmentation)):
 

--- a/spatial/05-xenium_processing.Rmd
+++ b/spatial/05-xenium_processing.Rmd
@@ -213,7 +213,9 @@ ggspavis::plotCoords(spe)
 
 Because Xenium reports data per cell, every count depends on the cell segmentation step.
 Segmentation employs a computational algorithm to identify a boundary for each cell and decides which transcripts belong to each cell.
-Segmentation quality therefore directly affects downstream results, and it remains an active area of research as no method handles every tissue perfectly.
+Segmentation quality therefore directly affects downstream results, but no current method handles every tissue perfectly. 
+Different cell types, such as neurons and muscle cells have non-cuboidal shapes so segmentation approaches for tisseus with those cell types maybe more difficult than others. 
+Improving sementation remains an active area of research. 
 
 The Xenium Onboard Analysis pipeline segments cells in two broad ways depending on the assay ([10x Genomics segmentation algorithms](https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/algorithms-overview/segmentation)):
 
@@ -228,20 +230,22 @@ This particular dataset only included a DAPI stain so cell segmentation was done
 A Xenium panel includes probes for both targeted genes and control probes. 
 
 To understand the control categories, it helps to know how Xenium turns images into counts.
-Each targeted gene is detected not by sequencing but by a characteristic pattern of fluorescent signals across imaging channels and cycles.
+Each targeted gene is detected not by sequencing but by a characteristic pattern of fluorescent signals at a specific site (punctum) across imaging channels and cycles.
 That pattern is called a **codeword**, and the full lookup table mapping codewords to genes is the **codebook** ([10x Genomics Xenium panel design concepts and terms](https://www.10xgenomics.com/support/software/xenium-panel-designer/latest/tutorials/xenium-panel-design-concepts-terms)).
 Decoding is the process of reading the observed signal at each detected fluorescent punctum and matching it to a codeword (and therefore a gene), with a quality score attached to each call.
 
 The codebook deliberately reserves some codewords and probes as controls, which let us estimate background and error rates:
 
-- **Negative control probes** are physical probes included in the panel that target sequences _not_ present in the transcriptome. Counts on these reflect nonspecific probe binding, so they measure assay background.
+- **Negative control probes** are physical probes included in the panel that target sequences _not_ present in the transcriptome. 
+Counts on these reflect nonspecific probe binding, so they measure assay background.
 - **Negative control codewords** are valid codewords that are deliberately left unassigned to any real probe in the panel. 
 Counts on these reflect optical or decoding errors, so they measure decoding specificity.
 - **Antisense** are probes targeting the antisense strand. 
 Counts on these reflect nonspecific probe binding and measure assay background. 
-- **BLANK** codewords are empty codewords that map to nothing. 
+- **BLANK** codewords are unused codewords.
+There is no probe in a particular gene panel that will generate the codeword. 
 These are also used to identify decoding specificity. 
-Note that this category does not appear in newer versions and has been replaced with Unassigned codewords.
+Note that although the probes are named with `BLANK` these correspond to Unassigned codewords described in the [10x documentation](https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/algorithms-overview/xoa-algorithms#qvs). 
 
 Because a high-quality cell should have essentially no control counts, these features are a powerful QC signal and we will use them below.
 To keep control counts from being mistaken for real gene counts, `readXeniumSXE()` moves them out of the main matrix and into alternative experiments (`altExps`) stored alongside the main object.
@@ -249,7 +253,7 @@ These can be accessed with `altExp()`.
 
 We can see which control experiments were separated out here:
 
-```{r inspect-altexps, live = TRUE}
+```{r inspect-altexps}
 # control features are stored separately from the gene panel, as altExps
 altExpNames(spe) |> 
   purrr::map(\(name) altExp(spe, name))
@@ -268,7 +272,9 @@ head(cell_types_df)
 
 ```{r annotations-table}
 # how many cells of each annotated type?
-table(cell_types_df$cell_type_annotation)
+cell_types_df |> 
+  dplyr::count(cell_type_annotation) |> 
+  dplyr::arrange(desc(n))
 ```
 
 The original annotations are fairly fine-grained.
@@ -326,11 +332,9 @@ cell_type_palette <- list(
   "Perivascular-Like" = "#FEAF16",
   "Dendritic cell" = "#1CBE4F",
   "Mast Cells" = "#565656",
+  "Hybrid" = "#FFF000",
   "Unlabeled" = "grey90"
 )
-
-# unlabeled should be greyed out
-cell_type_palette$Unlabeled <- "grey90"
 ```
 
 Finally, we'll use factors to define the order of the cell types so that they appear in the legend in the same order that we have defined above rather than in alphabetical order. 
@@ -346,6 +350,7 @@ Now that we have prepared our data, we can create our plot showing the lumped ce
 
 ```{r plot-celltypes, live = TRUE}
 #| fig.width: 8
+#| message: FALSE
 
 # plot all spots colored by cell type 
 ggspavis::plotCoords(spe, annotate = "cell_types_lumped") +
@@ -360,58 +365,12 @@ Cells from imaging based methods can be considered low-quality for one of two re
 1. The cell has a high level of background noise or has had issues decoding the codewords, as indicated by high per-cell counts for the negative control probes or negative codewords. 
 For Xenium, this information is stored in `control_probe_counts` and `control_codeword_counts` in the `colData`. 
 2. The cell has a low number of gene expression counts compared to other cells of the same size, indicating the cells may be debris or segmentation artifacts. 
-This information should be calculated for each cell. 
+For Xenium, this information is stored in `total_counts` and `cell_area` in the `colData`. 
 
-We will use [`SpaceTrooper`](https://bioconductor.org/packages/SpaceTrooper) ([Banzi _et al.,_ 2025](https://doi.org/10.64898/2025.12.24.696336)) to compute per-cell quality-control metrics that are tailored to imaging-based spatial data. 
-This includes cell area and total counts which is calculated from the `counts` assay in the main experiment. 
-
-`SpaceTrooper` supports many imaging-based spatial transcriptomics platforms (e.g., CosMx, MERFISH, Xenium).
-Because some of its metrics are platform-specific, we tell it which technology produced the data by setting it in the object's `metadata()` first.
-
-**Note** that you may see a warning when running the step below.
-This is expected for Xenium data.
-`SpaceTrooper` can compute a border-related metric based on cell aspect ratio and distance to the nearest field-of-view border that feeds its combined quality score.
-That metric exists to capture stitching artifacts seen at field-of-view borders. 
-Although you can calculate these metrics for Xenium, the Xenium output is not expected to have field-of-view border artifacts, so the metric is not calculated here and the warning simply notes its absence.
-
-```{r spatial-qc}
-# tell SpaceTrooper which platform this is
-metadata(spe)$technology <- "10X_Xenium"
-
-# compute spatial per-cell QC metrics (adds columns like cell area, and probe counts)
-# note that some of this may have been pre-calculated for this experiment but we'll re-do that here
-spe <- SpaceTrooper::spatialPerCellQC(
-  spe,
-  use_altexps = FALSE # don't calculate metrics for altexperiments
-)
-
-head(colData(spe))
-```
-
-`spatialPerCellQC()` adds several per-cell QC columns to `colData()`. 
-The ones we will use for QC include `total` and `Area_um`: 
-
-- `total`: total transcript counts per cell summed over all panel genes.
-- `Area_um`: the cell's area in square microns, derived from its segmentation polygon.
-
-**Note:** For this particular experiment, these metrics were already stored in the columns `total_counts` and `cell_area` found in the `colData`, but this will not be the case for all imaging-based experiments. 
-This is why we will use the columns calculated by `SpaceTrooper` and not the original columns. 
-
-We will ultimately combine this information with the existing control-feature counts stored in `control_probe_counts` and `control_codeword_counts`, which quantity the total counts falling on the negative control probe and negative control codeword categories. 
-This information serves as a direct read-out of background and decoding error.
-
-It also writes the centroid coordinates into `colData` as `x_centroid`/`y_centroid`.
-Because `spatialCoords()` already holds columns with those exact names, `ggspavis` errors on the duplicated names when it assembles its plotting data frame.
-We drop the `colData` copies in the code below, but note that the coordinates still live safely in `spatialCoords`:
-
-```{r dedupe-coords}
-# remove the duplicated coordinate columns from colData to avoid a name
-# collision with spatialCoords when plotting
-colData(spe) <- colData(spe) |>
-  as.data.frame() |>
-  dplyr::select(-c("x_centroid", "y_centroid")) |>
-  DataFrame()
-```
+**Note:** For other imaging based methods, this information may not be pre-calculated. 
+In this case the [`SpaceTrooper`](https://bioconductor.org/packages/SpaceTrooper) ([Banzi _et al.,_ 2025](https://doi.org/10.64898/2025.12.24.696336)) package can be used to compute per-cell quality-control metrics that are tailored to imaging-based spatial data. 
+Additionally, the exact filtering steps shown here may not be applicable for all imaging based platforms. 
+Please consult [OSTA section on quality control for imaging-based platforms](https://bioconductor.org/books/release/OSTA/pages/img-quality-control.html) for more details. 
 
 Low-quality cells tend to be outliers in the relationship between total counts and cell area. 
 Cells with very few counts for their area are often debris or segmentation artifacts. 
@@ -419,11 +378,12 @@ Below we can color the cells by these QC metrics.
 
 ```{r plot-qc}
 #| fig.width: 8
-p1 <- ggspavis::plotCoords(spe, annotate = "total") +
+#| message: FALSE
+
+p1 <- ggspavis::plotCoords(spe, annotate = "total_counts") +
   ggplot2::scale_color_distiller(palette = "Blues", direction = 1)
 
-p2 <- ggspavis::plotCoords(spe, annotate = "Area_um") +
-  scale_color_viridis_c() +
+p2 <- ggspavis::plotCoords(spe, annotate = "cell_area") +
  ggplot2::scale_color_distiller(palette = "YlOrRd", direction = 1)
 
 p1 + p2
@@ -435,18 +395,19 @@ Specifically, we use `scater::isOutlier()` to flag cells whose ratio falls more 
 * The MAD is a robust measure of spread and is less sensitive to extreme values than the standard deviation. 
 * We will use the common cutoff of 3 * MAD. 
 * We only flag the low side, since it is unusually _few_ counts for a cell's area that signals debris or a failed segmentation.
-* We work on the log scale because the ratio is strictly positive and right-skewed, which makes a symmetric MAD rule more appropriate.
+* We work on the log scale because the ratio is strictly positive and right-skewed. 
+Using the log scale will make the distribution more symmetric which is what is assumed when using the 3 * MAD rule.
 
 ```{r count-area-outliers}
 # counts-per-area ratio for each cell
-count_area_ratio <- spe$total / spe$Area_um
+count_area_ratio <- spe$total_counts / spe$cell_area
 
 # flag cells that are outliers on the low side
 # (3 median absolute deviations below the median, on the log2 scale since the metric is a ratio)
 outliers <- scater::isOutlier(count_area_ratio, log = TRUE, type = "lower", nmads = 3)
 
-# print the output
-outliers
+# print the structure which tells us where to find the identified threshold
+str(outliers)
 ```
 
 Now we can pull out the specific threshold corresponding to 3 MADs below the median from the `outliers` object. 
@@ -478,32 +439,60 @@ A high-quality cell should have essentially no control counts.
 Any counts in these categories indicate background or errors in that cell. 
 Therefore we exclude cells with a nonzero count in either control category or with a counts-per-area ratio below the cutoff. 
 
-```{r flag-exclude}
-# a cell is excluded if it is a counts-per-area outlier OR has any control counts
-exclude <- outliers |
-  spe$control_probe_counts > 0 |
-  spe$control_codeword_counts > 0
+First, let's look at what cells get filtered by using just the counts-per-area QC metric. 
 
-# fraction of cells flagged for removal
-sum(exclude) / length(exclude)
+```{r count-outliers, live=TRUE}
+# how many cells would get filtered? 
+sum(outliers)
 ```
 
-Now we can add a new column to the SPE indicating which cells to exclude and use that to visualize what cells will be excluded during filtering. 
 
-```{r plot-exclude}
-# store the flag and visualize which cells will be excluded
-spe$exclude <- exclude
+```{r visualize-counts-outliers}
+# now visualize them using the spatial coordinates 
+spe$counts_per_area_outliers <- outliers
 
-ggspavis::plotCoords(spe, annotate = "exclude") +
+ggspavis::plotCoords(spe, annotate = "counts_per_area_outliers") +
   guides(color = guide_legend(override.aes = list(size = 4))) +
   # add custom colors so excluded cells are easy to see
   scale_color_manual(values = c("grey90", "#00274C"))
 ```
 
-It looks like there's a group of cells at the top that are flagged, likely due to an issue with tissue placement on the slide. 
-We also see random cells that are low-quality scattered throughout the slide, which is typical of Xenium data.
+It looks like most of the cells that would be excluded if we used this metric alone are towards the edges of the tissue. 
+This is likely an artifact of the tissue placement. 
 
-Let's go ahead and filter our cells and remove them from the SPE object.
+Now, let's look at cells that get filtered by using just the control metrics.
+These are cells with either `control_probe_counts` or `control_codeword_counts` > 0. 
+
+```{r count-control-outliers}
+# add a column indicating if the cell has any control probes detected
+spe$control_exclude <- spe$control_probe_counts > 0 | spe$control_codeword_counts > 0
+
+# how many cells would be excluded
+sum(spe$control_exclude)
+```
+
+```{r visualize-control-outliers}
+ggspavis::plotCoords(spe, annotate = "control_exclude") +
+  guides(color = guide_legend(override.aes = list(size = 4))) +
+  # add custom colors so excluded cells are easy to see
+  scale_color_manual(values = c("grey90", "#00274C"))
+```
+
+In contrast, the cells that have controls detected and are therefore considered low-quality tend to be scattered randomly throughout the tissue, which is expected in Xenium. 
+
+Ultimately, we want to filter out both cells that have a low counts-per-area ratio and have detectable counts for control probes and codewords. 
+
+Let's do that below and add a new column to the SPE object indicating which cells should be removed.
+
+```{r flag-exclude, live = TRUE}
+# a cell is excluded if it is a counts-per-area outlier OR has any control counts
+spe$exclude <- spe$counts_per_area_outliers | spe$control_exclude
+
+# fraction of cells flagged for removal
+sum(spe$exclude) / length(spe$exclude)
+```
+
+We'll then filter our cells and remove them from the SPE object.
 
 ```{r filter-cells, live = TRUE}
 # keep only the cells not flagged for removal


### PR DESCRIPTION
Closes #1035

This PR cleans up the text for the Xenium notebook, including filling in TODO's, expanding on text where necessary and adding in citations. There isn't anything super special or noteworthy here, but please let me know if you need any more clarification in spots. 

For easier reviewing, here's a copy of the rendered notebook:
[05-xenium_processing.nb.html](https://github.com/user-attachments/files/30202403/05-xenium_processing.nb.html)
