### PR TITLE
Use mtx format and not h5 for CRC data

### DIFF
--- a/spatial/setup/crc-hd/Snakefile
+++ b/spatial/setup/crc-hd/Snakefile
@@ -9,7 +9,7 @@ configfile: "config.yaml"
 
 base_dir = Path(config["base_dir"])
 visium_dir = base_dir / "visium_hd"
-sc_h5_file = base_dir / "single_cell" / "filtered_feature_bc_matrix.h5"
+sce_dir = base_dir / "single_cell"
 output_normalized_spe = base_dir / config["output_normalized_spe"]
 output_normalized_sce = base_dir / config["output_normalized_sce"]
 
@@ -46,13 +46,15 @@ rule download_visium:
 # Download the single-cell reference matrix from 10x
 rule download_single_cell:
     output:
-        sc_h5_file,
+        directory(sce_dir),
     params:
         url=config["url_single_cell"],
     shell:
         """
-        mkdir -p $(dirname {output})
-        curl -L --fail {params.url} -o {output}
+        # scratch space alongside the target, so parent dirs get created too
+        mkdir -p {output}
+        curl -L --fail {params.url} -o single_cell.tar.gz
+        tar -xzf single_cell.tar.gz -C {output}
         """
 
 
@@ -73,15 +75,15 @@ rule prepare_spatial_experiment:
 # Prepare the reference SCE object
 rule prepare_single_cell:
     input:
-        sc_h5_file,
+        sce_dir,
     params:
-        url=config["annotations_url"]
+        url=config["url_annotations"]
     output:
         output_normalized_sce,
     shell:
         """
         Rscript prepare-single-cell.R \
-          --input_h5_file {input} \
+          --input_dir {input}/filtered_feature_bc_matrix \
           --annotations_url {params.url} \
           --output_file {output}
         """

--- a/spatial/setup/crc-hd/config.yaml
+++ b/spatial/setup/crc-hd/config.yaml
@@ -2,7 +2,7 @@ base_dir: ../../data/crc-hd/
 
 # URLs for downloading original dataset and annotations from 10x
 url_visium: https://cf.10xgenomics.com/samples/spatial-exp/4.1.0/Visium_HD_6p5mm_Human_Colon_Cancer/Visium_HD_6p5mm_Human_Colon_Cancer_segmented_outputs.tar.gz
-url_single_cell: https://cf.10xgenomics.com/samples/cell-exp/8.0.0/HumanColonCancer_Flex_Multiplex/HumanColonCancer_Flex_Multiplex_count_filtered_feature_bc_matrix.h5
+url_single_cell: https://cf.10xgenomics.com/samples/cell-exp/8.0.0/HumanColonCancer_Flex_Multiplex/HumanColonCancer_Flex_Multiplex_count_filtered_feature_bc_matrix.tar.gz
 url_annotations: https://raw.githubusercontent.com/10XGenomics/HumanColonCancer_VisiumHD/main/MetaData/SingleCell_MetaData.csv.gz
 
 # Output files

--- a/spatial/setup/crc-hd/prepare-single-cell.R
+++ b/spatial/setup/crc-hd/prepare-single-cell.R
@@ -22,9 +22,9 @@ set.seed(2026)
 
 option_list <- list(
   make_option(
-    "--input_h5_file",
+    "--input_dir",
     type = "character",
-    help = "Path to the filtered feature bc h5ad output file from Cell Ranger"
+    help = "Path to the filtered feature bc directory from Cell Ranger"
   ),
   make_option(
     "--annotations_url",
@@ -43,7 +43,7 @@ opts <- parse_args(OptionParser(option_list = option_list))
 # Read in data -----------------------------------------------------------------
 
 # read in sce and annotations
-sce <- DropletUtils::read10xCounts(opts$input_h5_file)
+sce <- DropletUtils::read10xCounts(opts$input_dir)
 annotations_df <- readr::read_csv(opts$annotations_url)
 
 # Prep SCE ---------------------------------------------------------------------

--- a/spatial/setup/crc-hd/prepare-spatial-experiment.R
+++ b/spatial/setup/crc-hd/prepare-spatial-experiment.R
@@ -46,7 +46,7 @@ opts <- parse_args(OptionParser(option_list = option_list))
 # Import data ------------------------------------------------------------------
 
 spe <- VisiumIO::TENxVisiumHD(
-  format = "h5",
+  format = "mtx", # use mtx to ensure counts assay is an actual matrix and not just reference to h5 file
   images = "lowres",
   segmented_outputs = opts$input_dir
 ) |>


### PR DESCRIPTION
I was working on the exercise notebook using the CRC data I prepped in #1059 and was having an issue where trying to access any of the assays in the object (both SPE and reference SCE) produced this error: 

```
Error in h(simpleError(msg, call)) : 
  error in evaluating the argument 'x' in selecting a method for function 'type': file '/home/ahawkins/repos/training-modules/spatial/data/crc-hd/single_cell/filtered_feature_bc_matrix.h5' does not exist
```

It appears to be using a `DelayedArray` to store the data rather than a sparse matrix making it hard to work with the data anywhere other than my own directory. To fix this, I switched to using the mtx instead of h5 format for both the SPE and SCE files. This now properly stores the counts data and I can move the object, load it in, and still access the contents correctly. 

Once this is approved, I'll re-sync to S3. 