### PR TITLE
Fix typo in linking data

### DIFF
--- a/scripts/link-data.sh
+++ b/scripts/link-data.sh
@@ -54,7 +54,7 @@ mkdir -p spatial/data/wilms-tumor/SCPCS000190
 mkdir -p spatial/data/osteo/GSM8478586
 mkdir -p spatial/data/crc-v1
 mkdir -p spatial/data/brca-xenium
-mkdir -p spatail/data/crc-hd
+mkdir -p spatial/data/crc-hd
 
 # Machine learning module directory
 mkdir -p machine-learning/data


### PR DESCRIPTION
It looks like the Docker builds were failing after I linked the new CRC data with an error that it couldn't find a directory. Turns out I spelled spatial wrong in one spot, so this should hopefully fix that. 